### PR TITLE
Make pyproject.toml work with uv.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ allow-direct-references = true
 
 [tool.uv]
 managed = true
-default-groups = ["dev"]
 
 [tool.ruff]
 extend-exclude = ["docs"]


### PR DESCRIPTION
`dev` is an extra, not a group, so uv complains about `default-groups = ["dev"]`

```
error: Default group `dev` (from `tool.uv.default-groups`) is not defined in the project's `dependency-groups` table
``