### PR TITLE
Fix ETag computation to use correct scan summary filename

### DIFF
--- a/src/inspect_scout/_view/_api_v2.py
+++ b/src/inspect_scout/_view/_api_v2.py
@@ -37,13 +37,13 @@ API_VERSION = "2.0.0-alpha"
 
 
 def _compute_scans_etag(scans_location: str) -> str | None:
-    """Compute ETag from API version and scan_summary.json mtimes."""
+    """Compute ETag from API version and _summary.json mtimes."""
     try:
         scans_dir = UPath(scans_location)
         mtimes = sorted(
-            (d.name, (d / "scan_summary.json").stat().st_mtime)
+            (d.name, (d / "_summary.json").stat().st_mtime)
             for d in scans_dir.rglob("scan_id=*")
-            if d.is_dir() and (d / "scan_summary.json").exists()
+            if d.is_dir() and (d / "_summary.json").exists()
         )
         return hashlib.md5(
             f"{API_VERSION}:{scans_location}:{mtimes}".encode()


### PR DESCRIPTION
Fixed `_compute_scans_etag()` to look for `_summary.json` instead of `scan_summary.json`. This bug has existed since the ETag feature was introduced in #84 - the function was not including the actual scan results for the ETag computations.