### PR TITLE
Add `TranscriptsView` ABC with eval log support; use in API instead of `TranscriptsReader`

### DIFF
--- a/src/inspect_scout/_transcript/database/database.py
+++ b/src/inspect_scout/_transcript/database/database.py
@@ -3,6 +3,7 @@ from types import TracebackType
 from typing import AsyncIterable, AsyncIterator, Iterable, Literal, Type
 
 import pyarrow as pa
+from typing_extensions import Self
 
 from inspect_scout._transcript.transcripts import Transcripts
 
@@ -15,18 +16,8 @@ from ..types import (
 from .source import TranscriptsSource
 
 
-class TranscriptsDB(abc.ABC):
-    """Database of transcripts."""
-
-    def __init__(self, location: str, where: list[Condition] | None = None) -> None:
-        """Create a transcripts database.
-
-        Args:
-            location: Database location (e.g. local or S3 file path)
-            where: Optional list of conditions used to filter transcripts.
-        """
-        self._location: str | None = location
-        self._where = where
+class TranscriptsView(abc.ABC):
+    """Read-only view of transcripts database."""
 
     @abc.abstractmethod
     async def connect(self) -> None:
@@ -35,10 +26,10 @@ class TranscriptsDB(abc.ABC):
 
     @abc.abstractmethod
     async def disconnect(self) -> None:
-        """Disconnect to transcripts database."""
+        """Disconnect from transcripts database."""
         ...
 
-    async def __aenter__(self) -> "TranscriptsDB":
+    async def __aenter__(self) -> Self:
         """Connect to transcripts database."""
         await self.connect()
         return self
@@ -52,22 +43,6 @@ class TranscriptsDB(abc.ABC):
         """Disconnect from transcripts database."""
         await self.disconnect()
         return None
-
-    @abc.abstractmethod
-    async def insert(
-        self,
-        transcripts: Iterable[Transcript]
-        | AsyncIterable[Transcript]
-        | Transcripts
-        | TranscriptsSource
-        | pa.RecordBatchReader,
-    ) -> None:
-        """Insert transcripts into database.
-
-        Args:
-           transcripts: Transcripts to insert (iterable, async iterable, or source).
-        """
-        ...
 
     @abc.abstractmethod
     async def transcript_ids(
@@ -119,5 +94,25 @@ class TranscriptsDB(abc.ABC):
         Args:
             t: Transcript to read.
             content: Content to read (messages, events, etc.)
+        """
+        ...
+
+
+class TranscriptsDB(TranscriptsView):
+    """Database of transcripts with write capability."""
+
+    @abc.abstractmethod
+    async def insert(
+        self,
+        transcripts: Iterable[Transcript]
+        | AsyncIterable[Transcript]
+        | Transcripts
+        | TranscriptsSource
+        | pa.RecordBatchReader,
+    ) -> None:
+        """Insert transcripts into database.
+
+        Args:
+           transcripts: Transcripts to insert (iterable, async iterable, or source).
         """
         ...

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -38,7 +38,7 @@ from ...transcripts import (
 )
 from ...types import Transcript, TranscriptContent, TranscriptInfo
 from ..database import TranscriptsDB
-from ..reader import TranscriptsDBReader
+from ..reader import TranscriptsViewReader
 from ..source import TranscriptsSource
 from .encryption import (
     ENCRYPTION_KEY_ENV,
@@ -98,7 +98,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
             snapshot: Snapshot info. This is a mapping of transcript_id => filename
                 which we can use to avoid crawling.
         """
-        super().__init__(location, query.where if query is not None else None)
+        self._location = location
         self._target_file_size_mb = target_file_size_mb
         self._row_group_size_mb = row_group_size_mb
         self._query = query
@@ -1910,7 +1910,7 @@ class ParquetTranscripts(Transcripts):
                 transcript_id => filename mappings)
         """
         db = ParquetTranscriptsDB(self._location, query=self._query, snapshot=snapshot)
-        return TranscriptsDBReader(db)
+        return TranscriptsViewReader(db, self._location, self._query.where)
 
     @staticmethod
     @override

--- a/tests/transcript/test_lazy_json_persistence.py
+++ b/tests/transcript/test_lazy_json_persistence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
-from inspect_scout._transcript.eval_log import EvalLogTranscriptsDB
+from inspect_scout._transcript.eval_log import EvalLogTranscriptsView
 from inspect_scout._transcript.types import Transcript, TranscriptContent
 from inspect_scout._transcript.util import LazyJSONDict, filter_transcript
 
@@ -130,12 +130,12 @@ async def test_lazy_dict_survives_filter_transcript(
 
 @pytest.mark.asyncio
 async def test_lazy_dict_survives_eval_log_query(
-    eval_log_db_with_json_metadata: EvalLogTranscriptsDB,
+    eval_log_db_with_json_metadata: EvalLogTranscriptsView,
 ) -> None:
     """Test that LazyJSONDict survives through eval log query()."""
     # Query transcripts
     results = [
-        info async for info in eval_log_db_with_json_metadata.query([], None, False)
+        info async for info in eval_log_db_with_json_metadata.select([], None, False)
     ]
     assert len(results) > 0
 
@@ -310,7 +310,7 @@ async def parquet_db_with_nested_metadata(
 
 
 @pytest_asyncio.fixture
-async def eval_log_db_with_json_metadata() -> EvalLogTranscriptsDB:
+async def eval_log_db_with_json_metadata() -> EvalLogTranscriptsView:
     """Create an eval log DB with JSON metadata for testing."""
     import pandas as pd
 
@@ -328,6 +328,6 @@ async def eval_log_db_with_json_metadata() -> EvalLogTranscriptsDB:
         }
     )
 
-    db = EvalLogTranscriptsDB(df)
+    db = EvalLogTranscriptsView(df)
     await db.connect()
     return db

--- a/tests/transcript/test_transcripts_view_factory.py
+++ b/tests/transcript/test_transcripts_view_factory.py
@@ -1,0 +1,60 @@
+"""Tests for transcripts_view() and transcripts_db() factory functions."""
+
+from pathlib import Path
+
+import pytest
+from inspect_scout._transcript.database.factory import transcripts_db, transcripts_view
+from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
+from inspect_scout._transcript.eval_log import EvalLogTranscriptsView
+from inspect_scout._transcript.factory import _location_type
+
+# Path to real test eval logs
+TEST_EVAL_LOGS_DIR = Path(__file__).parent.parent / "recorder" / "logs"
+
+
+@pytest.fixture
+def parquet_db_location(tmp_path: Path) -> Path:
+    """Create a location that looks like a parquet database (empty dir)."""
+    db_path = tmp_path / "parquet_db"
+    db_path.mkdir()
+    return db_path
+
+
+def test_transcripts_view_returns_parquet_for_database(
+    parquet_db_location: Path,
+) -> None:
+    """transcripts_view() returns ParquetTranscriptsDB for parquet location."""
+    view = transcripts_view(str(parquet_db_location))
+    assert isinstance(view, ParquetTranscriptsDB)
+
+
+def test_transcripts_view_returns_eval_log_for_logs() -> None:
+    """transcripts_view() returns EvalLogTranscriptsView for eval log location."""
+    view = transcripts_view(str(TEST_EVAL_LOGS_DIR))
+    assert isinstance(view, EvalLogTranscriptsView)
+
+
+def test_transcripts_db_returns_parquet_for_database(
+    parquet_db_location: Path,
+) -> None:
+    """transcripts_db() returns ParquetTranscriptsDB for parquet location."""
+    db = transcripts_db(str(parquet_db_location))
+    assert isinstance(db, ParquetTranscriptsDB)
+
+
+def test_transcripts_db_raises_for_eval_log() -> None:
+    """transcripts_db() raises ValueError for eval log location."""
+    with pytest.raises(
+        ValueError, match="Mutable database not supported for eval logs"
+    ):
+        transcripts_db(str(TEST_EVAL_LOGS_DIR))
+
+
+def test_location_type_detects_database(parquet_db_location: Path) -> None:
+    """_location_type() returns 'database' for empty directory."""
+    assert _location_type(str(parquet_db_location)) == "database"
+
+
+def test_location_type_detects_eval_log() -> None:
+    """_location_type() returns 'eval_log' for directory with .eval files."""
+    assert _location_type(str(TEST_EVAL_LOGS_DIR)) == "eval_log"

--- a/tests/view/test_v2_api.py
+++ b/tests/view/test_v2_api.py
@@ -469,13 +469,10 @@ def _create_test_transcripts_for_api(count: int) -> list[Transcript]:
 
 async def _populate_transcripts(location: Path, transcripts: list[Transcript]) -> None:
     """Populate transcript database for testing."""
-    from inspect_scout import transcripts_from
-    from inspect_scout._transcript.database.reader import TranscriptsDBReader
+    from inspect_scout import transcripts_db
 
-    transcripts_obj = transcripts_from(str(location))
-    async with transcripts_obj.reader() as reader:
-        if isinstance(reader, TranscriptsDBReader):
-            await reader._db.insert(transcripts)
+    async with transcripts_db(str(location)) as db:
+        await db.insert(transcripts)
 
 
 class TestTranscriptsPagination:


### PR DESCRIPTION
## Summary
- Factor out `TranscriptsView` ABC for read-only database access
- Rename `EvalLogTranscriptsDB` → `EvalLogTranscriptsView` and make it conform to `TranscriptsView`
- Switch POST `/transcripts/{dir}` and GET `/transcripts/{dir}/{id}` endpoints from `TranscriptsReader` to `TranscriptsView`

`TranscriptsReader` was not designed for API endpoint use cases. `TranscriptsView` directly supports conditions, limits, and order_by parameters.