### PR TITLE
Pagination followup - push limit and cursor filtering to database

### DIFF
--- a/src/inspect_scout/_view/_api_v2_helpers.py
+++ b/src/inspect_scout/_view/_api_v2_helpers.py
@@ -1,10 +1,11 @@
 from typing import Any, Literal
 
+from .._transcript.columns import Condition, Operator
 from .._transcript.types import TranscriptInfo
-from ._api_v2_types import OrderBy, Pagination
+from ._api_v2_types import OrderBy
 
 
-def _ensure_tiebreaker(
+def ensure_tiebreaker(
     order_by: OrderBy | list[OrderBy] | None,
 ) -> list[tuple[str, Literal["ASC", "DESC"]]]:
     """Ensure sort order has transcript_id as final tiebreaker.
@@ -26,75 +27,65 @@ def _ensure_tiebreaker(
     return columns + [("transcript_id", "ASC")]
 
 
-def _compare_to_cursor(
-    transcript: TranscriptInfo,
+def cursor_to_condition(
     cursor: dict[str, Any],
     order_columns: list[tuple[str, Literal["ASC", "DESC"]]],
     direction: Literal["forward", "backward"],
-) -> bool:
-    """Check if transcript should be included based on cursor comparison.
+) -> Condition:
+    """Convert cursor to SQL condition for keyset pagination.
 
-    Uses lexicographic comparison on sort columns.
-    Returns True if transcript comes after cursor (forward) or before (backward).
+    For lexicographic ordering with columns (c1, c2, c3), generates:
+    forward+ASC:  (c1 > v1) OR (c1 = v1 AND c2 > v2) OR (c1 = v1 AND c2 = v2 AND c3 > v3)
+    forward+DESC: (c1 < v1) OR (c1 = v1 AND c2 < v2) OR ...
+    backward flips the comparison operators.
     """
-    for column, sort_dir in order_columns:
-        cursor_val = cursor.get(column)
-        transcript_val = getattr(transcript, column, None)
 
-        # Normalize None to empty string (matches sort behavior)
-        cursor_val = "" if cursor_val is None else cursor_val
-        transcript_val = "" if transcript_val is None else transcript_val
-
-        if transcript_val == cursor_val:
-            continue
-
-        is_greater = transcript_val > cursor_val
-        want_greater = (direction == "forward" and sort_dir == "ASC") or (
-            direction == "backward" and sort_dir == "DESC"
+    def get_operator(
+        sort_dir: Literal["ASC", "DESC"], pag_dir: Literal["forward", "backward"]
+    ) -> Operator:
+        want_greater = (pag_dir == "forward" and sort_dir == "ASC") or (
+            pag_dir == "backward" and sort_dir == "DESC"
         )
+        return Operator.GT if want_greater else Operator.LT
 
-        return is_greater if want_greater else not is_greater
+    # Build OR'd conditions for lexicographic comparison
+    or_conditions: list[Condition] = []
 
-    # All columns equal - same row as cursor, exclude
-    return False
+    for i in range(len(order_columns)):
+        and_conditions: list[Condition] = []
 
+        # Equality conditions for all preceding columns
+        for j in range(i):
+            col_name, _ = order_columns[j]
+            cursor_val = cursor.get(col_name)
+            # Match Python behavior: None -> ""
+            cursor_val = "" if cursor_val is None else cursor_val
+            and_conditions.append(
+                Condition(left=col_name, operator=Operator.EQ, right=cursor_val)
+            )
 
-def _apply_cursor_pagination(
-    transcripts: list[TranscriptInfo],
-    pagination: Pagination,
-    order_columns: list[tuple[str, Literal["ASC", "DESC"]]],
-) -> list[TranscriptInfo]:
-    """Apply cursor-based pagination to sorted transcripts.
+        # Comparison condition for current column
+        col_name, sort_dir = order_columns[i]
+        cursor_val = cursor.get(col_name)
+        cursor_val = "" if cursor_val is None else cursor_val
+        op = get_operator(sort_dir, direction)
+        and_conditions.append(Condition(left=col_name, operator=op, right=cursor_val))
 
-    Args:
-        transcripts: Already sorted list
-        pagination: Contains cursor, limit, direction
-        order_columns: Sort order as (column, direction) tuples
+        # Combine with AND
+        combined = and_conditions[0]
+        for cond in and_conditions[1:]:
+            combined = combined & cond
+        or_conditions.append(combined)
 
-    Returns:
-        Paginated slice of transcripts
-    """
-    if not pagination.cursor:
-        # First page
-        if pagination.direction == "forward":
-            return transcripts[: pagination.limit]
-        else:
-            return transcripts[-pagination.limit :]
+    # Combine all with OR
+    result = or_conditions[0]
+    for cond in or_conditions[1:]:
+        result = result | cond
 
-    # Find rows matching cursor condition
-    filtered: list[TranscriptInfo] = []
-    for transcript in transcripts:
-        if _compare_to_cursor(
-            transcript, pagination.cursor, order_columns, pagination.direction
-        ):
-            filtered.append(transcript)
-            if len(filtered) >= pagination.limit:
-                break
-
-    return filtered
+    return result
 
 
-def _build_cursor(
+def build_cursor(
     transcript: TranscriptInfo,
     order_columns: list[tuple[str, Literal["ASC", "DESC"]]],
 ) -> dict[str, Any]:
@@ -105,20 +96,11 @@ def _build_cursor(
     return cursor
 
 
-def _has_more_results(
-    all_results: list[TranscriptInfo],
-    paginated: list[TranscriptInfo],
-    pagination: Pagination,
-) -> bool:
-    """Check if more results exist beyond current page."""
-    if not paginated or len(paginated) < pagination.limit:
-        return False
-
-    if pagination.direction == "forward":
-        last_item = paginated[-1]
-        last_idx = all_results.index(last_item)
-        return last_idx < len(all_results) - 1
-    else:
-        first_item = paginated[0]
-        first_idx = all_results.index(first_item)
-        return first_idx > 0
+def reverse_order_columns(
+    order_columns: list[tuple[str, Literal["ASC", "DESC"]]],
+) -> list[tuple[str, Literal["ASC", "DESC"]]]:
+    """Reverse direction of all order columns."""
+    return [
+        (col, "DESC" if direction == "ASC" else "ASC")
+        for col, direction in order_columns
+    ]


### PR DESCRIPTION
## Summary
The initial pagination implementation for the `/transcripts` endpoint was inefficient. It was fetching ALL rows into memory and then applying pagination in Python. This PR pushes both the cursor condition and limit to the DB query for efficient database-level filtering.

## Key Changes

- **`_api_v2_helpers.py`**:
  - Added `cursor_to_condition()` - converts cursor to SQL WHERE condition for keyset pagination
  - Added `reverse_order_columns()` - reverses sort directions for backward pagination
  - Removed `_apply_cursor_pagination()`, `_compare_to_cursor()`, `_has_more_results()` (now handled at DB level)
- **`_api_v2.py`**:
  - Pushes cursor condition to DB via `.where()`
  - Handles backward pagination without cursor by reversing sort order then reversing results