### PR TITLE
Simplify `as_metadata` data about scanners as scorers

### DIFF
--- a/src/inspect_scout/_scanner/scorer.py
+++ b/src/inspect_scout/_scanner/scorer.py
@@ -124,13 +124,8 @@ def _metadata_from_result(result: Result) -> dict[str, Any] | None:
     # base metadata
     metadata = result.metadata or {}
 
-    # Add sentinal scanner value
-    metadata["scanner_content"] = True
-
-    # convert references to metadata
-    all_references = result.references
-    if all_references:
-        metadata["scanner_references"] = all_references
+    # add references to metadata
+    metadata["scanner_references"] = result.references
 
     # return metadata
     return metadata

--- a/src/inspect_scout/_scanner/scorer.py
+++ b/src/inspect_scout/_scanner/scorer.py
@@ -120,37 +120,20 @@ def as_scorer(
 
 
 def _metadata_from_result(result: Result) -> dict[str, Any] | None:
-    """Build the Score metadata dict from a Result.
+    """Build the Score metadata dict from a Result."""
+    # base metadata
+    metadata = result.metadata or {}
 
-    Reference entries are emitted as ``[{"id": ..., "cite": ...}, ...]``
-    so downstream consumers can map cite tokens (e.g. ``[M22]``) in the
-    explanation/metadata text back to message/event ids. References whose
-    ``cite`` is ``None`` are skipped (they couldn't be linked anyway).
-    """
+    # Add sentinal scanner value
+    metadata["scanner_content"] = True
 
-    def references_for_type(type: str) -> list[dict[str, str | None]]:
-        return [
-            ref.model_dump()
-            for ref in result.references
-            if ref.type == type and ref.cite is not None
-        ]
+    # convert references to metadata
+    all_references = result.references
+    if all_references:
+        metadata["scanner_references"] = all_references
 
-    if result.metadata or result.references:
-        # base metadata
-        metadata = result.metadata or {}
-
-        # convert references to metadata
-        msg_references = references_for_type("message")
-        if msg_references:
-            metadata["message_references"] = msg_references
-        evt_references = references_for_type("event")
-        if evt_references:
-            metadata["event_references"] = evt_references
-
-        # return metadata
-        return metadata
-    else:
-        return None
+    # return metadata
+    return metadata
 
 
 def _scanner_content(

--- a/src/inspect_scout/_scanner/scorer.py
+++ b/src/inspect_scout/_scanner/scorer.py
@@ -120,9 +120,20 @@ def as_scorer(
 
 
 def _metadata_from_result(result: Result) -> dict[str, Any] | None:
-    # references
-    def references_for_type(type: str) -> list[str]:
-        return [ref.id for ref in result.references if ref.type == type]
+    """Build the Score metadata dict from a Result.
+
+    Reference entries are emitted as ``[{"id": ..., "cite": ...}, ...]``
+    so downstream consumers can map cite tokens (e.g. ``[M22]``) in the
+    explanation/metadata text back to message/event ids. References whose
+    ``cite`` is ``None`` are skipped (they couldn't be linked anyway).
+    """
+
+    def references_for_type(type: str) -> list[dict[str, str | None]]:
+        return [
+            ref.model_dump()
+            for ref in result.references
+            if ref.type == type and ref.cite is not None
+        ]
 
     if result.metadata or result.references:
         # base metadata

--- a/tests/scanner/test_as_scorer.py
+++ b/tests/scanner/test_as_scorer.py
@@ -647,57 +647,47 @@ def test_user_assistant_filter_full_pipeline() -> None:
         assert score.metadata.get("other", 0) == 0
 
 
-# Tests for _metadata_from_result reference shape
+# Tests for _metadata_from_result
 
 
-def test_metadata_from_result_filters_message_refs_without_cite() -> None:
-    """Message references without a cite are dropped; cited ones become {id, cite}."""
-    result = Result(
-        value=True,
-        references=[
-            Reference(type="message", id="msg-A", cite="[M1]"),
-            Reference(type="message", id="msg-B", cite=None),
-        ],
-    )
-    metadata = _metadata_from_result(result)
-    assert metadata is not None
-    assert metadata["message_references"] == [
-        {"type": "message", "id": "msg-A", "cite": "[M1]"}
-    ]
-    assert "event_references" not in metadata
-
-
-def test_metadata_from_result_mixed_message_and_event_refs() -> None:
-    """Both message and event references are emitted under their respective keys."""
-    result = Result(
-        value=True,
-        references=[
-            Reference(type="message", id="msg-A", cite="[M1]"),
-            Reference(type="message", id="msg-B", cite="[M2]"),
-            Reference(type="event", id="evt-X", cite="[E1]"),
-        ],
-    )
-    metadata = _metadata_from_result(result)
-    assert metadata is not None
-    assert metadata["message_references"] == [
-        {"type": "message", "id": "msg-A", "cite": "[M1]"},
-        {"type": "message", "id": "msg-B", "cite": "[M2]"},
-    ]
-    assert metadata["event_references"] == [
-        {"type": "event", "id": "evt-X", "cite": "[E1]"}
-    ]
-
-
-def test_metadata_from_result_no_metadata_no_refs_returns_none() -> None:
-    """A Result with neither metadata nor references yields None."""
+def test_metadata_from_result_includes_scanner_content_sentinel() -> None:
+    """Metadata always includes the scanner_content sentinel."""
     result = Result(value=True)
-    assert _metadata_from_result(result) is None
-
-
-def test_metadata_from_result_metadata_only_passes_through() -> None:
-    """Metadata without references is returned unchanged (no reference keys added)."""
-    result = Result(value=True, metadata={"foo": "bar", "n": 42})
     metadata = _metadata_from_result(result)
-    assert metadata == {"foo": "bar", "n": 42}
-    assert "message_references" not in metadata
-    assert "event_references" not in metadata
+    assert metadata is not None
+    assert metadata["scanner_content"] is True
+
+
+def test_metadata_from_result_passes_through_references() -> None:
+    """References are stored as Reference objects under scanner_references."""
+    refs = [
+        Reference(type="message", id="msg-A", cite="[M1]"),
+        Reference(type="event", id="evt-X", cite="[E1]"),
+    ]
+    result = Result(value=True, references=refs)
+    metadata = _metadata_from_result(result)
+    assert metadata is not None
+    assert metadata["scanner_references"] == refs
+
+
+def test_metadata_from_result_no_refs_omits_key() -> None:
+    """When there are no references, scanner_references is not present."""
+    result = Result(value=True)
+    metadata = _metadata_from_result(result)
+    assert metadata is not None
+    assert "scanner_references" not in metadata
+
+
+def test_metadata_from_result_preserves_existing_metadata() -> None:
+    """Existing metadata is preserved alongside scanner keys."""
+    result = Result(
+        value=True,
+        metadata={"foo": "bar", "n": 42},
+        references=[Reference(type="message", id="msg-A", cite="[M1]")],
+    )
+    metadata = _metadata_from_result(result)
+    assert metadata is not None
+    assert metadata["foo"] == "bar"
+    assert metadata["n"] == 42
+    assert metadata["scanner_content"] is True
+    assert len(metadata["scanner_references"]) == 1

--- a/tests/scanner/test_as_scorer.py
+++ b/tests/scanner/test_as_scorer.py
@@ -20,9 +20,13 @@ from inspect_ai.model import (
     ModelOutput,
 )
 from inspect_ai.scorer import mean
-from inspect_scout._scanner.result import Result
+from inspect_scout._scanner.result import Reference, Result
 from inspect_scout._scanner.scanner import Scanner, ScannerConfig, scanner
-from inspect_scout._scanner.scorer import _scanner_content, as_scorer
+from inspect_scout._scanner.scorer import (
+    _metadata_from_result,
+    _scanner_content,
+    as_scorer,
+)
 from inspect_scout._transcript.types import Transcript, TranscriptContent
 
 
@@ -641,3 +645,59 @@ def test_user_assistant_filter_full_pipeline() -> None:
     # Check metadata confirms no 'other' roles
     if score.metadata:
         assert score.metadata.get("other", 0) == 0
+
+
+# Tests for _metadata_from_result reference shape
+
+
+def test_metadata_from_result_filters_message_refs_without_cite() -> None:
+    """Message references without a cite are dropped; cited ones become {id, cite}."""
+    result = Result(
+        value=True,
+        references=[
+            Reference(type="message", id="msg-A", cite="[M1]"),
+            Reference(type="message", id="msg-B", cite=None),
+        ],
+    )
+    metadata = _metadata_from_result(result)
+    assert metadata is not None
+    assert metadata["message_references"] == [
+        {"type": "message", "id": "msg-A", "cite": "[M1]"}
+    ]
+    assert "event_references" not in metadata
+
+
+def test_metadata_from_result_mixed_message_and_event_refs() -> None:
+    """Both message and event references are emitted under their respective keys."""
+    result = Result(
+        value=True,
+        references=[
+            Reference(type="message", id="msg-A", cite="[M1]"),
+            Reference(type="message", id="msg-B", cite="[M2]"),
+            Reference(type="event", id="evt-X", cite="[E1]"),
+        ],
+    )
+    metadata = _metadata_from_result(result)
+    assert metadata is not None
+    assert metadata["message_references"] == [
+        {"type": "message", "id": "msg-A", "cite": "[M1]"},
+        {"type": "message", "id": "msg-B", "cite": "[M2]"},
+    ]
+    assert metadata["event_references"] == [
+        {"type": "event", "id": "evt-X", "cite": "[E1]"}
+    ]
+
+
+def test_metadata_from_result_no_metadata_no_refs_returns_none() -> None:
+    """A Result with neither metadata nor references yields None."""
+    result = Result(value=True)
+    assert _metadata_from_result(result) is None
+
+
+def test_metadata_from_result_metadata_only_passes_through() -> None:
+    """Metadata without references is returned unchanged (no reference keys added)."""
+    result = Result(value=True, metadata={"foo": "bar", "n": 42})
+    metadata = _metadata_from_result(result)
+    assert metadata == {"foo": "bar", "n": 42}
+    assert "message_references" not in metadata
+    assert "event_references" not in metadata

--- a/tests/scanner/test_as_scorer.py
+++ b/tests/scanner/test_as_scorer.py
@@ -650,12 +650,12 @@ def test_user_assistant_filter_full_pipeline() -> None:
 # Tests for _metadata_from_result
 
 
-def test_metadata_from_result_includes_scanner_content_sentinel() -> None:
-    """Metadata always includes the scanner_content sentinel."""
+def test_metadata_from_result_always_includes_scanner_references() -> None:
+    """scanner_references is always present, even as an empty list when no refs."""
     result = Result(value=True)
     metadata = _metadata_from_result(result)
     assert metadata is not None
-    assert metadata["scanner_content"] is True
+    assert metadata["scanner_references"] == []
 
 
 def test_metadata_from_result_passes_through_references() -> None:
@@ -670,12 +670,13 @@ def test_metadata_from_result_passes_through_references() -> None:
     assert metadata["scanner_references"] == refs
 
 
-def test_metadata_from_result_no_refs_omits_key() -> None:
-    """When there are no references, scanner_references is not present."""
+def test_metadata_from_result_no_refs_includes_empty_list() -> None:
+    """When there are no references, scanner_references is present as an empty list."""
     result = Result(value=True)
     metadata = _metadata_from_result(result)
     assert metadata is not None
-    assert "scanner_references" not in metadata
+    assert "scanner_references" in metadata
+    assert metadata["scanner_references"] == []
 
 
 def test_metadata_from_result_preserves_existing_metadata() -> None:
@@ -689,5 +690,4 @@ def test_metadata_from_result_preserves_existing_metadata() -> None:
     assert metadata is not None
     assert metadata["foo"] == "bar"
     assert metadata["n"] == 42
-    assert metadata["scanner_content"] is True
     assert len(metadata["scanner_references"]) == 1


### PR DESCRIPTION
These changes will trigger the Inspect Viewer to display a scan specific sidebar alongside transcripts.