### PR TITLE
Disable UPath listings cache when enumerating scanners

### DIFF
--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -289,7 +289,10 @@ class FileRecorder(ScanRecorder):
 
         # enumerate the scanners
         scanners = [
-            file.stem for file in sorted(UPath(scan_location, use_listings_cache=False).glob("*.parquet"))
+            file.stem
+            for file in sorted(
+                UPath(scan_location, use_listings_cache=False).glob("*.parquet")
+            )
         ]
 
         return _ScanResultsArrowFiles(


### PR DESCRIPTION
UPath will cache listings by default. This can result in the view server never discovering a scanner if you accidentally query before the parquet file has been generated.

This PR disables that caching.