### PR TITLE
stream parquet files as arrow ipc

### DIFF
--- a/docs/reference/async.qmd
+++ b/docs/reference/async.qmd
@@ -15,6 +15,7 @@ Normal usage of Scout (e.g. in a script or notebook) should prefer the correspon
 ### scan_list_async
 ### scan_status_async
 ### scan_results_df_async
+### scan_results_arrow_async
 
 
 

--- a/docs/reference/results.qmd
+++ b/docs/reference/results.qmd
@@ -11,6 +11,8 @@ reference: inspect_scout
 ### Summary
 ### scan_results_df
 ### ScanResultsDF
+### scan_results_arrow
+### ScanResultsArrow
 
 ## Validation
 

--- a/src/inspect_scout/__init__.py
+++ b/src/inspect_scout/__init__.py
@@ -2,6 +2,7 @@ from inspect_ai._util.deprecation import relocated_module_attribute
 
 from ._llm_scanner import AnswerMultiLabel, AnswerStructured, llm_scanner
 from ._recorder.recorder import (
+    ScanResultsArrow,
     ScanResultsDF,
     Status,
 )
@@ -24,6 +25,7 @@ from ._scanner.scanner import Scanner, scanner
 from ._scanner.scorer import as_scorer
 from ._scanner.types import ScannerInput
 from ._scanresults import (
+    scan_results_arrow,
     scan_results_df,
     scan_status,
 )
@@ -83,6 +85,8 @@ __all__ = [
     "scan_results_df",
     "Status",
     "ScanResultsDF",
+    "scan_results_arrow",
+    "ScanResultsArrow",
     "Summary",
     # transcript
     "transcripts_db",

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -9,6 +9,7 @@ from upath import UPath
 from ._recorder.factory import scan_recorder_type_for_location
 from ._recorder.file import _cast_value_column
 from ._recorder.recorder import (
+    ScanResultsArrow,
     ScanResultsDB,
     ScanResultsDF,
     Status,
@@ -38,6 +39,33 @@ async def scan_status_async(scan_location: str) -> Status:
     """
     recorder = scan_recorder_type_for_location(scan_location)
     return await recorder.status(scan_location)
+
+
+def scan_results_arrow(
+    scan_location: str,
+) -> ScanResultsArrow:
+    """Scan results as Arrow.
+
+    Args:
+        scan_location: Location of scan (e.g. directory or s3 bucket).
+
+    Returns:
+        ScanResultsArrow: Results as Arrow record batches.
+    """
+    return run_coroutine(scan_results_arrow_async(scan_location))
+
+
+async def scan_results_arrow_async(scan_location: str) -> ScanResultsArrow:
+    """Scan results as Arrow.
+
+    Args:
+        scan_location: Location of scan (e.g. directory or s3 bucket).
+
+    Returns:
+        ScanResultsArrow: Results as Arrow record batches.
+    """
+    recorder = scan_recorder_type_for_location(scan_location)
+    return await recorder.results_arrow(scan_location)
 
 
 def scan_results_df(
@@ -84,7 +112,7 @@ async def scan_results_df_async(
          ScanResults: Results as Pandas data frames.
     """
     recorder = scan_recorder_type_for_location(scan_location)
-    results = await recorder.results(scan_location, scanner=scanner)
+    results = await recorder.results_df(scan_location, scanner=scanner)
 
     # Expand resultset rows when in "results" mode
     if rows == "results":

--- a/src/inspect_scout/async/__init__.py
+++ b/src/inspect_scout/async/__init__.py
@@ -5,7 +5,7 @@ from .._scan import (
 )
 from .._scanlist import scan_list_async
 from .._scanresults import (
-    scan_results_db_async,
+    scan_results_arrow_async,
     scan_results_df_async,
     scan_status_async,
 )
@@ -17,5 +17,5 @@ __all__ = [
     "scan_list_async",
     "scan_status_async",
     "scan_results_df_async",
-    "scan_results_db_async",
+    "scan_results_arrow_async",
 ]


### PR DESCRIPTION
Variation of this PR (https://github.com/meridianlabs-ai/inspect_scout/pull/35/) which makes Arrow IPC part of the contract of the results recorder (note that other implementations e.g. databases are possible so we don't want to encode knowledge about the parquet files being the backing store into the server).