### PR TITLE
Fix path vs URI mismatch in `/config` endpoint

### DIFF
--- a/src/inspect_scout/_view/_api_v2.py
+++ b/src/inspect_scout/_view/_api_v2.py
@@ -181,9 +181,15 @@ def v2_api_app(
     )
     async def config(request: Request) -> AppConfig:
         """Return application configuration."""
+        transcripts = project().transcripts
+        transcripts = (
+            UPath(transcripts).resolve().as_uri() if transcripts is not None else None
+        )
+        # resolve scans uri
+        scans = UPath(project().scans or DEFAULT_SCANS_DIR).resolve().as_uri()
         return AppConfig(
-            transcripts_dir=project().transcripts,
-            scans_dir=project().scans or DEFAULT_SCANS_DIR,
+            transcripts_dir=transcripts,
+            scans_dir=scans,
         )
 
     @app.post(


### PR DESCRIPTION
## Summary
- Normalize paths to URIs in `/config` endpoint to match `OnlyDirAccessPolicy` format
- Fixes regression from 9ca4147e where `project().scans` returned plain paths instead of URIs