### PR TITLE
FastAPI endpoint async/sync conventions and fixes

### DIFF
--- a/design/fastapi-async.md
+++ b/design/fastapi-async.md
@@ -1,0 +1,40 @@
+# FastAPI Endpoint Async Convention
+
+## Rules
+
+1. **`async def`** — endpoint awaits something. Runs on the event loop.
+2. **`def`** — endpoint does sync blocking I/O (file reads, subprocess, etc.) and never awaits. FastAPI auto-runs it in a threadpool, keeping the event loop free.
+3. **`async def` + `anyio.to_thread.run_sync`** — endpoint must await *and* do sync blocking I/O. The sync blocker is manually offloaded.
+4. **`async def` with no awaits and no blocking** — fine as-is. Trivially fast, no reason to pay threadpool overhead.
+
+## Why this matters
+
+`async def` endpoints run directly on the asyncio event loop thread. A sync blocking call inside one blocks the *entire* loop — no other request can be served until it returns. FastAPI's auto-threadpool for `def` endpoints exists specifically to handle this.
+
+## Decision tree
+
+```
+Does the endpoint await anything?
+├─ No
+│   ├─ Does sync blocking I/O? → def (auto-threadpooled)
+│   └─ No blocking?            → async def (fine, trivially fast)
+└─ Yes
+    ├─ Also does sync blocking I/O? → async def + to_thread on blockers
+    └─ No blocking?                  → async def (correct)
+```
+
+## What counts as sync blocking
+
+- File/directory I/O (`open`, `read`, `exists`, `rename`, `iterdir`)
+- `subprocess.Popen`, `send2trash`
+- Sync database or KV store access
+- Heavy CPU work or module introspection
+
+## What does NOT count
+
+- Returning a value, dict copy, pure computation
+- Checking an in-memory variable
+
+## When in doubt
+
+If an endpoint has no awaits and you're unsure whether it blocks, use `def`. The threadpool overhead is negligible, and it's always safe — a non-blocking function runs fine in a thread. The only thing to avoid is paying threadpool cost for something you *know* is trivial.

--- a/src/inspect_scout/_view/_api_v2_config.py
+++ b/src/inspect_scout/_view/_api_v2_config.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path as PathlibPath
 
+import anyio
 from fastapi import APIRouter, Header, HTTPException, Request, Response
 from inspect_ai._util.error import PrerequisiteError
 from starlette.status import (
@@ -48,7 +49,7 @@ def create_config_router(
         summary="Get application configuration",
         description="Returns app config including transcripts and scans directories.",
     )
-    async def config(request: Request) -> AppConfig:
+    def config(request: Request) -> AppConfig:
         """Return application configuration."""
         EvalLogTranscriptsView.clear_cache()
         project = read_project()
@@ -78,7 +79,7 @@ def create_config_router(
         description="Returns the project configuration from scout.yaml. "
         "The ETag header contains a hash of the file for conditional updates.",
     )
-    async def get_project_config() -> Response:
+    def get_project_config() -> Response:
         """Return project configuration with ETag header."""
         config, etag = read_project_config_with_etag()
 
@@ -108,7 +109,9 @@ def create_config_router(
         expected_etag = if_match.strip('"') if if_match else None
 
         try:
-            updated_config, new_etag = write_project_config(config, expected_etag)
+            updated_config, new_etag = await anyio.to_thread.run_sync(
+                lambda: write_project_config(config, expected_etag)
+            )
         except FileNotFoundError:
             raise HTTPException(
                 status_code=HTTP_404_NOT_FOUND,

--- a/src/inspect_scout/_view/_api_v2_dist.py
+++ b/src/inspect_scout/_view/_api_v2_dist.py
@@ -33,7 +33,7 @@ def create_dist_router(dist_path: Path | None = None) -> APIRouter:
                 detail=(
                     "Unable to resolve dist directory path. This should not happen once the server has started."
                 ),
-            ) from None
+            )
 
         return DistResponse(path=dist_path.as_posix())
 

--- a/src/inspect_scout/_view/_api_v2_scanners.py
+++ b/src/inspect_scout/_view/_api_v2_scanners.py
@@ -28,7 +28,7 @@ def create_scanners_router() -> APIRouter:
         summary="List available scanners",
         description="Returns info about all registered scanners.",
     )
-    async def scanners() -> ScannersResponse:
+    def scanners() -> ScannersResponse:
         """Return info about all registered scanner factories."""
 
         def param_schema(p: inspect.Parameter) -> dict[str, Any]:

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -20,6 +20,7 @@ from fastapi.responses import StreamingResponse
 from inspect_ai._util.file import file
 from send2trash import send2trash
 from starlette.status import (
+    HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
     HTTP_409_CONFLICT,
     HTTP_500_INTERNAL_SERVER_ERROR,
@@ -382,6 +383,12 @@ def create_scans_router(
         scan_path = UPath(scans_dir) / decode_base64url(scan)
 
         def _delete_scan_sync() -> None:
+            if scan_path.protocol != "file" and scan_path.protocol != "":
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail="Delete is only supported for local scans",
+                )
+
             # Check if scan exists
             if not scan_path.exists():
                 raise HTTPException(

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -159,7 +159,7 @@ def create_scans_router(
         summary="Get active scans",
         description="Returns info on all currently running scans.",
     )
-    async def active_scans() -> ActiveScansResponse:
+    def active_scans() -> ActiveScansResponse:
         """Get info on all active scans from the KV store."""
         with active_scans_store() as store:
             return ActiveScansResponse(items=store.read_all())
@@ -173,7 +173,9 @@ def create_scans_router(
     )
     async def run_llm_scanner(body: ScanJobConfig) -> ScanStatus:
         """Run an llm_scanner scan via subprocess."""
-        proc, temp_path, _stdout_lines, stderr_lines = _spawn_scan_subprocess(body)
+        proc, temp_path, _stdout_lines, stderr_lines = await anyio.to_thread.run_sync(
+            lambda: _spawn_scan_subprocess(body)
+        )
         pid = proc.pid
 
         active_info = await _wait_for_active_scan(pid)
@@ -338,8 +340,10 @@ def create_scans_router(
                 detail=f"Scanner '{scanner}' not found in scan results",
             )
 
-        fields = result.get_fields(
-            scanner, "uuid", uuid, ["input", "input_type", "input_data"]
+        fields = await anyio.to_thread.run_sync(
+            lambda: result.get_fields(
+                scanner, "uuid", uuid, ["input", "input_type", "input_data"]
+            )
         )
 
         # `input` and `input_data` are pre-serialized JSON strings in the parquet
@@ -377,25 +381,28 @@ def create_scans_router(
         scans_dir = decode_base64url(dir)
         scan_path = UPath(scans_dir) / decode_base64url(scan)
 
-        # Check if scan exists
-        if not scan_path.exists():
-            raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
-                detail="Scan not found",
-            )
+        def _delete_scan_sync() -> None:
+            # Check if scan exists
+            if not scan_path.exists():
+                raise HTTPException(
+                    status_code=HTTP_404_NOT_FOUND,
+                    detail="Scan not found",
+                )
 
-        # Check if scan is active (prevent deletion of running scans)
-        scan_location_str = str(scan_path)
-        with active_scans_store() as store:
-            active_scans = store.read_all()
-            for active_info in active_scans.values():
-                if active_info.location == scan_location_str:
-                    raise HTTPException(
-                        status_code=HTTP_409_CONFLICT,
-                        detail=f"Cannot delete active scan: {active_info.scan_id}",
-                    )
+            # Check if scan is active (prevent deletion of running scans)
+            scan_location_str = str(scan_path)
+            with active_scans_store() as store:
+                active_scans = store.read_all()
+                for active_info in active_scans.values():
+                    if active_info.location == scan_location_str:
+                        raise HTTPException(
+                            status_code=HTTP_409_CONFLICT,
+                            detail=f"Cannot delete active scan: {active_info.scan_id}",
+                        )
 
-        send2trash(scan_path.path)
+            send2trash(scan_path.path)
+
+        await anyio.to_thread.run_sync(_delete_scan_sync)
 
         # Notify clients to invalidate scan caches
         await notify_topics(["scans"])

--- a/src/inspect_scout/_view/_api_v2_validations.py
+++ b/src/inspect_scout/_view/_api_v2_validations.py
@@ -48,7 +48,7 @@ def create_validation_router(
         description="Scans the project directory for validation files (.csv, .yaml, .json, .jsonl) "
         "and returns their URIs.",
     )
-    async def list_validations() -> list[str]:
+    def list_validations() -> list[str]:
         """List all validation files in the project."""
         paths: list[str] = []
 
@@ -69,7 +69,7 @@ def create_validation_router(
         description="Creates a new validation file at the specified path with optional initial cases. "
         "Returns the URI of the created file.",
     )
-    async def create_validation(body: CreateValidationSetRequest) -> str:
+    def create_validation(body: CreateValidationSetRequest) -> str:
         """Create a new validation file."""
         # Convert URI to path
         file_path = _uri_to_path(body.path)
@@ -114,7 +114,7 @@ def create_validation_router(
         summary="Get validation cases",
         description="Returns all cases from a validation file.",
     )
-    async def get_validation_cases(
+    def get_validation_cases(
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
     ) -> list[dict[str, Any]]:
         """Get all cases from a validation file."""
@@ -141,7 +141,7 @@ def create_validation_router(
         summary="Delete a validation file",
         description="Deletes a validation file from the project.",
     )
-    async def delete_validation(
+    def delete_validation(
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
     ) -> None:
         """Delete a validation file."""
@@ -165,7 +165,7 @@ def create_validation_router(
         summary="Rename a validation file",
         description="Renames a validation file. Returns the new URI.",
     )
-    async def rename_validation(
+    def rename_validation(
         body: RenameValidationSetRequest,
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
     ) -> str:
@@ -227,7 +227,7 @@ def create_validation_router(
         summary="Get a specific case",
         description="Returns a specific case from a validation file by ID.",
     )
-    async def get_validation_case(
+    def get_validation_case(
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
         case_id: str = PathParam(description="Case ID (base64url-encoded)"),
     ) -> dict[str, Any]:
@@ -264,7 +264,7 @@ def create_validation_router(
         description="Creates or updates a case in a validation file. If the case ID exists, "
         "it will be updated; otherwise, a new case will be created.",
     )
-    async def upsert_validation_case(
+    def upsert_validation_case(
         body: ValidationCaseRequest,
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
         case_id: str = PathParam(description="Case ID (base64url-encoded)"),
@@ -307,7 +307,7 @@ def create_validation_router(
         summary="Delete a case",
         description="Deletes a case from a validation file.",
     )
-    async def delete_validation_case(
+    def delete_validation_case(
         uri: str = PathParam(description="Validation file URI (base64url-encoded)"),
         case_id: str = PathParam(description="Case ID (base64url-encoded)"),
     ) -> None:


### PR DESCRIPTION
## Summary
- 12 endpoints: `async def` → `def` (sync blocking, no awaits — let FastAPI auto-threadpool)
- 4 endpoints: wrap sync blockers in `anyio.to_thread.run_sync` (mixed async+sync)
- Guard `DELETE /scans/{dir}/{scan}` against remote paths (`send2trash` is local-only)
- Remove spurious `from None` in dist endpoint
- Add `design/fastapi-async.md` documenting the decision tree