### PR TITLE
Fix `LabelsAnswer` missing choice mapping in prompt.

### DIFF
--- a/src/inspect_scout/_llm_scanner/answer.py
+++ b/src/inspect_scout/_llm_scanner/answer.py
@@ -164,13 +164,15 @@ class _LabelsAnswer(Answer):
     def format(self) -> str:
         if not self.labels:
             raise ValueError("Must have labels")
-        _, letters = _answer_options(self.labels)
+        formatted_choices, letters = _answer_options(self.labels)
         format_template = (
             LABELS_ANSWER_FORMAT_MULTI
             if self.multi_classification
             else LABELS_ANSWER_FORMAT_SINGLE
         )
-        return Template(format_template).render(letters=letters)
+        return Template(format_template).render(
+            letters=letters, formatted_choices=formatted_choices
+        )
 
     def result_for_answer(
         self, output: ModelOutput, extract_references: Callable[[str], list[Reference]]

--- a/src/inspect_scout/_llm_scanner/prompt.py
+++ b/src/inspect_scout/_llm_scanner/prompt.py
@@ -42,11 +42,11 @@ LABELS_ANSWER_PROMPT = (
 )
 LABELS_ANSWER_FORMAT_SINGLE = (
     ANSWER_FORMAT_PREAMBLE
-    + "'ANSWER: $LETTER' (without quotes) where $LETTER is one of {{ letters }}."
+    + "'ANSWER: $LETTER' (without quotes) where $LETTER is one of {{ letters }} representing:\n{{ formatted_choices }}"
 )
 LABELS_ANSWER_FORMAT_MULTI = (
     ANSWER_FORMAT_PREAMBLE
-    + "'ANSWER: $LETTERS' (without quotes) where $LETTERS is a comma-separated list of letters from {{ letters }}."
+    + "'ANSWER: $LETTERS' (without quotes) where $LETTERS is a comma-separated list of letters from {{ letters }} representing:\n{{ formatted_choices }}"
 )
 
 STR_ANSWER_PROMPT = "Answer the following question about the transcript above:"

--- a/tests/llm_scanner/test_answer.py
+++ b/tests/llm_scanner/test_answer.py
@@ -34,14 +34,14 @@ def _dummy_extract_references(text: str) -> list[Reference]:
         (
             _LabelsAnswer(labels=["Choice A", "Choice B", "Choice C"]),
             "Answer the following multiple choice question about the transcript above:",
-            "'ANSWER: $LETTER' (without quotes) where $LETTER is one of A,B,C.",
+            "'ANSWER: $LETTER' (without quotes) where $LETTER is one of A,B,C representing:\nA) Choice A\nB) Choice B\nC) Choice C",
         ),
         (
             _LabelsAnswer(
                 labels=["Choice A", "Choice B", "Choice C"], multi_classification=True
             ),
             "Answer the following multiple choice question about the transcript above:",
-            "'ANSWER: $LETTERS' (without quotes) where $LETTERS is a comma-separated list of letters from A,B,C.",
+            "'ANSWER: $LETTERS' (without quotes) where $LETTERS is a comma-separated list of letters from A,B,C representing:\nA) Choice A\nB) Choice B\nC) Choice C",
         ),
         (
             _StrAnswer(),


### PR DESCRIPTION
Fixes a regression from commit 09fb1cb where `LabelsAnswer` prompts no longer included the mapping from letters (A, B, C) to their actual label values. The LLM was told to answer with "A, B, or C" but had no way to know what those letters represented.

Before (broken):
```
'ANSWER: $LETTER' (without quotes) where $LETTER is one of A,B,C.
```

After (fixed):
```
'ANSWER: $LETTER' (without quotes) where $LETTER is one of A,B,C representing:
A) Choice A
B) Choice B
C) Choice C
```