### PR TITLE
Use PyArrow `BufferOutputStream` instead of BytesIO in `scanner_table`.

### DIFF
--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -274,6 +274,12 @@ def scanner_table(buffer_dir: UPath, scanner: str) -> bytes | None:
     flush_accumulated(writer)
     writer.close()
 
+    # TODO: If we changed the signature of this function from:
+    #   bytes | None
+    #     to
+    #   pa.Buffer | None
+    # We could avoid the copy (that to_pybytes does) altogether.
+    # Keep in mind that the previous BytesIO.getvalue() made a copy too.
     return buffer.getvalue().to_pybytes()
 
 


### PR DESCRIPTION
## Summary

Replace Python's `io.BytesIO` with PyArrow's native `pa.BufferOutputStream` for in-memory parquet writing in `scanner_table()`.

## Key Changes

- Use `pa.BufferOutputStream()` instead of `io.BytesIO()` for the write buffer
- Simplify return: `buffer.getvalue().to_pybytes()` replaces `buffer.seek(0); buffer.getvalue()`

## Why

May address intermittent `BufferError: Existing exports of data: object cannot be re-sized` seen during GC. Investigation found `ParquetWriter.close()` doesn't release buffer references to Python's BytesIO (refcount 4 → 2 only after `del writer`). PyArrow's [`BufferOutputStream`](https://arrow.apache.org/docs/python/generated/pyarrow.BufferOutputStream.html) is the [documented native type](https://arrow.apache.org/docs/python/memory.html) for this use case, noted as "more efficient" with PyArrow tools. Whether this fully resolves the intermittent error is unconfirmed since we couldn't reproduce it reliably.