### PR TITLE
Stop doing `chdir_python`. Just do `add_to_syspath` instead.

### DIFF
--- a/src/inspect_scout/_scanjob.py
+++ b/src/inspect_scout/_scanjob.py
@@ -424,7 +424,7 @@ def scanjob_from_file(file: str, scanjob_args: dict[str, Any]) -> ScanJob | None
     if scanjob_path.suffix in [".json", ".yml", ".yaml"]:
         return scanjob_from_config_file(scanjob_path)
     else:
-        # add plugin root to sys.path for imports
+        # add scanjob directory to sys.path for imports
         with add_to_syspath(scanjob_path.parent.as_posix()):
             load_module(scanjob_path)
             scanjob_decorators = parse_decorators(scanjob_path, "scanjob")

--- a/src/inspect_scout/_scanner/scanner.py
+++ b/src/inspect_scout/_scanner/scanner.py
@@ -412,7 +412,7 @@ def scanners_from_file(file: str, scanner_args: dict[str, Any]) -> list[Scanner[
     if not scanner_path.exists():
         raise PrerequisiteError(f"The file '{pretty_path(file)}' does not exist.")
 
-    # add plugin root to sys.path for imports
+    # add file directory to sys.path for imports
     with add_to_syspath(scanner_path.parent.as_posix()):
         # create scanners
         load_module(scanner_path)


### PR DESCRIPTION
## Current Pattern

### How scanners and scanjobs are currently loaded

In `inspect_scout/_scanjob.py:428`, `scanjob_from_file` uses `chdir_python`:

```python
with chdir_python(scanjob_path.parent.as_posix()):
    load_module(scanjob_path)
    ...
```

`chdir_python` (in `inspect_ai/_util/path.py:60-80`) does two things:
1. Changes the current working directory (`os.chdir`)
2. Appends the directory to `sys.path`

This allows plugin files (e.g., `testing.py`) to use relative imports:
```python
from scanners.target_word import target_word_message, target_word_transcript
```

### Why `chdir_python` is an anti-pattern

- **Global state mutation**: Modifies `cwd` - inherently fragile
- **Implicit dependencies**: Creates hidden dependencies on filesystem layout
- **Non-portable plugins**: Plugin code only works when loaded via this mechanism
- **Potential conflicts**: Could conflict with other imports if paths collide

## New Pattern: sys.path manipulation (no chdir)

**How it works**: When loading a scanjob file, add its directory to `sys.path` (but don't `chdir`). Plugin writers use absolute imports from that root.

**Loader change** (in `inspect_scout/_scanjob.py`):
```python
# Instead of chdir_python
with add_to_syspath(scanjob_path.parent.as_posix()):
    load_module(scanjob_path)
    ...
```

---

## Plugin Layout Examples

### Level 1: Simplest - everything in one file

No imports between plugin files needed.

```
myproject/
└── testing.py      # contains both @scanjob and @scanner definitions
```

```python
# testing.py
from inspect_scout import Scanner, scanner, scanjob, ScanJob

@scanner(messages=["assistant"])
def my_scanner() -> Scanner[ChatMessageAssistant]:
    async def execute(message: ChatMessageAssistant) -> Result:
        ...
    return execute

@scanjob
def job() -> ScanJob:
    return ScanJob(
        transcripts=transcripts_from(...),
        scanners=[my_scanner()],
    )
```

---

### Level 2: Flat directory - scanners as sibling modules

Scanjob imports from sibling `.py` files. No `__init__.py` needed.

```
myproject/
├── testing.py          # @scanjob
├── target_word.py      # @scanner
└── tool_usage.py       # @scanner
```

```python
# testing.py
from target_word import target_word_message
from tool_usage import tool_usage

@scanjob
def job() -> ScanJob:
    return ScanJob(
        scanners=[target_word_message("hello"), tool_usage()],
    )
```

```python
# target_word.py
from inspect_scout import Scanner, scanner, Result

@scanner(messages=["assistant"])
def target_word_message(target: str) -> Scanner[ChatMessageAssistant]:
    ...
```

---

### Level 3: Subdirectory - scanners in a package

Scanjob imports from a subdirectory. Requires `__init__.py`.

```
myproject/
├── testing.py
└── scanners/
    ├── __init__.py         # required (can be empty)
    ├── target_word.py
    └── tool_usage.py
```

```python
# testing.py
from scanners.target_word import target_word_message
from scanners.tool_usage import tool_usage

@scanjob
def job() -> ScanJob:
    return ScanJob(
        scanners=[target_word_message("hello"), tool_usage()],
    )
```

---

### Level 4: Nested packages - organized by category

Deeper nesting with sub-packages. Each directory needs `__init__.py`.

```
myproject/
├── testing.py
└── scanners/
    ├── __init__.py
    ├── target_word.py
    └── behavior/
        ├── __init__.py     # required
        └── behavior_scanner.py
```

```python
# testing.py
from scanners.target_word import target_word_message
from scanners.behavior.behavior_scanner import behavior_scanner

@scanjob
def job() -> ScanJob:
    return ScanJob(
        scanners=[target_word_message("hello"), behavior_scanner()],
    )
```

---

### Level 5: Scanner importing another scanner

Scanner modules can import from siblings if in a package.

```
myproject/
├── testing.py
└── scanners/
    ├── __init__.py
    ├── utils.py            # shared utilities
    └── target_word.py      # imports from utils
```

```python
# scanners/target_word.py
from scanners.utils import find_positions  # absolute import from plugin root

@scanner(messages=["assistant"])
def target_word_message(target: str) -> Scanner[ChatMessageAssistant]:
    ...
```

Alternative using relative imports (also works):
```python
# scanners/target_word.py
from .utils import find_positions  # relative import within package

@scanner(messages=["assistant"])
def target_word_message(target: str) -> Scanner[ChatMessageAssistant]:
    ...
```
