### PR TITLE
Set `tool.hatch.build.only-packages = false`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ dist = ["twine", "build"]
 
 
 [tool.hatch.build]
-only-packages = true
 exclude = ["docs/", "tests/"]
 
 [tool.hatch.version]


### PR DESCRIPTION
https://hatch.pypa.io/1.13/config/build/#excluding-files-outside-packages

It seems that this option is excluding files in `src/inspect_scout/_view/www/dist`, which are needed for the viewer to run.

Maybe this isn't the right approach. It seems like it'd be better to surgically include files in that directory in the package, rather than including all non-Python files in `src/inspect_scout` in the package.