### PR TITLE
Export apiScoutServerV1

### DIFF
--- a/src/inspect_scout/_view/www/src/index.ts
+++ b/src/inspect_scout/_view/www/src/index.ts
@@ -3,6 +3,7 @@ export { App } from "./App";
 
 // Client APIs
 export { apiScoutServer } from "./api/api-scout-server";
+export { apiScoutServerV1 } from "./api/api-scout-server-v1";
 
 // Client API - Types
 export type { ScanApi } from "./api/api.ts";


### PR DESCRIPTION
The (deprecated) `apiScoutServerV1` was not exported to the frontend library.