### PR TITLE
Bump to latest mono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 - Bugfix: resolve transcript_score types to string when resuming scans.
+- Scout View: Fix error when attempting to collapse all or expand all events in transcripts.
+- Scout View: Improvements to expand / collapse behavior in transcripts.
+- Scout View: Don't show empty entries in messages view when a message is retried.
 
 ## 0.4.26 (15 April 2026)
 

--- a/src/inspect_scout/_view/dist/assets/index-BQFTC6uj.js
+++ b/src/inspect_scout/_view/dist/assets/index-BQFTC6uj.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc9a439eb1b81945ac72455097c7988aea1ab6490f19f1b23e8ff6b2c139be7a
+size 3137621

--- a/src/inspect_scout/_view/dist/assets/index-BvXTL0gG.css
+++ b/src/inspect_scout/_view/dist/assets/index-BvXTL0gG.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6cbdd2dc93d479449e600fef35c3ab958db96f1ba0c300455cf7088baaa6734
-size 888994

--- a/src/inspect_scout/_view/dist/assets/index-Cccx2dKG.css
+++ b/src/inspect_scout/_view/dist/assets/index-Cccx2dKG.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39ae5a7e10419b21e521aa87e621d00e6a1932cf8a7faa85ee1d0d3b728b724d
+size 891656

--- a/src/inspect_scout/_view/dist/assets/index-_ItE8DgV.js
+++ b/src/inspect_scout/_view/dist/assets/index-_ItE8DgV.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62b0a0acb7775f14e18d85be8e11151adb929cdfbbc56f8b958b81fe7c0413b5
-size 3131094

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bae6b0151baf39be3fbd20f290c8eed2fc7ddf5db82915020cfc195f1551781e
+oid sha256:67b7270059b9b69b8d94d2c228dba37073b5b50d6b6b83af05f8b9e28c670cbe
 size 1129


### PR DESCRIPTION
- Scout View: Fix error when attempting to collapse all or expand all events in transcripts.
- Scout View: Improvements to expand / collapse behavior in transcripts.
- Scout View: Don't show empty entries in messages view when a message is retried.