### PR TITLE
Add dev mode proxy to allow debugging with `pnpm dev` front end code.

### DIFF
--- a/src/inspect_scout/_view/www/vite.config.ts
+++ b/src/inspect_scout/_view/www/vite.config.ts
@@ -63,6 +63,14 @@ export default defineConfig(({ mode }) => {
       ...baseConfig,
       mode: "development",
       base: "",
+      server: {
+        proxy: {
+          "/api": {
+            target: "http://127.0.0.1:7576",
+            changeOrigin: true,
+          },
+        },
+      },
       build: {
         outDir: "dist",
         minify: false,


### PR DESCRIPTION
This allows one to debug using vite's hot swap enabled dev server instead using the actual `scout view` server. An additional bonus is that, since the dev isn't doing `pnpm watch:dev`, their `dist` directory isn't touched.