### PR TITLE
Add eval status to log metadata

### DIFF
--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -425,6 +425,7 @@ TranscriptColumns: list[Column] = (
     EvalId
     + EvalLogPath
     + [
+        EvalColumn("status", path="status", required=True),
         EvalColumn("eval_created", path="eval.created", type=datetime, required=True),
         EvalColumn("eval_tags", path="eval.tags", default="", value=list_as_str),
         EvalColumn("eval_metadata", path="eval.metadata", default={}),

--- a/src/inspect_scout/_transcript/log.py
+++ b/src/inspect_scout/_transcript/log.py
@@ -38,6 +38,11 @@ class LogMetadata(Metadata):
         return Column("eval_id")
 
     @property
+    def status(self) -> Column:
+        """Status of eval."""
+        return Column("status")
+
+    @property
     def log(self) -> Column:
         """Location that the log file was read from."""
         return Column("log")


### PR DESCRIPTION
Alright, my first PR to scout!

Our researchers want to be able to run scanners on eval set directories while excluding the retried log files (remember that we don't do log cleanup after retry). I couldn't seem to find a way to do that, but it's possible that I've just misunderstood something. I was able to use this to get what I wanted, though, so here's a PR.

Go team!