### PR TITLE
Hide early parse exit behind `SCOUT_EARLY_PARSE_EXIT` env var

### DIFF
--- a/src/inspect_scout/_transcript/json/load_filtered.py
+++ b/src/inspect_scout/_transcript/json/load_filtered.py
@@ -220,11 +220,11 @@ async def _parse_and_filter(
     async for prefix, event, value in ijson.parse_async(sample_json, use_float=True):
         # Early exit: messages-only with no attachment refs
         if (
-            os.environ.get("SCOUT_EARLY_PARSE_EXIT")
-            and events_coro is None
+            events_coro is None
             and prefix == "messages"
             and event == "end_array"
             and not state.attachment_refs
+            and os.environ.get("SCOUT_EARLY_PARSE_EXIT")
         ):
             break
 


### PR DESCRIPTION
## Summary
- Gates the early exit optimization from #186 behind a `SCOUT_EARLY_PARSE_EXIT` environment variable
- When not set, parsing continues through the entire file even for messages-only requests