### PR TITLE
Track scan job completion status explicitly in the filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Scanning: Switch from `dill` to `cloudpickle` and restore default `max_processes` to 4 after resolving multiprocessing serialization issues.
+- Track scan job completion status explicitly in the filesystem (vs. merely looking at whether buffer dir exists).
 
 ## 0.4.1 (12 December 2025)
 

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -52,7 +52,9 @@ class RecorderBuffer:
         # establish scan summary if required
         scan_summary_file = self._buffer_dir.joinpath(SCAN_SUMMARY)
         if not scan_summary_file.exists():
-            self._scan_summary = Summary(list(spec.scanners.keys()))
+            self._scan_summary = Summary(
+                complete=False, scanners=list(spec.scanners.keys())
+            )
             with open(scan_summary_file.as_posix(), "w") as f:
                 f.write(self._scan_summary.model_dump_json(indent=2))
         else:
@@ -387,6 +389,6 @@ def read_scan_summary(scan_dir: UPath, spec: ScanSpec) -> Summary:
             if summary:
                 return Summary.model_validate_json(summary)
             else:
-                return Summary(list(spec.scanners.keys()))
+                return Summary(complete=False, scanners=list(spec.scanners.keys()))
     except FileNotFoundError:
-        return Summary(list(spec.scanners.keys()))
+        return Summary(complete=False, scanners=list(spec.scanners.keys()))

--- a/src/inspect_scout/_recorder/summary.py
+++ b/src/inspect_scout/_recorder/summary.py
@@ -35,14 +35,19 @@ class ScannerSummary(BaseModel):
 class Summary(BaseModel):
     """Summary of scan results."""
 
+    complete: bool = Field(default=True)
+    """Is the scan complete?"""
+
     scanners: dict[str, ScannerSummary] = Field(default_factory=dict)
     """Summary for each scanner."""
 
     def __init__(
-        self, scanners: list[str] | dict[str, ScannerSummary] | None = None, **data: Any
+        self,
+        scanners: list[str] | dict[str, ScannerSummary] | None = None,
+        **data: Any,
     ):
         if isinstance(scanners, list):
-            super().__init__(scanners={k: ScannerSummary() for k in scanners})
+            super().__init__(scanners={k: ScannerSummary() for k in scanners}, **data)
         else:
             super().__init__(scanners=scanners, **data)
 


### PR DESCRIPTION
(vs. merely looking at whether buffer dir exists).