### PR TITLE
Add config parameter to generate_answer / structured_generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `generate_answer()` / `structured_generate()`: add `config: GenerateConfig | None` parameter for per-call overrides (e.g. `cache`), so callers no longer need to mutate or copy the role `Model` to set generation options. `parallel_tool_calls` remains forced to `False` for structured answers.
 - Scout View: Improve message collapse behavior.
 - Scout View: Fade out bottom of truncated expandable panels to indicate more content below.
 - Scout View: Fix timeline error markers incorrectly flagging every model and tool event.

--- a/src/inspect_scout/_llm_scanner/generate.py
+++ b/src/inspect_scout/_llm_scanner/generate.py
@@ -12,6 +12,7 @@ from typing import Literal, overload
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageUser,
+    GenerateConfig,
     Model,
     ModelOutput,
     get_model,
@@ -61,6 +62,7 @@ async def generate_answer(
     answer: AnswerSpec,
     *,
     model: str | Model | None = None,
+    config: GenerateConfig | None = None,
     retry_refusals: int = 3,
     parse: Literal[True] = True,
     extract_refs: Callable[[str], list[Reference]] | None = None,
@@ -74,6 +76,7 @@ async def generate_answer(
     answer: _TextualAnswerSpec,
     *,
     model: str | Model | None = None,
+    config: GenerateConfig | None = None,
     retry_refusals: int = 3,
     parse: Literal[False],
 ) -> ModelOutput: ...
@@ -84,6 +87,7 @@ async def generate_answer(
     answer: AnswerSpec,
     *,
     model: str | Model | None = None,
+    config: GenerateConfig | None = None,
     retry_refusals: int = 3,
     parse: bool = True,
     extract_refs: Callable[[str], list[Reference]] | None = None,
@@ -103,6 +107,9 @@ async def generate_answer(
             how to extract the result.
         model: Model to use for generation. Can be a model name string
             or ``Model`` instance. If ``None``, uses the default model.
+        config: Per-call :class:`GenerateConfig` overrides (e.g. ``cache``,
+            ``temperature``). For :class:`AnswerStructured` answers,
+            ``parallel_tool_calls`` is always forced to ``False``.
         retry_refusals: Number of times to retry on model refusals
             (``stop_reason == "content_filter"``).
         parse: When ``True`` (default), parse the model output into a
@@ -126,6 +133,7 @@ async def generate_answer(
             schema=structured_schema(answer),
             answer_tool=answer.answer_tool,
             model=model,
+            config=config,
             max_attempts=answer.max_attempts,
             retry_refusals=retry_refusals,
         )
@@ -150,6 +158,7 @@ async def generate_answer(
             get_model(model),
             prompt,
             resolved_answer,
+            config,
             retry_refusals,
             extract_refs or _no_references,
             value_to_float,
@@ -160,7 +169,7 @@ async def generate_answer(
             prompt,
             tools=[],
             tool_choice=None,
-            config=None,
+            config=config,
             retry_refusals=retry_refusals,
         )
 
@@ -172,6 +181,7 @@ async def _text_generate(
     model: Model,
     input: str | list[ChatMessage],
     answer: Answer,
+    config: GenerateConfig | None,
     retry_refusals: int,
     extract_refs: Callable[[str], list[Reference]],
     value_to_float: ValueToFloat | None,
@@ -193,7 +203,7 @@ async def _text_generate(
             messages,
             tools=[],
             tool_choice=None,
-            config=None,
+            config=config,
             retry_refusals=retry_refusals,
         )
 

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -37,6 +37,7 @@ async def structured_generate(
     schema: JSONSchema,
     answer_tool: str | None = "answer",
     model: str | Model | None = None,
+    config: GenerateConfig | None = None,
     max_attempts: int = 3,
     retry_refusals: int = 3,
 ) -> tuple[dict[str, Any] | None, list[ChatMessage], ModelOutput]:
@@ -73,7 +74,9 @@ async def structured_generate(
             input=messages,
             tools=[answer_tooldef],
             tool_choice=ToolFunction(answer_tooldef.name),
-            config=GenerateConfig(parallel_tool_calls=False),
+            config=(config or GenerateConfig()).merge(
+                GenerateConfig(parallel_tool_calls=False)
+            ),
             retry_refusals=retry_refusals,
         )
         messages.append(output.message)

--- a/tests/llm_scanner/test_generate.py
+++ b/tests/llm_scanner/test_generate.py
@@ -11,7 +11,7 @@ import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from inspect_ai.model import ModelOutput
+from inspect_ai.model import GenerateConfig, ModelOutput
 from inspect_scout._llm_scanner.generate import generate_answer
 from inspect_scout._llm_scanner.types import (
     AnswerMultiLabel,
@@ -56,6 +56,41 @@ async def test_generate_normal_dispatch() -> None:
     mock_gen.assert_awaited_once()
     assert isinstance(result, Result)
     assert result.value is True
+
+
+@pytest.mark.anyio
+async def test_generate_forwards_config_text() -> None:
+    cfg = GenerateConfig(cache=True)
+    with patch(
+        "inspect_scout._llm_scanner.generate.generate_retry_refusals",
+        new_callable=AsyncMock,
+        return_value=_make_mock_output(),
+    ) as mock_gen:
+        await generate_answer("Q?", "boolean", model="mockllm/model", config=cfg)
+    assert mock_gen.call_args.kwargs["config"] is cfg
+
+
+@pytest.mark.anyio
+async def test_generate_forwards_config_structured() -> None:
+    class MyAnswer(BaseModel):
+        explanation: str = Field(description="Reasoning")
+        score: int = Field(alias="value", description="Score")
+
+    cfg = GenerateConfig(cache=True, parallel_tool_calls=True)
+    with patch(
+        "inspect_scout._llm_scanner.structured.generate_retry_refusals",
+        new_callable=AsyncMock,
+        return_value=ModelOutput.from_content(model="test", content="{}"),
+    ) as mock_gen:
+        await generate_answer(
+            "Q?",
+            AnswerStructured(type=MyAnswer, max_attempts=1),
+            model="mockllm/model",
+            config=cfg,
+        )
+    forwarded = mock_gen.call_args.kwargs["config"]
+    assert forwarded.cache is True
+    assert forwarded.parallel_tool_calls is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Adds `config: GenerateConfig | None = None` to `generate_answer()` (all overloads), `structured_generate()`, and the internal `_text_generate()`, threaded through to `generate_retry_refusals()`.
- Motivation: callers (e.g. inspect_petri's judge/realism scanners) currently have to mutate or shallow-copy the shared `Model` returned by `get_model(role=...)` to set per-call options like `cache=`. With this they can pass `config=GenerateConfig(cache=...)` directly.
- For `AnswerStructured`, the caller's config is merged with `parallel_tool_calls=False` (which always wins, since the answer-tool protocol depends on it).

## Test plan
- [x] `pytest tests/llm_scanner/test_generate.py` — 23 passed, including new `test_generate_forwards_config_text` and `test_generate_forwards_config_structured`
- [x] `ruff check` / `ruff format` on changed files
- [x] mypy delta vs main: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)