### PR TITLE
Add branded `NewType`s for URIs and paths

### DIFF
--- a/src/inspect_scout/_util/path_str.py
+++ b/src/inspect_scout/_util/path_str.py
@@ -1,17 +1,24 @@
-"""Branded string type for filesystem paths."""
+"""PathStr conversion functions."""
 
 from pathlib import Path
-from typing import NewType
+from urllib.parse import unquote
 
 from upath import UPath
 
-PathStr = NewType("PathStr", str)
-"""A filesystem path as a string (no encoding)."""
+from .str_types import PathStr, UriStr
+
+__all__ = ["PathStr", "as_path", "make_path"]
 
 
-def make_path(path: Path | UPath) -> PathStr:
-    """Convert a Path or UPath to PathStr."""
-    return PathStr(str(path))
+def make_path(path: Path | UPath | UriStr) -> PathStr:
+    """Convert a Path, UPath, or UriStr to PathStr.
+
+    If passed a UriStr, decodes percent-encoded characters.
+    """
+    if isinstance(path, (Path, UPath)):
+        return PathStr(str(path))
+    # UriStr case - decode percent-encoding
+    return PathStr(unquote(UPath(path).path))
 
 
 def as_path(raw: str) -> PathStr:

--- a/src/inspect_scout/_util/str_types.py
+++ b/src/inspect_scout/_util/str_types.py
@@ -1,0 +1,9 @@
+"""Branded string types for type-safe URI and path handling."""
+
+from typing import NewType
+
+UriStr = NewType("UriStr", str)
+"""A percent-encoded URI string per RFC 3986."""
+
+PathStr = NewType("PathStr", str)
+"""A filesystem path as a string (no encoding)."""

--- a/src/inspect_scout/_util/uri_str.py
+++ b/src/inspect_scout/_util/uri_str.py
@@ -1,15 +1,12 @@
-"""Branded string type for URIs (percent-encoded per RFC 3986)."""
+"""UriStr conversion functions."""
 
 from pathlib import Path
-from typing import NewType
-from urllib.parse import unquote
 
 from upath import UPath
 
-from .path_str import PathStr, as_path
+from .str_types import PathStr, UriStr
 
-UriStr = NewType("UriStr", str)
-"""A percent-encoded URI string per RFC 3986."""
+__all__ = ["UriStr", "as_uri", "make_uri"]
 
 
 def make_uri(path: Path | UPath | PathStr) -> UriStr:
@@ -18,11 +15,6 @@ def make_uri(path: Path | UPath | PathStr) -> UriStr:
     Resolves the path to an absolute path before encoding.
     """
     return UriStr(UPath(path).resolve().as_uri())
-
-
-def uri_to_path(uri: UriStr) -> PathStr:
-    """Convert a file:// URI to a decoded path string."""
-    return as_path(unquote(UPath(uri).path))
 
 
 def as_uri(raw: str) -> UriStr:


### PR DESCRIPTION
## Summary

- Add `UriStr` and `PathStr` branded `NewType`s for type-safe string handling
- `UriStr`: percent-encoded URI per RFC 3986
- `PathStr`: filesystem path as string (no encoding)
- Conversion functions: `make_uri`, `make_path` (accepts Path, UPath, or UriStr)
- Assertion functions: `as_uri`, `as_path` for caller-asserted casts
- Types defined in `str_types.py`, functions in `path_str.py` and `uri_str.py`