### PR TITLE
metrics performance improvements

### DIFF
--- a/src/inspect_scout/_concurrency/common.py
+++ b/src/inspect_scout/_concurrency/common.py
@@ -28,7 +28,6 @@ class ScanMetrics:
     tasks_scanning: int = 0
     buffered_scanner_jobs: int = 0
     completed_scans: int = 0
-    cpu_use: float = 0
     # RSS for now, but we can revisit
     memory_usage: int = 0
 

--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Awaitable, Callable, Literal
 import anyio
 import psutil
 from anyio import create_task_group
+from inspect_ai.util import throttle
 from inspect_ai.util._anyio import inner_exception
 
 from .._display import display
@@ -113,11 +114,11 @@ def single_process_strategy(
         def _scanner_job_info(item: ScannerJob) -> str:
             return f"{item.union_transcript.transcript_id, item.scanner_name}"
 
+        @throttle(2)
         def _update_metrics() -> None:
             if update_metrics:
                 # USS - Unique Set Size
                 metrics.memory_usage = process.memory_full_info().uss
-                metrics.cpu_use = process.cpu_percent()
                 # print(f"{diag_prefix} CPU {metrics.cpu_use}")
                 metrics.buffered_scanner_jobs = len(scanner_job_deque)
                 update_metrics(metrics)


### PR DESCRIPTION
1. Don't capture cpu usage anymore (we don't display it as it was flaky enough to provide no real signal)
2. Only push metrics updates every 2 secodns.