### PR TITLE
Update metrics once per second

### DIFF
--- a/src/inspect_scout/_concurrency/common.py
+++ b/src/inspect_scout/_concurrency/common.py
@@ -1,4 +1,3 @@
-import datetime
 from dataclasses import dataclass, fields
 from functools import reduce
 from typing import (
@@ -32,8 +31,6 @@ class ScanMetrics:
     cpu_use: float = 0
     # RSS for now, but we can revisit
     memory_usage: int = 0
-
-    last_updated_at: datetime.datetime = datetime.datetime.now()
 
 
 def sum_metrics(metrics_list: Iterable[ScanMetrics]) -> ScanMetrics:


### PR DESCRIPTION
Every worker was updating metrics once per second, which was using a lot of CPU. Specifically, parsing the contents of the file that contains the process's memory usage.

This PR changes `single_process_strategy` so metrics are only updated once per second, not once per worker per second.