### PR TITLE
Pass scores and target through in `as_scorer` path

### DIFF
--- a/src/inspect_scout/_scanner/scorer.py
+++ b/src/inspect_scout/_scanner/scorer.py
@@ -66,6 +66,8 @@ def as_scorer(
                     "id": state.sample_id,
                     "epoch": state.epoch,
                     "sample_metadata": state.metadata,
+                    "target": target.target if len(target) > 1 else target.text,
+                    "scores": state.scores,
                 },
                 messages=messages,
                 events=events,


### PR DESCRIPTION
## Summary

Fast follow to #299.

PR #299 unthinned `target` and added `scores` to `Transcript.metadata` when loading from the index, but the `as_scorer` path — where a scanner runs as an Inspect scorer during a live eval — constructs its own `Transcript` from `TaskState` and wasn't populating either field. This adds both so scanners get the same metadata regardless of whether they run against the index or inline as a scorer.