### PR TITLE
Defer `_index_logs()` until `connect()` for L2 cache hits.

### DIFF
--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -205,6 +205,7 @@ class EvalLogTranscriptsView(TranscriptsView):
         self._fs: AsyncFilesystem | None = None
 
     async def connect(self) -> None:
+        # Skip if already connected
         if self._conn is not None:
             return
 
@@ -229,6 +230,7 @@ class EvalLogTranscriptsView(TranscriptsView):
                     f"file:{self._cache_key}?mode=memory&cache=shared", uri=True
                 )
             else:
+                # No cache key (DataFrame input) - use anonymous memory db
                 self._conn = sqlite3.connect(":memory:")
 
             df.to_sql(TRANSCRIPTS, self._conn, index=False, if_exists="replace")


### PR DESCRIPTION
## Summary
- Defer expensive `_index_logs()` call from constructor to `connect()`
- On L2 cache hit, skip DataFrame creation entirely - just connect to cached SQLite
- Eliminate `_transcripts_df` instance variable; DataFrame is now local to `connect()`
- `read()` and `snapshot()` now query SQLite directly instead of DataFrame

## Motivation
The L2 SQLite cache (PR #143) wasn't delivering full performance benefits because `_index_logs()` ran in the constructor before the cache check in `connect()`.

## Design
All queries now operate on SQLite. DataFrame is only an intermediate step for populating SQLite on cache miss, then discarded.