### PR TITLE
Redesign transcript search API

### DIFF
--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -168,9 +168,12 @@ def create_search_router() -> APIRouter:
                     status_code=502,
                     detail=str(err),
                 ) from err
-        results = output if isinstance(output, list) else [output]
 
-        # Persist
+        if isinstance(output, list):
+            raise RuntimeError(
+                "Single-transcript search returned multiple results unexpectedly"
+            )
+
         created_at = datetime.now(timezone.utc).isoformat()
         if isinstance(request, GrepSearchRequest):
             saved: SavedSearch = GrepSavedSearch(
@@ -179,7 +182,7 @@ def create_search_router() -> APIRouter:
                 regex=request.regex,
                 ignore_case=request.ignore_case,
                 word_boundary=request.word_boundary,
-                results=results,
+                result=output,
                 created_at=created_at,
             )
         else:
@@ -187,9 +190,10 @@ def create_search_router() -> APIRouter:
                 search_id=sid,
                 query=request.query,
                 model=request.model,
-                results=results,
+                result=output,
                 created_at=created_at,
             )
+
         with _search_store() as store:
             store.put(key, saved.model_dump_json())
 

--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -15,16 +15,14 @@ from .._grep_scanner._grep_scanner import grep_scanner
 from .._llm_scanner import ResultReducer
 from .._llm_scanner._llm_scanner import llm_scanner
 from .._query import Column, Query
+from .._scanner.result import Result
 from .._transcript.database.factory import transcripts_view
 from .._transcript.types import TranscriptContent
 from .._util.appdirs import scout_data_dir
 from ._api_v2_types import (
-    GrepSavedSearchResult,
     GrepSearchInput,
     GrepSearchRequest,
-    LlmSavedSearchResult,
     LlmSearchInput,
-    SavedSearchResult,
     SearchInput,
     SearchInputListResponse,
     SearchRequest,
@@ -53,9 +51,7 @@ If nothing in the transcript matches the query, say so briefly.
 """
 
 MAX_ENTRIES = 500
-SAVED_SEARCH_RESULT_ADAPTER: TypeAdapter[SavedSearchResult] = TypeAdapter(
-    SavedSearchResult
-)
+SEARCH_RESULT_ADAPTER: TypeAdapter[Result] = TypeAdapter(Result)
 SEARCH_INPUT_ADAPTER: TypeAdapter[SearchInput] = TypeAdapter(SearchInput)
 
 
@@ -214,7 +210,7 @@ def create_search_router() -> APIRouter:
         request: SearchRequest,
         dir: str = Path(description="Transcripts directory (base64url-encoded)"),
         id: str = Path(description="Transcript ID"),
-    ) -> SavedSearchResult:
+    ) -> Result:
         """Search a transcript using grep or LLM-based search.
 
         Returns cached results if the same search was run before.
@@ -240,7 +236,7 @@ def create_search_router() -> APIRouter:
                     created_at=datetime.now(timezone.utc).isoformat(),
                 )
             )
-            return SAVED_SEARCH_RESULT_ADAPTER.validate_json(cached)
+            return SEARCH_RESULT_ADAPTER.validate_json(cached)
 
         # Load transcript
         async with transcripts_view(transcript_dir) as view:
@@ -290,30 +286,11 @@ def create_search_router() -> APIRouter:
             search_id=sid,
             created_at=created_at,
         )
-        if isinstance(request, GrepSearchRequest):
-            saved: SavedSearchResult = GrepSavedSearchResult(
-                search_id=sid,
-                query=request.query,
-                regex=request.regex,
-                ignore_case=request.ignore_case,
-                word_boundary=request.word_boundary,
-                result=output,
-                created_at=created_at,
-            )
-        else:
-            saved = LlmSavedSearchResult(
-                search_id=sid,
-                query=request.query,
-                model=request.model,
-                result=output,
-                created_at=created_at,
-            )
-
         _save_search_input(search_input)
         with _search_result_store() as store:
-            store.put(key, saved.model_dump_json())
+            store.put(key, output.model_dump_json())
 
-        return saved
+        return output
 
     @router.get(
         "/transcripts/{dir}/{id}/searches/{search_id}",
@@ -331,7 +308,7 @@ def create_search_router() -> APIRouter:
             default=None,
             description="Event filter used for the cached search result",
         ),
-    ) -> SavedSearchResult:
+    ) -> Result:
         """Get a cached search result by search input ID and transcript scope."""
         transcript_dir = decode_base64url(dir)
         key = _result_key(
@@ -347,6 +324,6 @@ def create_search_router() -> APIRouter:
 
         if value is None:
             raise HTTPException(status_code=404, detail="Search result not found")
-        return SAVED_SEARCH_RESULT_ADAPTER.validate_json(value)
+        return SEARCH_RESULT_ADAPTER.validate_json(value)
 
     return router

--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -4,9 +4,10 @@ import hashlib
 import json
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Path
-from fastapi.responses import Response
+from fastapi import Query as QueryParam
 from inspect_ai._util.kvstore import KVStore
 from pydantic import TypeAdapter
 
@@ -18,11 +19,14 @@ from .._transcript.database.factory import transcripts_view
 from .._transcript.types import TranscriptContent
 from .._util.appdirs import scout_data_dir
 from ._api_v2_types import (
-    GrepSavedSearch,
+    GrepSavedSearchResult,
+    GrepSearchInput,
     GrepSearchRequest,
-    LlmSavedSearch,
-    SavedSearch,
-    SavedSearchListResponse,
+    LlmSavedSearchResult,
+    LlmSearchInput,
+    SavedSearchResult,
+    SearchInput,
+    SearchInputListResponse,
     SearchRequest,
 )
 from ._server_common import decode_base64url
@@ -49,7 +53,10 @@ If nothing in the transcript matches the query, say so briefly.
 """
 
 MAX_ENTRIES = 500
-SAVED_SEARCH_ADAPTER: TypeAdapter[SavedSearch] = TypeAdapter(SavedSearch)
+SAVED_SEARCH_RESULT_ADAPTER: TypeAdapter[SavedSearchResult] = TypeAdapter(
+    SavedSearchResult
+)
+SEARCH_INPUT_ADAPTER: TypeAdapter[SearchInput] = TypeAdapter(SearchInput)
 
 
 def _normalize_filter(
@@ -67,16 +74,29 @@ def _search_id(request: SearchRequest) -> str:
     parts: dict[str, object] = {
         "query": request.query,
         "type": request.type,
-        "messages": _normalize_filter(request.messages),
-        "events": _normalize_filter(request.events),
     }
     if isinstance(request, GrepSearchRequest):
         parts["regex"] = request.regex
         parts["ignore_case"] = request.ignore_case
         parts["word_boundary"] = request.word_boundary
-    elif request.model is not None:
+    else:
         parts["model"] = request.model
     canonical = json.dumps(parts, sort_keys=True)
+    return hashlib.sha256(canonical.encode()).hexdigest()[:12]
+
+
+def _scope_id(
+    messages: str | None | Sequence[object],
+    events: str | None | Sequence[object],
+) -> str:
+    """Deterministic ID from transcript content filters."""
+    canonical = json.dumps(
+        {
+            "messages": _normalize_filter(messages),
+            "events": _normalize_filter(events),
+        },
+        sort_keys=True,
+    )
     return hashlib.sha256(canonical.encode()).hexdigest()[:12]
 
 
@@ -85,19 +105,80 @@ def _dir_hash(transcript_dir: str) -> str:
     return hashlib.sha256(transcript_dir.encode()).hexdigest()[:12]
 
 
-def _transcript_prefix(transcript_dir: str, transcript_id: str) -> str:
-    """Composite key prefix for all searches within a transcript."""
-    return f"{_dir_hash(transcript_dir)}:{transcript_id}:"
+def _search_input_key(search_type: Literal["grep", "llm"], search_id: str) -> str:
+    """Full key for a global search input."""
+    return f"{search_type}:{search_id}"
 
 
-def _composite_key(transcript_dir: str, transcript_id: str, search_id: str) -> str:
-    """Full composite key for a single search."""
-    return f"{_transcript_prefix(transcript_dir, transcript_id)}{search_id}"
+def _search_input_prefix(search_type: Literal["grep", "llm"]) -> str:
+    """Key prefix for search inputs of a given type."""
+    return f"{search_type}:"
 
 
-def _search_store() -> KVStore:
-    """Open the single search KVStore."""
-    db_path = scout_data_dir("search") / "searches.db"
+def _result_key(
+    transcript_dir: str,
+    transcript_id: str,
+    search_id: str,
+    *,
+    messages: str | None | Sequence[object],
+    events: str | None | Sequence[object],
+) -> str:
+    """Full key for one transcript-specific cached search result."""
+    return (
+        f"{_dir_hash(transcript_dir)}:{transcript_id}:"
+        f"{_scope_id(messages, events)}:{search_id}"
+    )
+
+
+def _search_input_from_request(
+    request: SearchRequest,
+    *,
+    search_id: str,
+    created_at: str,
+) -> SearchInput:
+    """Build the global input-history object for a search request."""
+    if isinstance(request, GrepSearchRequest):
+        return GrepSearchInput(
+            search_id=search_id,
+            query=request.query,
+            regex=request.regex,
+            ignore_case=request.ignore_case,
+            word_boundary=request.word_boundary,
+            created_at=created_at,
+        )
+    return LlmSearchInput(
+        search_id=search_id,
+        query=request.query,
+        model=request.model,
+        created_at=created_at,
+    )
+
+
+def _save_search_input(search_input: SearchInput) -> None:
+    """Persist or refresh one global search input."""
+    with _search_input_store() as store:
+        store.put(
+            _search_input_key(search_input.type, search_input.search_id),
+            search_input.model_dump_json(),
+        )
+
+
+def _parse_scope_filter(value: str | None) -> str | None:
+    """Parse transcript scope query parameters for cached-result lookups."""
+    if value is None or value == "all":
+        return value
+    return value
+
+
+def _search_input_store() -> KVStore:
+    """Open the global search input-history KVStore."""
+    db_path = scout_data_dir("search") / "search_inputs.db"
+    return KVStore(db_path.as_posix(), max_entries=MAX_ENTRIES)
+
+
+def _search_result_store() -> KVStore:
+    """Open the transcript-specific search result KVStore."""
+    db_path = scout_data_dir("search") / "search_results.db"
     return KVStore(db_path.as_posix(), max_entries=MAX_ENTRIES)
 
 
@@ -109,28 +190,57 @@ def create_search_router() -> APIRouter:
     """
     router = APIRouter(tags=["search"])
 
-    @router.post(
-        "/transcripts/{dir}/{id}/search",
-        summary="Search a transcript",
-    )
+    @router.get("/searches", summary="List recent search inputs")
+    async def list_search_inputs(
+        search_type: Literal["grep", "llm"] = QueryParam(
+            alias="type", description="Search input type to list"
+        ),
+        count: int = QueryParam(
+            default=20,
+            ge=1,
+            le=100,
+            description="Maximum number of recent search inputs to return",
+        ),
+    ) -> SearchInputListResponse:
+        """List recent global search inputs, newest first."""
+        with _search_input_store() as store:
+            rows = store.list_by_prefix(_search_input_prefix(search_type))
+
+        items = [SEARCH_INPUT_ADAPTER.validate_json(value) for _, value in rows[:count]]
+        return SearchInputListResponse(items=items)
+
+    @router.post("/transcripts/{dir}/{id}/search", summary="Search a transcript")
     async def search(
         request: SearchRequest,
         dir: str = Path(description="Transcripts directory (base64url-encoded)"),
         id: str = Path(description="Transcript ID"),
-    ) -> SavedSearch:
+    ) -> SavedSearchResult:
         """Search a transcript using grep or LLM-based search.
 
         Returns cached results if the same search was run before.
         """
         transcript_dir = decode_base64url(dir)
         sid = _search_id(request)
-        key = _composite_key(transcript_dir, id, sid)
+        key = _result_key(
+            transcript_dir,
+            id,
+            sid,
+            messages=request.messages,
+            events=request.events,
+        )
 
         # Check cache
-        with _search_store() as store:
+        with _search_result_store() as store:
             cached = store.get(key)
         if cached:
-            return SAVED_SEARCH_ADAPTER.validate_json(cached)
+            _save_search_input(
+                _search_input_from_request(
+                    request,
+                    search_id=sid,
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                )
+            )
+            return SAVED_SEARCH_RESULT_ADAPTER.validate_json(cached)
 
         # Load transcript
         async with transcripts_view(transcript_dir) as view:
@@ -175,8 +285,13 @@ def create_search_router() -> APIRouter:
             )
 
         created_at = datetime.now(timezone.utc).isoformat()
+        search_input = _search_input_from_request(
+            request,
+            search_id=sid,
+            created_at=created_at,
+        )
         if isinstance(request, GrepSearchRequest):
-            saved: SavedSearch = GrepSavedSearch(
+            saved: SavedSearchResult = GrepSavedSearchResult(
                 search_id=sid,
                 query=request.query,
                 regex=request.regex,
@@ -186,7 +301,7 @@ def create_search_router() -> APIRouter:
                 created_at=created_at,
             )
         else:
-            saved = LlmSavedSearch(
+            saved = LlmSavedSearchResult(
                 search_id=sid,
                 query=request.query,
                 model=request.model,
@@ -194,68 +309,44 @@ def create_search_router() -> APIRouter:
                 created_at=created_at,
             )
 
-        with _search_store() as store:
+        _save_search_input(search_input)
+        with _search_result_store() as store:
             store.put(key, saved.model_dump_json())
 
         return saved
 
     @router.get(
-        "/transcripts/{dir}/{id}/searches",
-        summary="List saved searches for a transcript",
-    )
-    async def list_searches(
-        dir: str = Path(description="Transcripts directory (base64url-encoded)"),
-        id: str = Path(description="Transcript ID"),
-    ) -> SavedSearchListResponse:
-        """List all saved searches for a transcript, newest first."""
-        transcript_dir = decode_base64url(dir)
-        prefix = _transcript_prefix(transcript_dir, id)
-
-        with _search_store() as store:
-            rows = store.list_by_prefix(prefix)
-
-        items = [SAVED_SEARCH_ADAPTER.validate_json(value) for _, value in rows]
-        return SavedSearchListResponse(items=items)
-
-    @router.get(
         "/transcripts/{dir}/{id}/searches/{search_id}",
-        summary="Get a saved search",
+        summary="Get a saved search result",
     )
     async def get_search(
         dir: str = Path(description="Transcripts directory (base64url-encoded)"),
         id: str = Path(description="Transcript ID"),
         search_id: str = Path(description="Search ID"),
-    ) -> SavedSearch:
-        """Get a single saved search by ID."""
+        messages: str | None = QueryParam(
+            default=None,
+            description="Message filter used for the cached search result",
+        ),
+        events: str | None = QueryParam(
+            default=None,
+            description="Event filter used for the cached search result",
+        ),
+    ) -> SavedSearchResult:
+        """Get a cached search result by search input ID and transcript scope."""
         transcript_dir = decode_base64url(dir)
-        key = _composite_key(transcript_dir, id, search_id)
+        key = _result_key(
+            transcript_dir,
+            id,
+            search_id,
+            messages=_parse_scope_filter(messages),
+            events=_parse_scope_filter(events),
+        )
 
-        with _search_store() as store:
+        with _search_result_store() as store:
             value = store.get(key)
 
         if value is None:
-            raise HTTPException(status_code=404, detail="Search not found")
-        return SAVED_SEARCH_ADAPTER.validate_json(value)
-
-    @router.delete(
-        "/transcripts/{dir}/{id}/searches/{search_id}",
-        summary="Delete a saved search",
-        status_code=204,
-    )
-    async def delete_search(
-        dir: str = Path(description="Transcripts directory (base64url-encoded)"),
-        id: str = Path(description="Transcript ID"),
-        search_id: str = Path(description="Search ID"),
-    ) -> Response:
-        """Delete a saved search by ID."""
-        transcript_dir = decode_base64url(dir)
-        key = _composite_key(transcript_dir, id, search_id)
-
-        with _search_store() as store:
-            deleted = store.delete(key)
-
-        if not deleted:
-            raise HTTPException(status_code=404, detail="Search not found")
-        return Response(status_code=204)
+            raise HTTPException(status_code=404, detail="Search result not found")
+        return SAVED_SEARCH_RESULT_ADAPTER.validate_json(value)
 
     return router

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -15,7 +15,7 @@ from .._query.order_by import OrderBy
 from .._recorder.active_scans_store import ActiveScanInfo
 from .._recorder.recorder import Status as RecorderStatus
 from .._recorder.summary import Summary
-from .._scanner.result import Error, Result
+from .._scanner.result import Error
 from .._scanspec import ScanSpec
 from .._transcript.types import EventFilter, MessageFilter, TranscriptInfo
 
@@ -366,33 +366,3 @@ class SearchInputListResponse:
     """Response from the list search inputs endpoint."""
 
     items: list[SearchInput]
-
-
-class SavedSearchResultBase(SearchInputBase):
-    """Shared fields for persisted search results."""
-
-    result: Result
-
-
-class GrepSavedSearchResult(SavedSearchResultBase):
-    """A persisted grep search result."""
-
-    type: Literal["grep"] = "grep"
-    regex: bool
-    ignore_case: bool
-    word_boundary: bool
-
-
-class LlmSavedSearchResult(SavedSearchResultBase):
-    """A persisted LLM search result."""
-
-    type: Literal["llm"] = "llm"
-    model: str | None = None
-
-
-SavedSearchResult = TypeAliasType(
-    "SavedSearchResult",
-    Annotated[
-        GrepSavedSearchResult | LlmSavedSearchResult, Field(discriminator="type")
-    ],
-)

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -329,18 +329,52 @@ SearchRequest = TypeAliasType(
 )
 
 
-class SavedSearchBase(BaseModel):
-    """Shared fields for persisted search results."""
+class SearchInputBase(BaseModel):
+    """Shared fields for persisted search input history."""
 
     search_id: str
     query: str
-    result: Result
     created_at: str
 
     model_config = ConfigDict(extra="forbid")
 
 
-class GrepSavedSearch(SavedSearchBase):
+class GrepSearchInput(SearchInputBase):
+    """A persisted grep search input."""
+
+    type: Literal["grep"] = "grep"
+    regex: bool
+    ignore_case: bool
+    word_boundary: bool
+
+
+class LlmSearchInput(SearchInputBase):
+    """A persisted LLM search input."""
+
+    type: Literal["llm"] = "llm"
+    model: str | None = None
+
+
+SearchInput = TypeAliasType(
+    "SearchInput",
+    Annotated[GrepSearchInput | LlmSearchInput, Field(discriminator="type")],
+)
+
+
+@dataclass
+class SearchInputListResponse:
+    """Response from the list search inputs endpoint."""
+
+    items: list[SearchInput]
+
+
+class SavedSearchResultBase(SearchInputBase):
+    """Shared fields for persisted search results."""
+
+    result: Result
+
+
+class GrepSavedSearchResult(SavedSearchResultBase):
     """A persisted grep search result."""
 
     type: Literal["grep"] = "grep"
@@ -349,21 +383,16 @@ class GrepSavedSearch(SavedSearchBase):
     word_boundary: bool
 
 
-class LlmSavedSearch(SavedSearchBase):
+class LlmSavedSearchResult(SavedSearchResultBase):
     """A persisted LLM search result."""
 
     type: Literal["llm"] = "llm"
     model: str | None = None
 
 
-SavedSearch = TypeAliasType(
-    "SavedSearch",
-    Annotated[GrepSavedSearch | LlmSavedSearch, Field(discriminator="type")],
+SavedSearchResult = TypeAliasType(
+    "SavedSearchResult",
+    Annotated[
+        GrepSavedSearchResult | LlmSavedSearchResult, Field(discriminator="type")
+    ],
 )
-
-
-@dataclass
-class SavedSearchListResponse:
-    """Response from the list searches endpoint."""
-
-    items: list[SavedSearch]

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -334,7 +334,7 @@ class SavedSearchBase(BaseModel):
 
     search_id: str
     query: str
-    results: list[Result]
+    result: Result
     created_at: str
 
     model_config = ConfigDict(extra="forbid")

--- a/src/inspect_scout/_view/dist/assets/index-BM0df8mg.css
+++ b/src/inspect_scout/_view/dist/assets/index-BM0df8mg.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0116c68fabdb79462645f385d9b2cecd48a86a6cb576fd45c153cd6e03853399
-size 892342

--- a/src/inspect_scout/_view/dist/assets/index-CEievCmk.css
+++ b/src/inspect_scout/_view/dist/assets/index-CEievCmk.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f27daa3882c8cb10b2bfea4597ba92877e4aac57fdcc7075f6976ed9a73c964f
+size 892369

--- a/src/inspect_scout/_view/dist/assets/index-DvjIeGN-.js
+++ b/src/inspect_scout/_view/dist/assets/index-DvjIeGN-.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:866a411a616c26c4f555c29596be2519e1b8dab63e611bca72785abde93ef72a
+size 3145827

--- a/src/inspect_scout/_view/dist/assets/index-XlrdLetI.js
+++ b/src/inspect_scout/_view/dist/assets/index-XlrdLetI.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b039e8fa0218eb5ff450e7df69b8f17c9ca73090b71472b3f9713facc4dd5228
-size 3145341

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:422f8531dd06b13eccd23273eab957cad85c35e927b58f9140d73563b01686b4
+oid sha256:9b254e2853111c6d433de582c801e23ebeefb01f95fa3a05577b4a28542eb977
 size 1129

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -3197,57 +3197,6 @@
         "title": "GenerateConfig",
         "type": "object"
       },
-      "GrepSavedSearchResult": {
-        "additionalProperties": false,
-        "description": "A persisted grep search result.",
-        "properties": {
-          "created_at": {
-            "title": "Created At",
-            "type": "string"
-          },
-          "ignore_case": {
-            "title": "Ignore Case",
-            "type": "boolean"
-          },
-          "query": {
-            "title": "Query",
-            "type": "string"
-          },
-          "regex": {
-            "title": "Regex",
-            "type": "boolean"
-          },
-          "result": {
-            "$ref": "#/components/schemas/Result"
-          },
-          "search_id": {
-            "title": "Search Id",
-            "type": "string"
-          },
-          "type": {
-            "const": "grep",
-            "default": "grep",
-            "title": "Type",
-            "type": "string"
-          },
-          "word_boundary": {
-            "title": "Word Boundary",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "search_id",
-          "query",
-          "created_at",
-          "result",
-          "type",
-          "regex",
-          "ignore_case",
-          "word_boundary"
-        ],
-        "title": "GrepSavedSearchResult",
-        "type": "object"
-      },
       "GrepSearchInput": {
         "additionalProperties": false,
         "description": "A persisted grep search input.",
@@ -4101,53 +4050,6 @@
         "type": "object"
       },
       "JsonValue": {},
-      "LlmSavedSearchResult": {
-        "additionalProperties": false,
-        "description": "A persisted LLM search result.",
-        "properties": {
-          "created_at": {
-            "title": "Created At",
-            "type": "string"
-          },
-          "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Model"
-          },
-          "query": {
-            "title": "Query",
-            "type": "string"
-          },
-          "result": {
-            "$ref": "#/components/schemas/Result"
-          },
-          "search_id": {
-            "title": "Search Id",
-            "type": "string"
-          },
-          "type": {
-            "const": "llm",
-            "default": "llm",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "search_id",
-          "query",
-          "created_at",
-          "result",
-          "type"
-        ],
-        "title": "LlmSavedSearchResult",
-        "type": "object"
-      },
       "LlmScannerParams": {
         "description": "Parameters for llm_scanner.",
         "properties": {
@@ -6683,23 +6585,6 @@
         ],
         "title": "SandboxEvent",
         "type": "object"
-      },
-      "SavedSearchResult": {
-        "discriminator": {
-          "mapping": {
-            "grep": "#/components/schemas/GrepSavedSearchResult",
-            "llm": "#/components/schemas/LlmSavedSearchResult"
-          },
-          "propertyName": "type"
-        },
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/GrepSavedSearchResult"
-          },
-          {
-            "$ref": "#/components/schemas/LlmSavedSearchResult"
-          }
-        ]
       },
       "ScanJobConfig": {
         "additionalProperties": false,
@@ -12251,7 +12136,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedSearchResult"
+                  "$ref": "#/components/schemas/Result"
                 }
               }
             },
@@ -12344,7 +12229,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedSearchResult"
+                  "$ref": "#/components/schemas/Result"
                 }
               }
             },

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -3197,7 +3197,7 @@
         "title": "GenerateConfig",
         "type": "object"
       },
-      "GrepSavedSearch": {
+      "GrepSavedSearchResult": {
         "additionalProperties": false,
         "description": "A persisted grep search result.",
         "properties": {
@@ -3238,14 +3238,61 @@
         "required": [
           "search_id",
           "query",
+          "created_at",
           "result",
+          "type",
+          "regex",
+          "ignore_case",
+          "word_boundary"
+        ],
+        "title": "GrepSavedSearchResult",
+        "type": "object"
+      },
+      "GrepSearchInput": {
+        "additionalProperties": false,
+        "description": "A persisted grep search input.",
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "ignore_case": {
+            "title": "Ignore Case",
+            "type": "boolean"
+          },
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "regex": {
+            "title": "Regex",
+            "type": "boolean"
+          },
+          "search_id": {
+            "title": "Search Id",
+            "type": "string"
+          },
+          "type": {
+            "const": "grep",
+            "default": "grep",
+            "title": "Type",
+            "type": "string"
+          },
+          "word_boundary": {
+            "title": "Word Boundary",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "search_id",
+          "query",
           "created_at",
           "type",
           "regex",
           "ignore_case",
           "word_boundary"
         ],
-        "title": "GrepSavedSearch",
+        "title": "GrepSearchInput",
         "type": "object"
       },
       "GrepSearchRequest": {
@@ -4054,7 +4101,7 @@
         "type": "object"
       },
       "JsonValue": {},
-      "LlmSavedSearch": {
+      "LlmSavedSearchResult": {
         "additionalProperties": false,
         "description": "A persisted LLM search result.",
         "properties": {
@@ -4094,11 +4141,11 @@
         "required": [
           "search_id",
           "query",
-          "result",
           "created_at",
+          "result",
           "type"
         ],
-        "title": "LlmSavedSearch",
+        "title": "LlmSavedSearchResult",
         "type": "object"
       },
       "LlmScannerParams": {
@@ -4133,6 +4180,49 @@
           "answer"
         ],
         "title": "LlmScannerParams",
+        "type": "object"
+      },
+      "LlmSearchInput": {
+        "additionalProperties": false,
+        "description": "A persisted LLM search input.",
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "search_id": {
+            "title": "Search Id",
+            "type": "string"
+          },
+          "type": {
+            "const": "llm",
+            "default": "llm",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "search_id",
+          "query",
+          "created_at",
+          "type"
+        ],
+        "title": "LlmSearchInput",
         "type": "object"
       },
       "LlmSearchRequest": {
@@ -6594,39 +6684,22 @@
         "title": "SandboxEvent",
         "type": "object"
       },
-      "SavedSearch": {
+      "SavedSearchResult": {
         "discriminator": {
           "mapping": {
-            "grep": "#/components/schemas/GrepSavedSearch",
-            "llm": "#/components/schemas/LlmSavedSearch"
+            "grep": "#/components/schemas/GrepSavedSearchResult",
+            "llm": "#/components/schemas/LlmSavedSearchResult"
           },
           "propertyName": "type"
         },
         "oneOf": [
           {
-            "$ref": "#/components/schemas/GrepSavedSearch"
+            "$ref": "#/components/schemas/GrepSavedSearchResult"
           },
           {
-            "$ref": "#/components/schemas/LlmSavedSearch"
+            "$ref": "#/components/schemas/LlmSavedSearchResult"
           }
         ]
-      },
-      "SavedSearchListResponse": {
-        "description": "Response from the list searches endpoint.",
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/SavedSearch"
-            },
-            "title": "Items",
-            "type": "array"
-          }
-        },
-        "required": [
-          "items"
-        ],
-        "title": "SavedSearchListResponse",
-        "type": "object"
       },
       "ScanJobConfig": {
         "additionalProperties": false,
@@ -8435,6 +8508,40 @@
           "intermediate"
         ],
         "title": "ScoreEvent",
+        "type": "object"
+      },
+      "SearchInput": {
+        "discriminator": {
+          "mapping": {
+            "grep": "#/components/schemas/GrepSearchInput",
+            "llm": "#/components/schemas/LlmSearchInput"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/GrepSearchInput"
+          },
+          {
+            "$ref": "#/components/schemas/LlmSearchInput"
+          }
+        ]
+      },
+      "SearchInputListResponse": {
+        "description": "Response from the list search inputs endpoint.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SearchInput"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "SearchInputListResponse",
         "type": "object"
       },
       "SpanBeginEvent": {
@@ -11658,6 +11765,59 @@
         "summary": " Validation Case"
       }
     },
+    "/searches": {
+      "get": {
+        "description": "List recent global search inputs, newest first.",
+        "operationId": "list_search_inputs_searches_get",
+        "parameters": [
+          {
+            "description": "Search input type to list",
+            "in": "query",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "description": "Search input type to list",
+              "enum": [
+                "grep",
+                "llm"
+              ],
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of recent search inputs to return",
+            "in": "query",
+            "name": "count",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Maximum number of recent search inputs to return",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Count",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchInputListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List recent search inputs",
+        "tags": [
+          "search"
+        ]
+      }
+    },
     "/startscan": {
       "post": {
         "description": "Runs a scan using llm_scanner with the provided ScanJobConfig.",
@@ -12091,7 +12251,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedSearch"
+                  "$ref": "#/components/schemas/SavedSearchResult"
                 }
               }
             },
@@ -12104,103 +12264,9 @@
         ]
       }
     },
-    "/transcripts/{dir}/{id}/searches": {
-      "get": {
-        "description": "List all saved searches for a transcript, newest first.",
-        "operationId": "list_searches_transcripts__dir___id__searches_get",
-        "parameters": [
-          {
-            "description": "Transcripts directory (base64url-encoded)",
-            "in": "path",
-            "name": "dir",
-            "required": true,
-            "schema": {
-              "description": "Transcripts directory (base64url-encoded)",
-              "title": "Dir",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Transcript ID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "description": "Transcript ID",
-              "title": "Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SavedSearchListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "List saved searches for a transcript",
-        "tags": [
-          "search"
-        ]
-      }
-    },
     "/transcripts/{dir}/{id}/searches/{search_id}": {
-      "delete": {
-        "description": "Delete a saved search by ID.",
-        "operationId": "delete_search_transcripts__dir___id__searches__search_id__delete",
-        "parameters": [
-          {
-            "description": "Transcripts directory (base64url-encoded)",
-            "in": "path",
-            "name": "dir",
-            "required": true,
-            "schema": {
-              "description": "Transcripts directory (base64url-encoded)",
-              "title": "Dir",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Transcript ID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "description": "Transcript ID",
-              "title": "Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Search ID",
-            "in": "path",
-            "name": "search_id",
-            "required": true,
-            "schema": {
-              "description": "Search ID",
-              "title": "Search Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Delete a saved search",
-        "tags": [
-          "search"
-        ]
-      },
       "get": {
-        "description": "Get a single saved search by ID.",
+        "description": "Get a cached search result by search input ID and transcript scope.",
         "operationId": "get_search_transcripts__dir___id__searches__search_id__get",
         "parameters": [
           {
@@ -12235,6 +12301,42 @@
               "title": "Search Id",
               "type": "string"
             }
+          },
+          {
+            "description": "Message filter used for the cached search result",
+            "in": "query",
+            "name": "messages",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Message filter used for the cached search result",
+              "title": "Messages"
+            }
+          },
+          {
+            "description": "Event filter used for the cached search result",
+            "in": "query",
+            "name": "events",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Event filter used for the cached search result",
+              "title": "Events"
+            }
           }
         ],
         "responses": {
@@ -12242,14 +12344,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedSearch"
+                  "$ref": "#/components/schemas/SavedSearchResult"
                 }
               }
             },
             "description": "Successful Response"
           }
         },
-        "summary": "Get a saved search",
+        "summary": "Get a saved search result",
         "tags": [
           "search"
         ]

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -3217,12 +3217,8 @@
             "title": "Regex",
             "type": "boolean"
           },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/Result"
-            },
-            "title": "Results",
-            "type": "array"
+          "result": {
+            "$ref": "#/components/schemas/Result"
           },
           "search_id": {
             "title": "Search Id",
@@ -3242,7 +3238,7 @@
         "required": [
           "search_id",
           "query",
-          "results",
+          "result",
           "created_at",
           "type",
           "regex",
@@ -4081,12 +4077,8 @@
             "title": "Query",
             "type": "string"
           },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/Result"
-            },
-            "title": "Results",
-            "type": "array"
+          "result": {
+            "$ref": "#/components/schemas/Result"
           },
           "search_id": {
             "title": "Search Id",
@@ -4102,7 +4094,7 @@
         "required": [
           "search_id",
           "query",
-          "results",
+          "result",
           "created_at",
           "type"
         ],

--- a/tests/view/test_api_v2_search.py
+++ b/tests/view/test_api_v2_search.py
@@ -101,10 +101,10 @@ class TestSearchEndpoint:
         assert request.events == "all"
         assert request.messages is None
 
-    def test_grep_search_lifecycle(
+    def test_grep_search_input_and_cached_result_lifecycle(
         self, client: TestClient, transcript_location: Path, tmp_path: Path
     ) -> None:
-        """Persist, list, fetch, and delete a grep search."""
+        """Persist global grep input history and transcript-scoped cached results."""
         grep_calls: list[dict[str, str | bool]] = []
 
         def fake_grep_scanner(
@@ -113,7 +113,7 @@ class TestSearchEndpoint:
             regex: bool,
             ignore_case: bool,
             word_boundary: bool,
-        ) -> Callable[[Transcript], Awaitable[list[Result]]]:
+        ) -> Callable[[Transcript], Awaitable[Result]]:
             grep_calls.append(
                 {
                     "query": query,
@@ -123,8 +123,8 @@ class TestSearchEndpoint:
                 }
             )
 
-            async def _scan(_: Transcript) -> list[Result]:
-                return [Result(value=1, explanation="Matched one message.")]
+            async def _scan(_: Transcript) -> Result:
+                return Result(value=1, explanation="Matched one message.")
 
             return _scan
 
@@ -142,6 +142,7 @@ class TestSearchEndpoint:
             create_response = client.post(
                 f"/transcripts/{encoded_dir}/t001/search",
                 json={
+                    "messages": "all",
                     "query": "needle",
                     "type": "grep",
                     "regex": True,
@@ -152,12 +153,9 @@ class TestSearchEndpoint:
 
             assert create_response.status_code == 200
             created = create_response.json()
-            assert created["type"] == "grep"
-            assert created["query"] == "needle"
-            assert created["regex"] is True
-            assert created["ignore_case"] is False
-            assert created["word_boundary"] is True
-            assert "model" not in created
+            assert created["value"] == 1
+            assert created["explanation"] == "Matched one message."
+            assert created["references"] == []
             assert grep_calls == [
                 {
                     "query": "needle",
@@ -167,26 +165,29 @@ class TestSearchEndpoint:
                 }
             ]
 
-            list_response = client.get(f"/transcripts/{encoded_dir}/t001/searches")
+            list_response = client.get("/searches?type=grep&count=10")
             assert list_response.status_code == 200
             listed = list_response.json()["items"]
             assert len(listed) == 1
-            assert listed[0] == created
+            search_id = listed[0]["search_id"]
+            assert listed[0] == {
+                "created_at": listed[0]["created_at"],
+                "ignore_case": False,
+                "query": "needle",
+                "regex": True,
+                "search_id": search_id,
+                "type": "grep",
+                "word_boundary": True,
+            }
 
-            search_id = created["search_id"]
             get_response = client.get(
-                f"/transcripts/{encoded_dir}/t001/searches/{search_id}"
+                f"/transcripts/{encoded_dir}/t001/searches/{search_id}?messages=all"
             )
             assert get_response.status_code == 200
             assert get_response.json() == created
 
-            delete_response = client.delete(
-                f"/transcripts/{encoded_dir}/t001/searches/{search_id}"
-            )
-            assert delete_response.status_code == 204
-
             missing_response = client.get(
-                f"/transcripts/{encoded_dir}/t001/searches/{search_id}"
+                f"/transcripts/{encoded_dir}/t001/searches/{search_id}?events=all"
             )
             assert missing_response.status_code == 404
 
@@ -254,9 +255,9 @@ class TestSearchEndpoint:
         first = first_response.json()
         second = second_response.json()
         assert first == second
-        assert first["type"] == "llm"
-        assert first["model"] == "openai/gpt-5.4-mini"
-        assert "regex" not in first
+        assert first["value"] == "The assistant says the needle is in the haystack."
+        assert first["explanation"] == "LLM summary."
+        assert first["references"] == []
         assert llm_calls == [
             {
                 "question": "Where is the needle?",


### PR DESCRIPTION
Following up on #399 

Previously we had `SavedSearches` that represented both the parameters of the search as well as the results, and we both stored it in the kvstore as well as returned it to the client. We realized that we should split this up.

Our two main goals are 
* Provide a global list of recent searches
* When you select a recent search, if that search has previously been performed on the current transcript, show the cached results

So we now have a top-level `GET /searches` that provides a list of recent searches. You can also `GET /transcripts/{dir}/{id}/searches/{search_id}` which will give you the cached results if that search has been performed before or it will 404.

`POST /transcripts/{dir}/{id}/search` now responds with just a `Result`, which is a subset of the `SavedSearches` that it previously responded with. Even though `grep_scanner` and `llm_scanner` both return `Result | list[Result]`, in practice, since we're scanning a single transcript, they always return just a `Result`.