### PR TITLE
perf: lazy-load scan_events and use PyArrow range requests for S3 parquet reads

### DIFF
--- a/scripts/export_openapi_schema.py
+++ b/scripts/export_openapi_schema.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel
 
 
 def main() -> None:
@@ -25,7 +25,9 @@ def main() -> None:
     sys.path.insert(0, str(repo_root / "src"))
 
     from inspect_ai._view._openapi import build_openapi_schema
+    from inspect_ai.log import EventsData
     from inspect_scout._llm_scanner.params import LlmScannerParams
+    from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
     from inspect_scout._transcript.types import Transcript
     from inspect_scout._validation.types import ValidationCase
     from inspect_scout._view._api_v2 import v2_api_app
@@ -42,6 +44,13 @@ def main() -> None:
 
     class RawEncoding(RootModel[_RawEncoding]):
         pass
+
+    class ScannerInputResponse(BaseModel):
+        """Schema-only type for scanner input column values."""
+
+        input_type: ScannerInputNames
+        input: ScannerInput
+        input_data: EventsData | None = None
 
     # Create the real app, then add stub endpoints for scout-specific types.
     app = v2_api_app()
@@ -64,6 +73,10 @@ def main() -> None:
 
     @app.get("/schema/raw-encoding")
     def _raw_encoding() -> RawEncoding:
+        raise NotImplementedError
+
+    @app.get("/schema/scanner-input")
+    def _scanner_input() -> ScannerInputResponse:
         raise NotImplementedError
 
     schema = build_openapi_schema(app)

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.dataset as ds
+import pyarrow.fs as pafs
 import pyarrow.parquet as pq
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import file, filesystem
@@ -239,7 +240,34 @@ class FileRecorder(ScanRecorder):
     async def results_arrow(
         scan_location: str,
     ) -> ScanResultsArrow:
+        scan_path = UPath(scan_location)
+
         class _ScanResultsArrowFiles(ScanResultsArrow):
+            def _resolve_parquet_source(
+                self, scanner: str
+            ) -> tuple[str | io.BytesIO, pafs.FileSystem | None]:
+                """Return (path, filesystem) for opening a parquet file.
+
+                For cloud paths with native PyArrow support (S3, GCS, ABFS),
+                returns a pyarrow filesystem that uses HTTP range requests.
+                For az:// (no native PyArrow support), downloads via fsspec
+                and returns a BytesIO. For local paths, returns (str, None).
+                """
+                scanner_path = scan_path / f"{scanner}.parquet"
+                path_str = scanner_path.as_posix()
+
+                if path_str.startswith(
+                    ("s3://", "gs://", "gcs://", "abfs://", "abfss://")
+                ):
+                    pa_fs, pa_path = pafs.FileSystem.from_uri(path_str)
+                    return pa_path, pa_fs
+
+                if path_str.startswith("az://"):
+                    with file(path_str, "rb") as f:
+                        return io.BytesIO(f.read()), None
+
+                return str(scanner_path), None
+
             @override
             def reader(
                 self,
@@ -247,27 +275,23 @@ class FileRecorder(ScanRecorder):
                 streaming_batch_size: int = 1024,
                 exclude_columns: list[str] | None = None,
             ) -> pa.RecordBatchReader:
-                scan_path = UPath(scan_location)
-                scanner_path = scan_path / f"{scanner}.parquet"
+                pa_path, pa_fs = self._resolve_parquet_source(scanner)
 
-                # For remote filesystems (S3, etc.), pre-fetch the file into memory
-                # to avoid per-row-group latency. This is 2-3x faster for files with
-                # many row groups. For local files, read directly to avoid memory copy.
-                scanner_path_str = scanner_path.as_posix()
-                if scanner_path_str.startswith(("s3://", "gs://", "az://", "abfs://")):
-                    # Pre-fetch entire file into memory for faster iteration
-                    with file(scanner_path_str, "rb") as f:
-                        file_bytes = f.read()
-                    parquet = pq.ParquetFile(io.BytesIO(file_bytes))
+                if pa_fs is not None:
+                    # Use pre_buffer=True to coalesce HTTP range requests,
+                    # then read() + to_reader() instead of iter_batches()
+                    # which doesn't support pre_buffer.
+                    parquet = pq.ParquetFile(pa_path, filesystem=pa_fs, pre_buffer=True)
                 else:
-                    # Local files: read directly (no memory copy needed)
-                    parquet = pq.ParquetFile(str(scanner_path))
+                    parquet = pq.ParquetFile(pa_path)
 
-                columns = [
-                    c
-                    for c in parquet.schema.names
-                    if exclude_columns is None or c not in exclude_columns
-                ]
+                exclude = set(exclude_columns) if exclude_columns else set()
+                columns = [c for c in parquet.schema.names if c not in exclude]
+
+                if pa_fs is not None:
+                    table = parquet.read(columns=columns)
+                    return table.to_reader(max_chunksize=streaming_batch_size)
+
                 fields_by_name = {f.name: f for f in parquet.schema_arrow}
                 arrow_schema = pa.schema([fields_by_name[name] for name in columns])
 
@@ -278,27 +302,46 @@ class FileRecorder(ScanRecorder):
                     ),
                 )
 
-            def _get_dataset(self, scanner: str) -> "ds.Dataset":
-                scan_path = UPath(scan_location)
-                scanner_path = scan_path / f"{scanner}.parquet"
-                scanner_path_str = scanner_path.as_posix()
+            def _point_lookup(
+                self,
+                scanner: str,
+                id_column: str,
+                id_value: Any,
+                target_columns: list[str],
+            ) -> pa.Table:
+                """Look up a single row by id, returning a 1-row table.
 
-                # For remote filesystems, pre-fetch the file into memory
-                if scanner_path_str.startswith(("s3://", "gs://", "az://", "abfs://")):
-                    with file(scanner_path_str, "rb") as f:
-                        file_bytes = f.read()
-                    table = pq.read_table(io.BytesIO(file_bytes))
-                    return ds.dataset(table)
-                return ds.dataset(str(scanner_path), format="parquet")
+                For remote files, scans only the id column across row groups
+                via range requests, then fetches target columns from the
+                matching group only. For local files, uses a dataset filter.
+                """
+                pa_path, pa_fs = self._resolve_parquet_source(scanner)
+
+                if pa_fs is not None:
+                    pf = pq.ParquetFile(pa_path, filesystem=pa_fs)
+                    for i in range(pf.metadata.num_row_groups):
+                        rg_ids = pf.read_row_group(i, columns=[id_column])
+                        mask = pc.equal(rg_ids[id_column], id_value)
+                        if pc.any(mask).as_py():
+                            rg_data = pf.read_row_group(i, columns=target_columns)
+                            return rg_data.filter(mask)
+                    return pa.table({c: [] for c in target_columns})
+
+                dataset: ds.Dataset = (
+                    ds.dataset(pq.read_table(pa_path))
+                    if isinstance(pa_path, io.BytesIO)
+                    else ds.dataset(pa_path, format="parquet")
+                )
+                return dataset.to_table(
+                    columns=target_columns,
+                    filter=(pc.field(id_column) == id_value),
+                )
 
             def get_field(
                 self, scanner: str, id_column: str, id_value: Any, target_column: str
             ) -> "Scalar[Any]":
-                dataset = self._get_dataset(scanner)
-
-                table = dataset.to_table(
-                    columns=[target_column],
-                    filter=(pc.field(id_column) == id_value),
+                table = self._point_lookup(
+                    scanner, id_column, id_value, [target_column]
                 )
 
                 if len(table) == 0:
@@ -311,6 +354,15 @@ class FileRecorder(ScanRecorder):
 
                 return cast("Scalar[Any]", table[target_column][0])
 
+            def _schema_names(self, scanner: str) -> set[str]:
+                """Return the set of column names in a scanner's parquet file."""
+                pa_path, pa_fs = self._resolve_parquet_source(scanner)
+                if pa_fs is not None:
+                    pf = pq.ParquetFile(pa_path, filesystem=pa_fs)
+                else:
+                    pf = pq.ParquetFile(pa_path)
+                return set(pf.schema.names)
+
             def get_fields(
                 self,
                 scanner: str,
@@ -322,15 +374,11 @@ class FileRecorder(ScanRecorder):
 
                 Missing columns (e.g. in old parquet files) return None.
                 """
-                dataset = self._get_dataset(scanner)
-                schema_names = set(dataset.schema.names)
+                schema_names = self._schema_names(scanner)
                 present = [c for c in target_columns if c in schema_names]
                 missing = [c for c in target_columns if c not in schema_names]
 
-                table = dataset.to_table(
-                    columns=present,
-                    filter=(pc.field(id_column) == id_value),
-                )
+                table = self._point_lookup(scanner, id_column, id_value, present)
 
                 if len(table) == 0:
                     raise KeyError(f"{id_value!r} not found in {id_column}")

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -16,6 +16,7 @@ import anyio
 import pyarrow.ipc as pa_ipc
 from duckdb import InvalidInputException
 from fastapi import APIRouter, HTTPException, Path, Request, Response
+from fastapi import Query as QueryParam
 from fastapi.responses import StreamingResponse
 from inspect_ai._util.file import file
 from send2trash import send2trash
@@ -34,10 +35,10 @@ from .._recorder.factory import scan_recorder_for_location
 from .._scanjob_config import ScanJobConfig
 from .._scanjobs.duckdb import scan_jobs_view
 from .._scanresults import scan_results_arrow_async, scan_results_df_async
+from .._transcript.eval_log import JSON_COLUMNS
 from ._api_v2_types import (
     ActiveScansResponse,
     DistinctRequest,
-    ScannerInputResponse,
     ScanRow,
     ScansRequest,
     ScansResponse,
@@ -46,6 +47,10 @@ from ._api_v2_types import (
 from ._pagination_helpers import build_pagination_context
 from ._server_common import InspectPydanticJSONResponse, decode_base64url
 from .invalidationTopics import notify_topics
+
+# Scan result columns that are stored as pre-serialized JSON strings in
+# parquet, in addition to the transcript-level JSON_COLUMNS.
+_SCAN_JSON_COLUMNS = frozenset(JSON_COLUMNS) | {"scan_events", "input_data"}
 
 # TODO: temporary simulation tracking currently running scans (by location path)
 _running_scans: set[str] = set()
@@ -160,7 +165,7 @@ def create_scans_router(
         summary="Get active scans",
         description="Returns info on all currently running scans.",
     )
-    def active_scans() -> ActiveScansResponse:
+    async def active_scans() -> ActiveScansResponse:
         """Get info on all active scans from the KV store."""
         with active_scans_store() as store:
             return ActiveScansResponse(items=store.read_all())
@@ -174,9 +179,7 @@ def create_scans_router(
     )
     async def run_llm_scanner(body: ScanJobConfig) -> ScanStatus:
         """Run an llm_scanner scan via subprocess."""
-        proc, temp_path, _stdout_lines, stderr_lines = await anyio.to_thread.run_sync(
-            lambda: _spawn_scan_subprocess(body)
-        )
+        proc, temp_path, _stdout_lines, stderr_lines = _spawn_scan_subprocess(body)
         pid = proc.pid
 
         active_info = await _wait_for_active_scan(pid)
@@ -263,14 +266,24 @@ def create_scans_router(
         "/scans/{dir}/{scan}/{scanner}",
         summary="Get scanner dataframe containing results for all transcripts",
         description="Streams scanner results as Arrow IPC format with LZ4 compression. "
-        "Excludes input column for efficiency; use the input endpoint for input text.",
+        "Use exclude_columns to omit heavy columns from the response.",
     )
     async def scan_df(
         dir: str = Path(description="Scans directory (base64url-encoded)"),
         scan: str = Path(description="Scan path (base64url-encoded)"),
         scanner: str = Path(description="Scanner name"),
+        exclude_columns: str | None = QueryParam(
+            default=None,
+            description="Comma-separated list of column names to exclude",
+        ),
     ) -> Response:
         """Stream scanner results as Arrow IPC with LZ4 compression."""
+        excluded = (
+            [c.strip() for c in exclude_columns.split(",") if c.strip()]
+            if exclude_columns
+            else []
+        )
+
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)
 
@@ -287,7 +300,7 @@ def create_scans_router(
             with result.reader(
                 scanner,
                 streaming_batch_size=streaming_batch_size,
-                exclude_columns=["input"],
+                exclude_columns=excluded,
             ) as reader:
                 with pa_ipc.new_stream(
                     buf,
@@ -313,24 +326,37 @@ def create_scans_router(
         )
 
     @router.get(
-        "/scans/{dir}/{scan}/{scanner}/{uuid}/input",
-        response_model=ScannerInputResponse,
-        summary="Get scanner input for a specific result",
-        description="Returns a JSON envelope with input, input_type, and input_data "
-        "(EventsData pools for condensed events, or null).",
+        "/scans/{dir}/{scan}/{scanner}/{uuid}",
+        summary="Get specific columns for a result row",
+        description="Returns requested columns as a JSON object. "
+        "Pass a comma-separated list via the `columns` query parameter.",
     )
-    async def scanner_input(
+    async def scanner_row(
         dir: str = Path(description="Scans directory (base64url-encoded)"),
         scan: str = Path(description="Scan path (base64url-encoded)"),
         scanner: str = Path(description="Scanner name"),
         uuid: str = Path(description="UUID of the specific result row"),
+        columns: str | None = QueryParam(
+            default=None,
+            description="Comma-separated list of column names to return",
+        ),
     ) -> Response:
-        """Retrieve scanner input as a JSON envelope.
+        """Retrieve specific columns for a result row as a JSON object.
 
-        Returns ``{"input_type": ..., "input": ..., "input_data": ...}``
-        where ``input`` and ``input_data`` are raw JSON from parquet —
-        no server-side parsing or re-encoding.
+        Columns in ``JSON_COLUMNS`` are pre-serialized JSON strings in
+        parquet — embedded raw in the response without re-encoding.
+        All other columns are serialized with ``json.dumps()``.
         """
+        if not columns:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="Missing required query parameter: columns",
+            )
+
+        requested = list(
+            dict.fromkeys(c.strip() for c in columns.split(",") if c.strip())
+        )
+
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)
 
@@ -341,30 +367,29 @@ def create_scans_router(
                 detail=f"Scanner '{scanner}' not found in scan results",
             )
 
-        fields = await anyio.to_thread.run_sync(
-            lambda: result.get_fields(
-                scanner, "uuid", uuid, ["input", "input_type", "input_data"]
-            )
-        )
+        try:
+            row = result.get_fields(scanner, "uuid", uuid, requested)
+        except (KeyError, ValueError) as err:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"No row found for uuid: {uuid}",
+            ) from err
 
-        # `input` and `input_data` are pre-serialized JSON strings in the parquet
-        # columns. The call to `.get_fields()` does `.as_py()` which returns a Python
-        # `str` from Arrow's `large_string`. This means that `fields["input"]` is
-        # a python `str`. They both pass straight through as raw JSON fragments
-        # — no parsing, no re-encoding, no extra copies beyond Arrow → Python str.
-        # Obviously, there's no type safety here — `response_model`` is for OpenAPI
-        # schema only.
+        # Build JSON manually: columns in JSON_COLUMNS are pre-serialized
+        # JSON strings in parquet and are embedded raw to avoid double-encoding.
+        parts: list[str] = []
+        for col in requested:
+            value = row[col]
+            if value is None:
+                serialized = "null"
+            elif col in _SCAN_JSON_COLUMNS and isinstance(value, str) and value:
+                serialized = value
+            else:
+                serialized = json.dumps(value)
+            parts.append(json.dumps(col) + ":" + serialized)
 
         return Response(
-            content=(
-                '{"input_type":'
-                + json.dumps(fields["input_type"])
-                + ',"input":'
-                + (fields["input"] or "null")
-                + ',"input_data":'
-                + (fields["input_data"] or "null")
-                + "}"
-            ),
+            content="{" + ",".join(parts) + "}",
             media_type="application/json",
         )
 
@@ -382,34 +407,25 @@ def create_scans_router(
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)
 
-        def _delete_scan_sync() -> None:
-            if scan_path.protocol != "file" and scan_path.protocol != "":
-                raise HTTPException(
-                    status_code=HTTP_400_BAD_REQUEST,
-                    detail="Delete is only supported for local scans",
-                )
+        # Check if scan exists
+        if not scan_path.exists():
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail="Scan not found",
+            )
 
-            # Check if scan exists
-            if not scan_path.exists():
-                raise HTTPException(
-                    status_code=HTTP_404_NOT_FOUND,
-                    detail="Scan not found",
-                )
+        # Check if scan is active (prevent deletion of running scans)
+        scan_location_str = str(scan_path)
+        with active_scans_store() as store:
+            active_scans = store.read_all()
+            for active_info in active_scans.values():
+                if active_info.location == scan_location_str:
+                    raise HTTPException(
+                        status_code=HTTP_409_CONFLICT,
+                        detail=f"Cannot delete active scan: {active_info.scan_id}",
+                    )
 
-            # Check if scan is active (prevent deletion of running scans)
-            scan_location_str = str(scan_path)
-            with active_scans_store() as store:
-                active_scans = store.read_all()
-                for active_info in active_scans.values():
-                    if active_info.location == scan_location_str:
-                        raise HTTPException(
-                            status_code=HTTP_409_CONFLICT,
-                            detail=f"Cannot delete active scan: {active_info.scan_id}",
-                        )
-
-            send2trash(scan_path.path)
-
-        await anyio.to_thread.run_sync(_delete_scan_sync)
+        send2trash(scan_path.path)
 
         # Notify clients to invalidate scan caches
         await notify_topics(["scans"])

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -266,23 +266,19 @@ def create_scans_router(
         "/scans/{dir}/{scan}/{scanner}",
         summary="Get scanner dataframe containing results for all transcripts",
         description="Streams scanner results as Arrow IPC format with LZ4 compression. "
-        "Use exclude_columns to omit heavy columns from the response.",
+        "Use exclude_column to omit heavy columns from the response.",
     )
     async def scan_df(
         dir: str = Path(description="Scans directory (base64url-encoded)"),
         scan: str = Path(description="Scan path (base64url-encoded)"),
         scanner: str = Path(description="Scanner name"),
-        exclude_columns: str | None = QueryParam(
-            default=None,
-            description="Comma-separated list of column names to exclude",
+        exclude_column: list[str] = QueryParam(  # noqa: B008
+            default=[],
+            description="Column names to exclude (repeat for multiple)",
         ),
     ) -> Response:
         """Stream scanner results as Arrow IPC with LZ4 compression."""
-        excluded = (
-            [c.strip() for c in exclude_columns.split(",") if c.strip()]
-            if exclude_columns
-            else []
-        )
+        excluded = [c.strip() for c in exclude_column if c.strip()]
 
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)
@@ -329,16 +325,16 @@ def create_scans_router(
         "/scans/{dir}/{scan}/{scanner}/{uuid}",
         summary="Get specific columns for a result row",
         description="Returns requested columns as a JSON object. "
-        "Pass a comma-separated list via the `columns` query parameter.",
+        "Repeat the `column` query parameter for each column.",
     )
     async def scanner_row(
         dir: str = Path(description="Scans directory (base64url-encoded)"),
         scan: str = Path(description="Scan path (base64url-encoded)"),
         scanner: str = Path(description="Scanner name"),
         uuid: str = Path(description="UUID of the specific result row"),
-        columns: str | None = QueryParam(
-            default=None,
-            description="Comma-separated list of column names to return",
+        column: list[str] = QueryParam(  # noqa: B008
+            default=[],
+            description="Column names to return (repeat for multiple)",
         ),
     ) -> Response:
         """Retrieve specific columns for a result row as a JSON object.
@@ -347,15 +343,13 @@ def create_scans_router(
         parquet — embedded raw in the response without re-encoding.
         All other columns are serialized with ``json.dumps()``.
         """
-        if not columns:
+        if not column:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST,
-                detail="Missing required query parameter: columns",
+                detail="Missing required query parameter: column",
             )
 
-        requested = list(
-            dict.fromkeys(c.strip() for c in columns.split(",") if c.strip())
-        )
+        requested = list(dict.fromkeys(c.strip() for c in column if c.strip()))
 
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -15,7 +15,6 @@ from .._recorder.active_scans_store import ActiveScanInfo
 from .._recorder.recorder import Status as RecorderStatus
 from .._recorder.summary import Summary
 from .._scanner.result import Error
-from .._scanner.types import ScannerInput, ScannerInputNames
 from .._scanspec import ScanSpec
 from .._transcript.types import TranscriptInfo
 
@@ -263,19 +262,6 @@ class ScannersResponse:
     """Response body for GET /scanners endpoint."""
 
     items: list[ScannerInfo]
-
-
-class ScannerInputResponse(BaseModel):
-    """Response body for GET /scans/{dir}/{scan}/scanners/{scanner}/input/{uuid}.
-
-    Used only for OpenAPI schema generation — the endpoint returns a
-    pre-serialized JSON string via ``Response`` to avoid parsing/re-encoding
-    the raw parquet payloads.
-    """
-
-    input_type: ScannerInputNames
-    input: ScannerInput
-    input_data: EventsData | None = None
 
 
 class MessagesEventsResponse(BaseModel):

--- a/src/inspect_scout/_view/_server_common.py
+++ b/src/inspect_scout/_view/_server_common.py
@@ -3,7 +3,66 @@ from typing import Any
 
 from fastapi.responses import JSONResponse
 from inspect_ai._util.json import to_json_safe
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue
+from pydantic_core import CoreSchema, core_schema
 from typing_extensions import override
+
+
+class CustomJsonSchemaGenerator(GenerateJsonSchema):
+    """Custom JSON schema generator for response-oriented OpenAPI schemas.
+
+    Customizations:
+    - Required is determined by nullability, not defaults
+      (`str | None` -> optional, `str` -> required even with default)
+    - JsonValue generates a proper recursive schema instead of empty {}
+    """
+
+    def _is_nullable_schema(self, schema: CoreSchema) -> bool:
+        """Check if schema represents a nullable type."""
+        schema_type = schema.get("type")
+        if schema_type == "nullable":
+            return True
+        if schema_type == "default":
+            return self._is_nullable_schema(schema.get("schema", {}))
+        return False
+
+    def field_is_required(
+        self,
+        field: core_schema.ModelField
+        | core_schema.DataclassField
+        | core_schema.TypedDictField,
+        total: bool,
+    ) -> bool:
+        schema = field.get("schema", {})
+        return not self._is_nullable_schema(schema)
+
+    def generate(
+        self, schema: CoreSchema, mode: JsonSchemaMode = "validation"
+    ) -> JsonSchemaValue:
+        result = super().generate(schema, mode)
+        self._fix_json_value_defs(result)
+        return result
+
+    def _fix_json_value_defs(self, schema: dict[str, Any]) -> None:
+        """Replace empty JsonValue definition with proper JSON schema.
+
+        Uses non-recursive definition since openapi-typescript inlines recursive
+        refs, causing TS2502 circular reference errors. Uses additionalProperties: true
+        for object to generate Record<string, unknown> instead of Record<string, never>.
+        """
+        defs = schema.get("$defs", {})
+        if "JsonValue" in defs and defs["JsonValue"] == {}:
+            defs["JsonValue"] = {
+                "oneOf": [
+                    {"type": "null"},
+                    {"type": "boolean"},
+                    {"type": "integer"},
+                    {"type": "number"},
+                    {"type": "string"},
+                    {"type": "array", "items": {}},
+                    {"type": "object", "additionalProperties": {}},
+                ]
+            }
 
 
 def decode_base64url(s: str) -> str:

--- a/src/inspect_scout/_view/dist/assets/index-Bcg34saJ.js
+++ b/src/inspect_scout/_view/dist/assets/index-Bcg34saJ.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3968cf571b12279ea4fbcd4aeb1c817fc80ddf6ae1686433929bac7b3777d1e
-size 3130854

--- a/src/inspect_scout/_view/dist/assets/index-D2-21d5B.js
+++ b/src/inspect_scout/_view/dist/assets/index-D2-21d5B.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:633806ce97d5e57f34922211a538d60ec07d8daba8aacaf863654f2892996134
-size 3131089

--- a/src/inspect_scout/_view/dist/assets/index-D2-21d5B.js
+++ b/src/inspect_scout/_view/dist/assets/index-D2-21d5B.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:633806ce97d5e57f34922211a538d60ec07d8daba8aacaf863654f2892996134
+size 3131089

--- a/src/inspect_scout/_view/dist/assets/index-_ItE8DgV.js
+++ b/src/inspect_scout/_view/dist/assets/index-_ItE8DgV.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62b0a0acb7775f14e18d85be8e11151adb929cdfbbc56f8b958b81fe7c0413b5
+size 3131094

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fa1f7d41d65c2d0dc5d088e57ea64cd42a69f686072f11291498c17a69e3670
+oid sha256:bae6b0151baf39be3fbd20f290c8eed2fc7ddf5db82915020cfc195f1551781e
 size 1129

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3954dc41b72610ed5efaf9b8052288fbfce159703b90100e883e06a5ca57a104
+oid sha256:1fa1f7d41d65c2d0dc5d088e57ea64cd42a69f686072f11291498c17a69e3670
 size 1129

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -7049,7 +7049,7 @@
         "type": "object"
       },
       "ScannerInputResponse": {
-        "description": "Response body for GET /scans/{dir}/{scan}/scanners/{scanner}/input/{uuid}.\n\nUsed only for OpenAPI schema generation \u2014 the endpoint returns a\npre-serialized JSON string via ``Response`` to avoid parsing/re-encoding\nthe raw parquet payloads.",
+        "description": "Schema-only type for scanner input column values.",
         "properties": {
           "input": {
             "anyOf": [
@@ -10910,7 +10910,7 @@
     },
     "/scans/{dir}/{scan}/{scanner}": {
       "get": {
-        "description": "Streams scanner results as Arrow IPC format with LZ4 compression. Excludes input column for efficiency; use the input endpoint for input text.",
+        "description": "Streams scanner results as Arrow IPC format with LZ4 compression. Use exclude_columns to omit heavy columns from the response.",
         "operationId": "scan_df_scans__dir___scan___scanner__get",
         "parameters": [
           {
@@ -10945,6 +10945,24 @@
               "title": "Scanner",
               "type": "string"
             }
+          },
+          {
+            "description": "Comma-separated list of column names to exclude",
+            "in": "query",
+            "name": "exclude_columns",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of column names to exclude",
+              "title": "Exclude Columns"
+            }
           }
         ],
         "responses": {
@@ -10963,10 +10981,10 @@
         ]
       }
     },
-    "/scans/{dir}/{scan}/{scanner}/{uuid}/input": {
+    "/scans/{dir}/{scan}/{scanner}/{uuid}": {
       "get": {
-        "description": "Returns a JSON envelope with input, input_type, and input_data (EventsData pools for condensed events, or null).",
-        "operationId": "scanner_input_scans__dir___scan___scanner___uuid__input_get",
+        "description": "Returns requested columns as a JSON object. Pass a comma-separated list via the `columns` query parameter.",
+        "operationId": "scanner_row_scans__dir___scan___scanner___uuid__get",
         "parameters": [
           {
             "description": "Scans directory (base64url-encoded)",
@@ -11011,21 +11029,37 @@
               "title": "Uuid",
               "type": "string"
             }
+          },
+          {
+            "description": "Comma-separated list of column names to return",
+            "in": "query",
+            "name": "columns",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of column names to return",
+              "title": "Columns"
+            }
           }
         ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScannerInputResponse"
-                }
+                "schema": {}
               }
             },
             "description": "Successful Response"
           }
         },
-        "summary": "Get scanner input for a specific result",
+        "summary": "Get specific columns for a result row",
         "tags": [
           "scans"
         ]
@@ -11083,6 +11117,24 @@
           }
         },
         "summary": " Raw Encoding"
+      }
+    },
+    "/schema/scanner-input": {
+      "get": {
+        "operationId": "_scanner_input_schema_scanner_input_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScannerInputResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": " Scanner Input"
       }
     },
     "/schema/transcript": {

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -10910,7 +10910,7 @@
     },
     "/scans/{dir}/{scan}/{scanner}": {
       "get": {
-        "description": "Streams scanner results as Arrow IPC format with LZ4 compression. Use exclude_columns to omit heavy columns from the response.",
+        "description": "Streams scanner results as Arrow IPC format with LZ4 compression. Use exclude_column to omit heavy columns from the response.",
         "operationId": "scan_df_scans__dir___scan___scanner__get",
         "parameters": [
           {
@@ -10947,21 +10947,18 @@
             }
           },
           {
-            "description": "Comma-separated list of column names to exclude",
+            "description": "Column names to exclude (repeat for multiple)",
             "in": "query",
-            "name": "exclude_columns",
+            "name": "exclude_column",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated list of column names to exclude",
-              "title": "Exclude Columns"
+              "default": [],
+              "description": "Column names to exclude (repeat for multiple)",
+              "items": {
+                "type": "string"
+              },
+              "title": "Exclude Column",
+              "type": "array"
             }
           }
         ],
@@ -10983,7 +10980,7 @@
     },
     "/scans/{dir}/{scan}/{scanner}/{uuid}": {
       "get": {
-        "description": "Returns requested columns as a JSON object. Pass a comma-separated list via the `columns` query parameter.",
+        "description": "Returns requested columns as a JSON object. Repeat the `column` query parameter for each column.",
         "operationId": "scanner_row_scans__dir___scan___scanner___uuid__get",
         "parameters": [
           {
@@ -11031,21 +11028,18 @@
             }
           },
           {
-            "description": "Comma-separated list of column names to return",
+            "description": "Column names to return (repeat for multiple)",
             "in": "query",
-            "name": "columns",
+            "name": "column",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated list of column names to return",
-              "title": "Columns"
+              "default": [],
+              "description": "Column names to return (repeat for multiple)",
+              "items": {
+                "type": "string"
+              },
+              "title": "Column",
+              "type": "array"
             }
           }
         ],

--- a/tests/view/test_custom_json_schema_generator.py
+++ b/tests/view/test_custom_json_schema_generator.py
@@ -1,0 +1,155 @@
+"""Tests for CustomJsonSchemaGenerator.
+
+Verifies:
+1. Field requiredness is determined by nullability, not defaults
+2. JsonValue generates a proper oneOf schema instead of empty {}
+"""
+
+from typing import Any
+
+import pytest
+from inspect_scout._view._server_common import CustomJsonSchemaGenerator
+from pydantic import BaseModel, Field, JsonValue
+
+
+# Test models for requiredness
+class NonNullableNoDefault(BaseModel):
+    field: str
+
+
+class NonNullableWithDefault(BaseModel):
+    field: str = Field(default="value")
+
+
+class NullableNoDefault(BaseModel):
+    field: str | None
+
+
+class NullableWithDefault(BaseModel):
+    field: str | None = Field(default=None)
+
+
+class NullableWithNonNoneDefault(BaseModel):
+    field: str | None = Field(default="value")
+
+
+class NestedNonNullable(BaseModel):
+    nested: NonNullableNoDefault
+
+
+class NestedNullable(BaseModel):
+    nested: NonNullableNoDefault | None = Field(default=None)
+
+
+# Test models for JsonValue
+class WithJsonValue(BaseModel):
+    value: JsonValue
+
+
+class WithNullableJsonValue(BaseModel):
+    value: JsonValue | None = Field(default=None)
+
+
+def get_schema(model: type[BaseModel]) -> dict[str, Any]:
+    """Get JSON schema using CustomJsonSchemaGenerator."""
+    return model.model_json_schema(schema_generator=CustomJsonSchemaGenerator)
+
+
+@pytest.mark.parametrize(
+    ("model", "field_name", "expected_required"),
+    [
+        # Non-nullable fields are always required
+        (NonNullableNoDefault, "field", True),
+        (NonNullableWithDefault, "field", True),
+        # Nullable fields are never required
+        (NullableNoDefault, "field", False),
+        (NullableWithDefault, "field", False),
+        (NullableWithNonNoneDefault, "field", False),
+        # Nested models follow same rules
+        (NestedNonNullable, "nested", True),
+        (NestedNullable, "nested", False),
+    ],
+    ids=[
+        "str_no_default",
+        "str_with_default",
+        "str|None_no_default",
+        "str|None_default_None",
+        "str|None_default_value",
+        "nested_non_nullable",
+        "nested_nullable",
+    ],
+)
+def test_field_requiredness(
+    model: type[BaseModel], field_name: str, expected_required: bool
+) -> None:
+    schema = get_schema(model)
+    required = schema.get("required", [])
+    if expected_required:
+        assert field_name in required
+    else:
+        assert field_name not in required
+
+
+def test_default_pydantic_treats_defaulted_fields_as_optional() -> None:
+    """Document difference: default Pydantic makes fields with defaults optional."""
+    schema = NonNullableWithDefault.model_json_schema()
+    assert "field" not in schema.get("required", [])
+
+    # Our custom generator keeps non-nullable fields required
+    custom_schema = get_schema(NonNullableWithDefault)
+    assert "field" in custom_schema.get("required", [])
+
+
+def test_json_value_generates_proper_schema() -> None:
+    """JsonValue should generate a proper oneOf schema, not empty {}."""
+    schema = get_schema(WithJsonValue)
+    defs = schema.get("$defs", {})
+
+    assert "JsonValue" in defs
+    json_value_schema = defs["JsonValue"]
+
+    # Should not be empty
+    assert json_value_schema != {}
+
+    # Should be a oneOf with all JSON primitive types
+    assert "oneOf" in json_value_schema
+    one_of = json_value_schema["oneOf"]
+
+    types = {item.get("type") for item in one_of if "type" in item}
+    assert types == {
+        "null",
+        "boolean",
+        "integer",
+        "number",
+        "string",
+        "array",
+        "object",
+    }
+
+
+def test_json_value_is_not_recursive() -> None:
+    """JsonValue uses non-recursive schema (openapi-typescript can't handle recursive)."""
+    schema = get_schema(WithJsonValue)
+    json_value_schema = schema["$defs"]["JsonValue"]
+
+    # Array items should be {} (any), not a $ref to JsonValue
+    array_schema = next(
+        s for s in json_value_schema["oneOf"] if s.get("type") == "array"
+    )
+    assert array_schema["items"] == {}
+
+    # Object additionalProperties should be {} (any), not a $ref to JsonValue
+    object_schema = next(
+        s for s in json_value_schema["oneOf"] if s.get("type") == "object"
+    )
+    assert object_schema["additionalProperties"] == {}
+
+
+def test_default_pydantic_json_value_is_empty() -> None:
+    """Document difference: default Pydantic generates empty {} for JsonValue."""
+    schema = WithJsonValue.model_json_schema()
+    assert schema["$defs"]["JsonValue"] == {}
+
+    # Our custom generator provides proper typing
+    custom_schema = get_schema(WithJsonValue)
+    assert custom_schema["$defs"]["JsonValue"] != {}

--- a/tests/view/test_v2_api.py
+++ b/tests/view/test_v2_api.py
@@ -21,14 +21,9 @@ from inspect_scout._view.server import (
     AuthorizationMiddleware,
 )
 from starlette.status import (
+    HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
 )
-
-
-def _base64url(s: str) -> str:
-    """Encode string as base64url (URL-safe base64 without padding)."""
-    return base64.urlsafe_b64encode(s.encode()).decode().rstrip("=")
-
 
 if TYPE_CHECKING:
     from inspect_scout._transcript.types import Transcript
@@ -36,8 +31,6 @@ if TYPE_CHECKING:
 
 def base64url(s: str) -> str:
     """Encode string as base64url (URL-safe base64 without padding)."""
-    import base64
-
     return base64.urlsafe_b64encode(s.encode()).decode().rstrip("=")
 
 
@@ -139,24 +132,30 @@ class TestViewServerAppScansEndpoint:
 class TestViewServerAppScanDfEndpoint:
     """Tests for the /scans/{dir}/{scan}/{scanner} endpoint."""
 
-    @pytest.mark.asyncio
-    async def test_scanner_df_endpoint_success(
-        self, client: TestClient, sample_dataframe: pd.DataFrame
-    ) -> None:
-        """Test successful retrieval of scanner dataframe."""
-        # Create a mock ScanResultsArrow
+    @staticmethod
+    def _mock_arrow_results(
+        df: pd.DataFrame,
+    ) -> MagicMock:
+        """Build a mock ScanResultsArrow with a working reader context manager."""
         mock_results = MagicMock(spec=ScanResultsArrow)
         mock_results.scanners = ["scanner1"]
 
-        # Create mock record batch reader
-        table = pa.Table.from_pandas(sample_dataframe, preserve_index=False)
+        table = pa.Table.from_pandas(df, preserve_index=False)
         mock_reader = MagicMock()
         mock_reader.__enter__ = MagicMock(return_value=mock_reader)
         mock_reader.__exit__ = MagicMock(return_value=None)
         mock_reader.__iter__ = MagicMock(return_value=iter([table.to_batches()[0]]))
         mock_reader.schema = table.schema
-
         mock_results.reader.return_value = mock_reader
+
+        return mock_results
+
+    @pytest.mark.asyncio
+    async def test_scanner_df_endpoint_success(
+        self, client: TestClient, sample_dataframe: pd.DataFrame
+    ) -> None:
+        """Test successful retrieval of scanner dataframe."""
+        mock_results = self._mock_arrow_results(sample_dataframe)
 
         with patch(
             "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
@@ -190,6 +189,46 @@ class TestViewServerAppScanDfEndpoint:
 
         assert response.status_code == HTTP_404_NOT_FOUND
 
+    @pytest.mark.asyncio
+    async def test_scanner_df_passes_exclude_columns(
+        self, client: TestClient, sample_dataframe: pd.DataFrame
+    ) -> None:
+        """exclude_columns query param is forwarded to reader()."""
+        mock_results = self._mock_arrow_results(sample_dataframe)
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1"
+                "?exclude_columns=input,scan_events"
+            )
+
+        assert response.status_code == 200
+        mock_results.reader.assert_called_once()
+        call_kwargs = mock_results.reader.call_args
+        assert call_kwargs.kwargs["exclude_columns"] == ["input", "scan_events"]
+
+    @pytest.mark.asyncio
+    async def test_scanner_df_no_exclude_columns(
+        self, client: TestClient, sample_dataframe: pd.DataFrame
+    ) -> None:
+        """Without exclude_columns, reader is called with empty list."""
+        mock_results = self._mock_arrow_results(sample_dataframe)
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1"
+            )
+
+        assert response.status_code == 200
+        call_kwargs = mock_results.reader.call_args
+        assert call_kwargs.kwargs["exclude_columns"] == []
+
 
 class TestViewServerAppScanEndpoint:
     """Tests for the /scans/{dir}/{scan} endpoint."""
@@ -220,6 +259,137 @@ class TestViewServerAppScanEndpoint:
         data = response.json()
         assert data["complete"] is True
         assert data["location"] == "/test/scan"
+
+
+class TestViewServerAppRowEndpoint:
+    """Tests for the /scans/{dir}/{scan}/{scanner}/{uuid} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_row_returns_requested_columns(self, client: TestClient) -> None:
+        """Happy path: returns requested columns as JSON."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+        mock_results.get_fields.return_value = {
+            "input_type": "human",
+            "input": '["hello"]',
+            "input_data": None,
+            "scan_events": '{"events": []}',
+        }
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
+                "?columns=input_type,input,input_data,scan_events"
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["input_type"] == "human"
+        assert data["input"] == ["hello"]
+        assert data["input_data"] is None
+        assert data["scan_events"] == {"events": []}
+
+    @pytest.mark.asyncio
+    async def test_row_unknown_columns_return_null(self, client: TestClient) -> None:
+        """Unknown column names return null in the response."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+        mock_results.get_fields.return_value = {
+            "nonexistent_col": None,
+        }
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
+                "?columns=nonexistent_col"
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["nonexistent_col"] is None
+
+    @pytest.mark.asyncio
+    async def test_row_rejects_missing_columns_param(self, client: TestClient) -> None:
+        """Returns 400 when columns query param is missing."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
+            )
+
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_row_returns_404_for_unknown_uuid(self, client: TestClient) -> None:
+        """Returns 404 when get_fields raises KeyError (unknown UUID)."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+        mock_results.get_fields.side_effect = KeyError("no row for uuid")
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/nonexistent-uuid"
+                "?columns=input"
+            )
+
+        assert response.status_code == HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_row_returns_404_for_unknown_scanner(
+        self, client: TestClient
+    ) -> None:
+        """Returns 404 when scanner name is not found."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/nonexistent/some-uuid"
+                "?columns=input"
+            )
+
+        assert response.status_code == HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_row_none_value_serialized_as_null(self, client: TestClient) -> None:
+        """None values for any column are returned as JSON null."""
+        mock_results = MagicMock(spec=ScanResultsArrow)
+        mock_results.scanners = ["scanner1"]
+        mock_results.get_fields.return_value = {
+            "input_type": None,
+            "input": None,
+        }
+
+        with patch(
+            "inspect_scout._view._api_v2_scans.scan_results_arrow_async",
+            return_value=mock_results,
+        ):
+            response = client.get(
+                f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
+                "?columns=input_type,input"
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["input_type"] is None
+        assert data["input"] is None
 
 
 class TestAuthorizationMiddleware:
@@ -398,9 +568,7 @@ class TestTranscriptsPagination:
         test_client = TestClient(v2_api_app())
 
         # Make request (empty dir)
-        response = test_client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}", json={}
-        )
+        response = test_client.post(f"/transcripts/{base64url(str(tmp_path))}", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -418,7 +586,7 @@ class TestTranscriptsPagination:
         await _populate_transcripts(tmp_path, transcripts)
 
         client = TestClient(v2_api_app())
-        response = client.post(f"/transcripts/{_base64url(str(tmp_path))}", json={})
+        response = client.post(f"/transcripts/{base64url(str(tmp_path))}", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -434,7 +602,7 @@ class TestTranscriptsPagination:
         client = TestClient(v2_api_app())
         # Filter to gpt-4 only (every other one = 5)
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={"filter": {"left": "model", "operator": "=", "right": "gpt-4"}},
         )
 
@@ -451,7 +619,7 @@ class TestTranscriptsPagination:
 
         client = TestClient(v2_api_app())
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={"pagination": {"limit": 3, "cursor": None, "direction": "forward"}},
         )
 
@@ -469,7 +637,7 @@ class TestTranscriptsPagination:
 
         # Make request without pagination
         client = TestClient(v2_api_app())
-        response = client.post(f"/transcripts/{_base64url(str(tmp_path))}", json={})
+        response = client.post(f"/transcripts/{base64url(str(tmp_path))}", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -486,7 +654,7 @@ class TestTranscriptsPagination:
         # Request first 3 items
         client = TestClient(v2_api_app())
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
             },
@@ -513,7 +681,7 @@ class TestTranscriptsPagination:
 
         # Get first page
         response1 = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
             },
@@ -523,7 +691,7 @@ class TestTranscriptsPagination:
 
         # Get second page using cursor
         response2 = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": cursor, "direction": "forward"},
             },
@@ -548,7 +716,7 @@ class TestTranscriptsPagination:
 
         # Get last 3 items (backward from end)
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": None, "direction": "backward"},
             },
@@ -568,7 +736,7 @@ class TestTranscriptsPagination:
         client = TestClient(v2_api_app())
 
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={"pagination": {"limit": 10, "cursor": None, "direction": "forward"}},
         )
 
@@ -588,7 +756,7 @@ class TestTranscriptsPagination:
 
         # Sort by model ASC, paginate
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "order_by": {"column": "model", "direction": "ASC"},
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
@@ -615,7 +783,7 @@ class TestTranscriptsPagination:
 
         # Sort by model ASC, then score DESC
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "order_by": [
                     {"column": "model", "direction": "ASC"},
@@ -646,7 +814,7 @@ class TestTranscriptsPagination:
 
         # Sort explicitly by transcript_id
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "order_by": {"column": "transcript_id", "direction": "DESC"},
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
@@ -674,7 +842,7 @@ class TestTranscriptsPagination:
 
         # Paginate without order_by
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
             },
@@ -737,7 +905,7 @@ class TestTranscriptsPagination:
 
         # Sort by score (None values treated as empty string)
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "order_by": {"column": "score", "direction": "ASC"},
                 "pagination": {"limit": 2, "cursor": None, "direction": "forward"},
@@ -763,7 +931,7 @@ class TestTranscriptsPagination:
 
         # Get first page of 3
         response1 = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": None, "direction": "forward"},
             },
@@ -773,7 +941,7 @@ class TestTranscriptsPagination:
 
         # Get second (last) page - should have 2 items and no next_cursor
         response2 = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 3, "cursor": cursor, "direction": "forward"},
             },
@@ -797,7 +965,7 @@ class TestTranscriptsPagination:
 
         # Request 100 items when only 5 exist
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {"limit": 100, "cursor": None, "direction": "forward"},
             },
@@ -821,7 +989,7 @@ class TestTranscriptsPagination:
         fake_cursor = {"transcript_id": "t005", "extra_key": "ignored"}
 
         response = client.post(
-            f"/transcripts/{_base64url(str(tmp_path))}",
+            f"/transcripts/{base64url(str(tmp_path))}",
             json={
                 "pagination": {
                     "limit": 3,

--- a/tests/view/test_v2_api.py
+++ b/tests/view/test_v2_api.py
@@ -190,10 +190,10 @@ class TestViewServerAppScanDfEndpoint:
         assert response.status_code == HTTP_404_NOT_FOUND
 
     @pytest.mark.asyncio
-    async def test_scanner_df_passes_exclude_columns(
+    async def test_scanner_df_passes_exclude_column(
         self, client: TestClient, sample_dataframe: pd.DataFrame
     ) -> None:
-        """exclude_columns query param is forwarded to reader()."""
+        """exclude_column query params are forwarded to reader()."""
         mock_results = self._mock_arrow_results(sample_dataframe)
 
         with patch(
@@ -202,7 +202,7 @@ class TestViewServerAppScanDfEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1"
-                "?exclude_columns=input,scan_events"
+                "?exclude_column=input&exclude_column=scan_events"
             )
 
         assert response.status_code == 200
@@ -211,10 +211,10 @@ class TestViewServerAppScanDfEndpoint:
         assert call_kwargs.kwargs["exclude_columns"] == ["input", "scan_events"]
 
     @pytest.mark.asyncio
-    async def test_scanner_df_no_exclude_columns(
+    async def test_scanner_df_no_exclude_column(
         self, client: TestClient, sample_dataframe: pd.DataFrame
     ) -> None:
-        """Without exclude_columns, reader is called with empty list."""
+        """Without exclude_column, reader is called with empty list."""
         mock_results = self._mock_arrow_results(sample_dataframe)
 
         with patch(
@@ -282,7 +282,7 @@ class TestViewServerAppRowEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
-                "?columns=input_type,input,input_data,scan_events"
+                "?column=input_type&column=input&column=input_data&column=scan_events"
             )
 
         assert response.status_code == 200
@@ -307,7 +307,7 @@ class TestViewServerAppRowEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
-                "?columns=nonexistent_col"
+                "?column=nonexistent_col"
             )
 
         assert response.status_code == 200
@@ -315,8 +315,8 @@ class TestViewServerAppRowEndpoint:
         assert data["nonexistent_col"] is None
 
     @pytest.mark.asyncio
-    async def test_row_rejects_missing_columns_param(self, client: TestClient) -> None:
-        """Returns 400 when columns query param is missing."""
+    async def test_row_rejects_missing_column_param(self, client: TestClient) -> None:
+        """Returns 400 when column query param is missing."""
         mock_results = MagicMock(spec=ScanResultsArrow)
         mock_results.scanners = ["scanner1"]
 
@@ -343,7 +343,7 @@ class TestViewServerAppRowEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/nonexistent-uuid"
-                "?columns=input"
+                "?column=input"
             )
 
         assert response.status_code == HTTP_404_NOT_FOUND
@@ -362,7 +362,7 @@ class TestViewServerAppRowEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/nonexistent/some-uuid"
-                "?columns=input"
+                "?column=input"
             )
 
         assert response.status_code == HTTP_404_NOT_FOUND
@@ -383,7 +383,7 @@ class TestViewServerAppRowEndpoint:
         ):
             response = client.get(
                 f"/scans/{base64url('/tmp')}/{base64url('test_scan')}/scanner1/some-uuid"
-                "?columns=input_type,input"
+                "?column=input_type&column=input"
             )
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

Large scan files in S3 can be very slow to load. #79 improved this greatly by lazy-loading the `input` field, but the `scan_events` field can also be huge.

This PR generalizes the lazy-loading of the `input` field, and adds a `/fields` endpoint for lazy loading multiple fields. The `/input` endpoint gets deprecated.

It also replaces the full-file-download with using PyArrow S3FileSystem (and GcsFileSystem), which supports much more efficient retrieval using range requests.

Companion PR: https://github.com/meridianlabs-ai/ts-mono/pull/13

## Changes

- `file.py`: Added `_resolve_parquet_source()`, `_point_lookup()`. Updated `reader()` to use `pre_buffer=True` for remote files. Updated `get_fields()` to do inline row-group scanning with a single `ParquetFile` open.
- `_api_v2_scans.py`: New `/fields` endpoint with allowlist validation. Deprecated old `/input` endpoint. Excluded `scan_events` from bulk streaming.
- `test_v2_api.py`: Tests for the new `/fields` endpoint (happy path, validation, error cases).
- Frontend submodule + dist updated with `/fields` endpoint integration.

## Test plan

- [X] Manual tested on our staging environment. Large scans that previously loaded in 2-3 minutes now loads in ~10 seconds.