### PR TITLE
Set min node version

### DIFF
--- a/src/inspect_scout/_view/www/package.json
+++ b/src/inspect_scout/_view/www/package.json
@@ -19,7 +19,7 @@
   },
   "packageManager": "pnpm@10.20.0",
   "engines": {
-    "node": "22.21.1",
+    "node": ">=22.21.1",
     "pnpm": ">=9.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Is there any reason it's locked to exactly 22.21.1? 
I can't built it with node 24