### PR TITLE
Add ability to include extra types in OpenAPI schema

### DIFF
--- a/src/inspect_scout/_view/www/openapi.json
+++ b/src/inspect_scout/_view/www/openapi.json
@@ -266,6 +266,22 @@
         "title": "ChatCompletionChoice",
         "type": "object"
       },
+      "ChatMessage": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatMessageSystem"
+          },
+          {
+            "$ref": "#/components/schemas/ChatMessageUser"
+          },
+          {
+            "$ref": "#/components/schemas/ChatMessageAssistant"
+          },
+          {
+            "$ref": "#/components/schemas/ChatMessageTool"
+          }
+        ]
+      },
       "ChatMessageAssistant": {
         "description": "Assistant chat message.",
         "properties": {
@@ -317,6 +333,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Id"
           },
           "metadata": {
@@ -329,6 +346,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Metadata"
           },
           "model": {
@@ -340,6 +358,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Model"
           },
           "role": {
@@ -361,6 +380,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Source"
           },
           "tool_calls": {
@@ -375,6 +395,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Tool Calls"
           }
         },
@@ -435,6 +456,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Id"
           },
           "metadata": {
@@ -447,6 +469,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Metadata"
           },
           "role": {
@@ -468,6 +491,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Source"
           }
         },
@@ -527,7 +551,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "function": {
             "anyOf": [
@@ -538,6 +563,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Function"
           },
           "id": {
@@ -549,6 +575,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Id"
           },
           "metadata": {
@@ -561,6 +588,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Metadata"
           },
           "role": {
@@ -582,6 +610,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Source"
           },
           "tool_call_id": {
@@ -593,6 +622,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Tool Call Id"
           }
         },
@@ -653,6 +683,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Id"
           },
           "metadata": {
@@ -665,6 +696,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Metadata"
           },
           "role": {
@@ -686,6 +718,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Source"
           },
           "tool_call_id": {
@@ -700,6 +733,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Tool Call Id"
           }
         },
@@ -1056,7 +1090,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "type": {
             "const": "audio",
@@ -1092,6 +1127,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Cited Text"
           },
           "internal": {
@@ -1106,6 +1142,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Internal"
           },
           "title": {
@@ -1117,6 +1154,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Title"
           },
           "type": {
@@ -1147,7 +1185,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "type": {
             "const": "data",
@@ -1181,7 +1220,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "mime_type": {
             "title": "Mime Type",
@@ -1225,7 +1265,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "type": {
             "const": "image",
@@ -1251,7 +1292,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "reasoning": {
             "title": "Reasoning",
@@ -1271,6 +1313,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Signature"
           },
           "summary": {
@@ -1282,6 +1325,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Summary"
           },
           "type": {
@@ -1330,6 +1374,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Citations"
           },
           "internal": {
@@ -1340,7 +1385,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "refusal": {
             "anyOf": [
@@ -1351,6 +1397,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Refusal"
           },
           "text": {
@@ -1386,6 +1433,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Context"
           },
           "error": {
@@ -1397,6 +1445,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Error"
           },
           "id": {
@@ -1411,7 +1460,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "name": {
             "title": "Name",
@@ -1467,7 +1517,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "type": {
             "const": "video",
@@ -1507,6 +1558,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Cited Text"
           },
           "internal": {
@@ -1521,6 +1573,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Internal"
           },
           "range": {
@@ -1531,7 +1584,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           },
           "title": {
             "anyOf": [
@@ -1542,6 +1596,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Title"
           },
           "type": {
@@ -5180,6 +5235,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Parse Error"
           },
           "type": {
@@ -5199,7 +5255,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           }
         },
         "required": [
@@ -5234,6 +5291,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Title"
           }
         },
@@ -6263,6 +6321,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Cited Text"
           },
           "internal": {
@@ -6277,6 +6336,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Internal"
           },
           "title": {
@@ -6288,6 +6348,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Title"
           },
           "type": {
@@ -6336,6 +6397,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "Labels"
           },
           "target": {
@@ -6346,7 +6408,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "default": null
           }
         },
         "required": [

--- a/src/inspect_scout/_view/www/src/types/generated.ts
+++ b/src/inspect_scout/_view/www/src/types/generated.ts
@@ -260,6 +260,7 @@ export interface components {
              */
             stop_reason: "stop" | "max_tokens" | "model_length" | "tool_calls" | "content_filter" | "unknown";
         };
+        ChatMessage: components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"];
         /**
          * ChatMessageAssistant
          * @description Assistant chat message.
@@ -267,24 +268,39 @@ export interface components {
         ChatMessageAssistant: {
             /** Content */
             content: string | (components["schemas"]["ContentText"] | components["schemas"]["ContentReasoning"] | components["schemas"]["ContentImage"] | components["schemas"]["ContentAudio"] | components["schemas"]["ContentVideo"] | components["schemas"]["ContentData"] | components["schemas"]["ContentToolUse"] | components["schemas"]["ContentDocument"])[];
-            /** Id */
-            id?: string | null;
-            /** Metadata */
-            metadata?: {
+            /**
+             * Id
+             * @default null
+             */
+            id: string | null;
+            /**
+             * Metadata
+             * @default null
+             */
+            metadata: {
                 [key: string]: unknown;
             } | null;
-            /** Model */
-            model?: string | null;
+            /**
+             * Model
+             * @default null
+             */
+            model: string | null;
             /**
              * Role
              * @default assistant
              * @constant
              */
             role: "assistant";
-            /** Source */
-            source?: ("input" | "generate") | null;
-            /** Tool Calls */
-            tool_calls?: components["schemas"]["ToolCall"][] | null;
+            /**
+             * Source
+             * @default null
+             */
+            source: ("input" | "generate") | null;
+            /**
+             * Tool Calls
+             * @default null
+             */
+            tool_calls: components["schemas"]["ToolCall"][] | null;
         };
         /**
          * ChatMessageSystem
@@ -293,10 +309,16 @@ export interface components {
         ChatMessageSystem: {
             /** Content */
             content: string | (components["schemas"]["ContentText"] | components["schemas"]["ContentReasoning"] | components["schemas"]["ContentImage"] | components["schemas"]["ContentAudio"] | components["schemas"]["ContentVideo"] | components["schemas"]["ContentData"] | components["schemas"]["ContentToolUse"] | components["schemas"]["ContentDocument"])[];
-            /** Id */
-            id?: string | null;
-            /** Metadata */
-            metadata?: {
+            /**
+             * Id
+             * @default null
+             */
+            id: string | null;
+            /**
+             * Metadata
+             * @default null
+             */
+            metadata: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -305,8 +327,11 @@ export interface components {
              * @constant
              */
             role: "system";
-            /** Source */
-            source?: ("input" | "generate") | null;
+            /**
+             * Source
+             * @default null
+             */
+            source: ("input" | "generate") | null;
         };
         /**
          * ChatMessageTool
@@ -315,13 +340,23 @@ export interface components {
         ChatMessageTool: {
             /** Content */
             content: string | (components["schemas"]["ContentText"] | components["schemas"]["ContentReasoning"] | components["schemas"]["ContentImage"] | components["schemas"]["ContentAudio"] | components["schemas"]["ContentVideo"] | components["schemas"]["ContentData"] | components["schemas"]["ContentToolUse"] | components["schemas"]["ContentDocument"])[];
-            error?: components["schemas"]["ToolCallError"] | null;
-            /** Function */
-            function?: string | null;
-            /** Id */
-            id?: string | null;
-            /** Metadata */
-            metadata?: {
+            /** @default null */
+            error: components["schemas"]["ToolCallError"] | null;
+            /**
+             * Function
+             * @default null
+             */
+            function: string | null;
+            /**
+             * Id
+             * @default null
+             */
+            id: string | null;
+            /**
+             * Metadata
+             * @default null
+             */
+            metadata: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -330,10 +365,16 @@ export interface components {
              * @constant
              */
             role: "tool";
-            /** Source */
-            source?: ("input" | "generate") | null;
-            /** Tool Call Id */
-            tool_call_id?: string | null;
+            /**
+             * Source
+             * @default null
+             */
+            source: ("input" | "generate") | null;
+            /**
+             * Tool Call Id
+             * @default null
+             */
+            tool_call_id: string | null;
         };
         /**
          * ChatMessageUser
@@ -342,10 +383,16 @@ export interface components {
         ChatMessageUser: {
             /** Content */
             content: string | (components["schemas"]["ContentText"] | components["schemas"]["ContentReasoning"] | components["schemas"]["ContentImage"] | components["schemas"]["ContentAudio"] | components["schemas"]["ContentVideo"] | components["schemas"]["ContentData"] | components["schemas"]["ContentToolUse"] | components["schemas"]["ContentDocument"])[];
-            /** Id */
-            id?: string | null;
-            /** Metadata */
-            metadata?: {
+            /**
+             * Id
+             * @default null
+             */
+            id: string | null;
+            /**
+             * Metadata
+             * @default null
+             */
+            metadata: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -354,10 +401,16 @@ export interface components {
              * @constant
              */
             role: "user";
-            /** Source */
-            source?: ("input" | "generate") | null;
-            /** Tool Call Id */
-            tool_call_id?: string[] | null;
+            /**
+             * Source
+             * @default null
+             */
+            source: ("input" | "generate") | null;
+            /**
+             * Tool Call Id
+             * @default null
+             */
+            tool_call_id: string[] | null;
         };
         /**
          * Condition
@@ -411,7 +464,8 @@ export interface components {
              * @enum {string}
              */
             format: "wav" | "mp3";
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /**
              * Type
              * @default audio
@@ -424,14 +478,23 @@ export interface components {
          * @description A generic content citation.
          */
         ContentCitation: {
-            /** Cited Text */
-            cited_text?: string | number[] | null;
-            /** Internal */
-            internal?: {
+            /**
+             * Cited Text
+             * @default null
+             */
+            cited_text: string | number[] | null;
+            /**
+             * Internal
+             * @default null
+             */
+            internal: {
                 [key: string]: components["schemas"]["JsonValue"];
             } | null;
-            /** Title */
-            title?: string | null;
+            /**
+             * Title
+             * @default null
+             */
+            title: string | null;
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
@@ -447,7 +510,8 @@ export interface components {
             data: {
                 [key: string]: components["schemas"]["JsonValue"];
             };
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /**
              * Type
              * @default data
@@ -464,7 +528,8 @@ export interface components {
             document: string;
             /** Filename */
             filename?: string;
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /** Mime Type */
             mime_type?: string;
             /**
@@ -487,7 +552,8 @@ export interface components {
             detail: "auto" | "low" | "high";
             /** Image */
             image: string;
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /**
              * Type
              * @default image
@@ -502,7 +568,8 @@ export interface components {
          *     See the specification for [thinking blocks](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#understanding-thinking-blocks) for Claude models.
          */
         ContentReasoning: {
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /** Reasoning */
             reasoning: string;
             /**
@@ -510,10 +577,16 @@ export interface components {
              * @default false
              */
             redacted: boolean;
-            /** Signature */
-            signature?: string | null;
-            /** Summary */
-            summary?: string | null;
+            /**
+             * Signature
+             * @default null
+             */
+            signature: string | null;
+            /**
+             * Summary
+             * @default null
+             */
+            summary: string | null;
             /**
              * Type
              * @default reasoning
@@ -526,11 +599,18 @@ export interface components {
          * @description Text content.
          */
         ContentText: {
-            /** Citations */
-            citations?: (components["schemas"]["ContentCitation"] | components["schemas"]["DocumentCitation"] | components["schemas"]["UrlCitation"])[] | null;
-            internal?: components["schemas"]["JsonValue"] | null;
-            /** Refusal */
-            refusal?: boolean | null;
+            /**
+             * Citations
+             * @default null
+             */
+            citations: (components["schemas"]["ContentCitation"] | components["schemas"]["DocumentCitation"] | components["schemas"]["UrlCitation"])[] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
+            /**
+             * Refusal
+             * @default null
+             */
+            refusal: boolean | null;
             /** Text */
             text: string;
             /**
@@ -547,13 +627,20 @@ export interface components {
         ContentToolUse: {
             /** Arguments */
             arguments: string;
-            /** Context */
-            context?: string | null;
-            /** Error */
-            error?: string | null;
+            /**
+             * Context
+             * @default null
+             */
+            context: string | null;
+            /**
+             * Error
+             * @default null
+             */
+            error: string | null;
             /** Id */
             id: string;
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /** Name */
             name: string;
             /** Result */
@@ -580,7 +667,8 @@ export interface components {
              * @enum {string}
              */
             format: "mp4" | "mpeg" | "mov";
-            internal?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            internal: components["schemas"]["JsonValue"] | null;
             /**
              * Type
              * @default video
@@ -595,15 +683,25 @@ export interface components {
          * @description A citation that refers to a page range in a document.
          */
         DocumentCitation: {
-            /** Cited Text */
-            cited_text?: string | number[] | null;
-            /** Internal */
-            internal?: {
+            /**
+             * Cited Text
+             * @default null
+             */
+            cited_text: string | number[] | null;
+            /**
+             * Internal
+             * @default null
+             */
+            internal: {
                 [key: string]: components["schemas"]["JsonValue"];
             } | null;
-            range?: components["schemas"]["DocumentRange"] | null;
-            /** Title */
-            title?: string | null;
+            /** @default null */
+            range: components["schemas"]["DocumentRange"] | null;
+            /**
+             * Title
+             * @default null
+             */
+            title: string | null;
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
@@ -1810,15 +1908,19 @@ export interface components {
             function: string;
             /** Id */
             id: string;
-            /** Parse Error */
-            parse_error?: string | null;
+            /**
+             * Parse Error
+             * @default null
+             */
+            parse_error: string | null;
             /**
              * Type
              * @default function
              * @enum {string}
              */
             type: "function" | "custom";
-            view?: components["schemas"]["ToolCallContent"] | null;
+            /** @default null */
+            view: components["schemas"]["ToolCallContent"] | null;
         };
         /**
          * ToolCallContent
@@ -1832,8 +1934,11 @@ export interface components {
              * @enum {string}
              */
             format: "text" | "markdown";
-            /** Title */
-            title?: string | null;
+            /**
+             * Title
+             * @default null
+             */
+            title: string | null;
         };
         /** ToolCallError */
         ToolCallError: {
@@ -2130,14 +2235,23 @@ export interface components {
          * @description A citation that refers to a URL.
          */
         UrlCitation: {
-            /** Cited Text */
-            cited_text?: string | number[] | null;
-            /** Internal */
-            internal?: {
+            /**
+             * Cited Text
+             * @default null
+             */
+            cited_text: string | number[] | null;
+            /**
+             * Internal
+             * @default null
+             */
+            internal: {
                 [key: string]: components["schemas"]["JsonValue"];
             } | null;
-            /** Title */
-            title?: string | null;
+            /**
+             * Title
+             * @default null
+             */
+            title: string | null;
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
@@ -2158,11 +2272,15 @@ export interface components {
         ValidationCase: {
             /** Id */
             id: string | string[];
-            /** Labels */
-            labels?: {
+            /**
+             * Labels
+             * @default null
+             */
+            labels: {
                 [key: string]: components["schemas"]["JsonValue"];
             } | null;
-            target?: components["schemas"]["JsonValue"] | null;
+            /** @default null */
+            target: components["schemas"]["JsonValue"] | null;
         };
         /** ValidationError */
         ValidationError: {


### PR DESCRIPTION
## Summary

Add support for injecting additional types into the OpenAPI schema that aren't directly referenced by any endpoint. This enables TypeScript type generation for types used elsewhere in the codebase.

## Key Changes

- Add `extra_schemas` list of `(name, type)` tuples to `custom_openapi()`
- Support Union types by creating `oneOf` schemas with all member types
- Support Pydantic models by adding their schemas directly
- Include two example types: `ChatMessage` (Union) and `ValidationCase` (Pydantic model)

## Why

Python type aliases (e.g., `ChatMessage = Union[...]`) don't preserve their names at runtime, so we must explicitly provide names when injecting them into the schema.