### PR TITLE
fix: normalize transcript_score during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: resolve transcript_score types to string when resuming scans.
+
 ## 0.4.26 (15 April 2026)
 
 - Utilities: Export `message_as_str` function.

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -307,15 +307,15 @@ def scanner_table(buffer_dir: UPath, scanner: str) -> bytes | None:
 
     # Correct schema to handle type inconsistencies across files:
     # 1. Promote null-type columns to string (unknown type)
-    # 2. Force 'value' column to string since it can have mixed types (bool, int, float, str)
-    #    across different result reports
+    # 2. Force 'value' and 'transcript_score' columns to string since they can have
+    #    mixed types across different result reports / transcripts
     corrected_fields = []
     for field in schema:
         if pa.types.is_null(field.type):
             # Promote null type to string
             corrected_fields.append(pa.field(field.name, pa.string(), nullable=True))
-        elif field.name == "value":
-            # Force value column to string to handle mixed types
+        elif field.name in {"value", "transcript_score"}:
+            # Force mixed-type columns to string
             corrected_fields.append(pa.field(field.name, pa.string(), nullable=True))
         else:
             corrected_fields.append(field)

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import io
 import tempfile
 from pathlib import Path
 from typing import Generator
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from inspect_ai.model import ChatMessageUser
 from inspect_scout._recorder.buffer import RecorderBuffer, scanner_table
@@ -145,6 +148,44 @@ async def test_sanitize_table_names(
 
     # Should still be able to retrieve
     scanner_table(recorder_buffer._buffer_dir, scanner_name)
+
+
+@pytest.mark.asyncio
+async def test_scanner_table_casts_mixed_transcript_score_to_string(
+    recorder_buffer: RecorderBuffer,
+    sample_results: list[ResultReport],
+) -> None:
+    scanner_name = "test_scanner"
+    await recorder_buffer.record(
+        TranscriptInfo(
+            transcript_id="score-int",
+            source_type="test",
+            source_id="source-1",
+            source_uri="/path/to/source-1.log",
+            score=1,
+        ),
+        scanner_name,
+        sample_results,
+        None,
+    )
+    await recorder_buffer.record(
+        TranscriptInfo(
+            transcript_id="score-json",
+            source_type="test",
+            source_id="source-2",
+            source_uri="/path/to/source-2.log",
+            score={"value": 0, "answer": "nope", "history": []},
+        ),
+        scanner_name,
+        sample_results,
+        None,
+    )
+
+    parquet_bytes = scanner_table(recorder_buffer._buffer_dir, scanner_name)
+    assert parquet_bytes is not None
+
+    table = pq.read_table(io.BytesIO(parquet_bytes))
+    assert table.schema.field("transcript_score").type == pa.string()
 
 
 def test_buffer_dir_respects_env_var(


### PR DESCRIPTION
## Summary
Fix `scan resume` crashes when buffered transcript metadata contains mixed `transcript_score` types across transcripts.

## Root Cause
`inspect_scout._recorder.buffer.scanner_table()` already forces the scanner output `value` column to `string` during parquet compaction because that column can legitimately contain mixed scalar types across result reports.

The same issue can happen for `transcript_score`:
- `TranscriptInfo.score` is typed as arbitrary JSON in `inspect_scout`
- some transcripts store `score` as a scalar such as `0` or `1`
- other transcripts store `score` as a structured JSON object

When a scan buffer contains both forms, Arrow may infer `transcript_score` as `int64` from earlier fragments. During `scan resume`, compaction then fails when later fragments contain JSON-stringified object scores, with errors like:

```text
Failed to cast batch to schema: Failed to parse string: '{"value":0,...}' as a scalar of type int64
```

## Fix
Treat `transcript_score` the same way `value` is already treated in `scanner_table()`:
- force the unified schema for `transcript_score` to `string` during compaction
- update the surrounding comment to document that both columns can legitimately have mixed types

This is a minimal fix that doesn't change scan semantics or scanner outputs.

We added a regression test to `tests/scanner/test_recorder_buffer.py` which should have minimal runtime impact.