### PR TITLE
Always-on per-transcript scanner gating + cacheable two-block llm_scanner prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Scanners: Run the first scanner alone for each transcript; release the rest only after it completes. Lets the lead's generate populate the prompt cache so followers hit the warm cache.
+- `llm_scanner`: Send default-template prompts as two content blocks (preamble + transcript / per-scanner tail) with `cache_prompt=True`. On Anthropic, the shared-prefix block is marked for caching so multiple scanners on the same transcript share a cache entry.
+- `llm_scanner`: `template` parameter accepts a `tuple[str, str]` of `(prefix, suffix)` to opt custom templates into the same two-block cache-aware rendering. Passing a single `str` keeps the legacy single-block behavior unchanged.
 - Scanner as Scorer: When `Result.value` is `None` but the result includes an answer, explanation, or metadata, return a `NOANSWER` score that preserves those fields instead of dropping the score entirely.
 - `generate_answer()` / `structured_generate()`: add `config: GenerateConfig | None` parameter for per-call overrides (e.g. `cache`), so callers no longer need to mutate or copy the role `Model` to set generation options. `parallel_tool_calls` remains forced to `False` for structured answers.
 - Scout View: Improve message collapse behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
+- LLM Scanner: Send default-template prompts as two content blocks (preamble + transcript / per-scanner tail) with `cache_prompt=True`. On Anthropic, the shared-prefix block is marked for caching so multiple scanners on the same transcript share a cache entry.
+- LLM Scanner: `template` parameter accepts a `tuple[str, str]` of `(prefix, suffix)` to opt custom templates into the same two-block cache-aware rendering. Passing a single `str` keeps the legacy single-block behavior unchanged.
 - Scanners: Run the first scanner alone for each transcript; release the rest only after it completes. Lets the lead's generate populate the prompt cache so followers hit the warm cache.
-- `llm_scanner`: Send default-template prompts as two content blocks (preamble + transcript / per-scanner tail) with `cache_prompt=True`. On Anthropic, the shared-prefix block is marked for caching so multiple scanners on the same transcript share a cache entry.
-- `llm_scanner`: `template` parameter accepts a `tuple[str, str]` of `(prefix, suffix)` to opt custom templates into the same two-block cache-aware rendering. Passing a single `str` keeps the legacy single-block behavior unchanged.
 - Scanner as Scorer: When `Result.value` is `None` but the result includes an answer, explanation, or metadata, return a `NOANSWER` score that preserves those fields instead of dropping the score entirely.
 - `generate_answer()` / `structured_generate()`: add `config: GenerateConfig | None` parameter for per-call overrides (e.g. `cache`), so callers no longer need to mutate or copy the role `Model` to set generation options. `parallel_tool_calls` remains forced to `False` for structured answers.
 - Scout View: Improve message collapse behavior.

--- a/src/inspect_scout/_concurrency/common.py
+++ b/src/inspect_scout/_concurrency/common.py
@@ -94,8 +94,14 @@ class ScannerJob(NamedTuple):
 
 
 ParseFunctionResult = (
-    tuple[Literal[True], list[ScannerJob]] | tuple[Literal[False], list[ResultReport]]
+    tuple[Literal[True], ScannerJob] | tuple[Literal[False], list[ResultReport]]
 )
+"""Result of parsing a transcript for scanning.
+
+Success branch carries the lead `ScannerJob` (with any followers attached
+on its `followers` field). Failure branch carries one `ResultReport` per
+affected scanner — parse failure is recorded as an error per scanner.
+"""
 
 
 class ConcurrencyStrategy(Protocol):

--- a/src/inspect_scout/_concurrency/common.py
+++ b/src/inspect_scout/_concurrency/common.py
@@ -84,6 +84,14 @@ class ScannerJob(NamedTuple):
     scanner_name: str
     """The name of the scanner within the scan job."""
 
+    followers: tuple["ScannerJob", ...] = ()
+    """Followers held back until this job (the "lead") completes.
+
+    The first scanner for a transcript runs alone so its generate call can
+    populate the prompt cache; once it completes, followers are enqueued to
+    hit the warm cache.
+    """
+
 
 ParseFunctionResult = (
     tuple[Literal[True], list[ScannerJob]] | tuple[Literal[False], list[ResultReport]]

--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -215,9 +215,9 @@ def single_process_strategy(
 
                 # Check success/failure tag
                 if result[0]:
-                    # Success: enqueue scanner jobs
-                    for scanner_job in result[1]:
-                        scanner_job_deque.append(scanner_job)
+                    # Success: enqueue the lead scanner job (followers are
+                    # attached to it and released when it completes).
+                    scanner_job_deque.append(result[1])
                 else:
                     # Error: record error results
                     for result_report in result[1]:

--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -258,6 +258,10 @@ def single_process_strategy(
                 )
                 return True
             finally:
+                # Release any followers held back by this lead. No-op when the
+                # job has no followers (single-scanner-per-transcript case).
+                for follower in scanner_job.followers:
+                    scanner_job_deque.append(follower)
                 metrics.tasks_scanning -= 1
 
         async def _worker_task(

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -1,7 +1,10 @@
 from typing import Any, Awaitable, Callable, Literal, cast, overload
 
+from inspect_ai._util.content import ContentText
 from inspect_ai.model import (
     ChatMessage,
+    ChatMessageUser,
+    GenerateConfig,
     Model,
     get_model,
 )
@@ -23,7 +26,10 @@ from .._transcript.types import Transcript, TranscriptContent
 from ._reducer import default_reducer, is_resultset_answer
 from .answer import Answer, answer_from_argument
 from .generate import generate_answer
-from .prompt import DEFAULT_SCANNER_TEMPLATE
+from .prompt import (
+    DEFAULT_SCANNER_TEMPLATE_PREFIX,
+    DEFAULT_SCANNER_TEMPLATE_SUFFIX,
+)
 from .types import AnswerSpec
 
 
@@ -33,7 +39,7 @@ def llm_scanner(
     question: str | Callable[[Transcript], Awaitable[str]],
     answer: AnswerSpec,
     value_to_float: ValueToFloat | None = None,
-    template: str | None = None,
+    template: str | tuple[str, str] | None = None,
     template_variables: dict[str, Any]
     | Callable[[Transcript], dict[str, Any]]
     | None = None,
@@ -56,7 +62,7 @@ def llm_scanner(
     question: None = None,
     answer: AnswerSpec,
     value_to_float: ValueToFloat | None = None,
-    template: str,
+    template: str | tuple[str, str],
     template_variables: dict[str, Any]
     | Callable[[Transcript], dict[str, Any]]
     | None = None,
@@ -79,7 +85,7 @@ def llm_scanner(
     question: str | Callable[[Transcript], Awaitable[str]] | None = None,
     answer: AnswerSpec,
     value_to_float: ValueToFloat | None = None,
-    template: str | None = None,
+    template: str | tuple[str, str] | None = None,
     template_variables: dict[str, Any]
     | Callable[[Transcript], dict[str, Any]]
     | None = None,
@@ -118,7 +124,18 @@ def llm_scanner(
                 - {{ answer_prompt }} (prompt for a specific type of answer).
                 - {{ answer_format }} (instructions on how to format the answer)
             In addition, scanner templates can bind to any data within
-            `Transcript.metadata` (e.g. {{ metadata.score }})
+            `Transcript.metadata` (e.g. {{ metadata.score }}).
+
+            Pass a `tuple[str, str]` of `(prefix, suffix)` to render the
+            prompt as two content blocks. The first block is intended to
+            hold the cacheable shared prefix (e.g. preamble + transcript
+            messages); the second holds the per-scanner tail (e.g. question
+            and answer format). Both templates receive the full variable
+            bag. When `template` is `None` (default) or a tuple, the prompt
+            is sent as a multi-block user message with `cache_prompt=True`,
+            allowing prompt-cache hits across scanners that share the
+            same prefix bytes for the same transcript. Passing a single
+            `str` keeps the legacy single-block behavior (no caching).
         template_variables: Additional variables to make available in the template.
             Optionally takes a function which receives the current `Transcript` which
             can return variables.
@@ -161,8 +178,18 @@ def llm_scanner(
         A ``Scanner`` function that analyzes Transcript instances and returns
         ``Result`` (single segment) or ``list[Result]`` (multiple segments).
     """
+    # Resolve template form once at factory time.
+    # - None or tuple: structured 2-block render with cache_prompt=True.
+    # - str: legacy single-block render, behavior unchanged.
+    resolved_template: str | tuple[str, str]
     if template is None:
-        template = DEFAULT_SCANNER_TEMPLATE
+        resolved_template = (
+            DEFAULT_SCANNER_TEMPLATE_PREFIX,
+            DEFAULT_SCANNER_TEMPLATE_SUFFIX,
+        )
+    else:
+        resolved_template = template
+
     resolved_answer = answer_from_argument(answer)
 
     # resolve retry_refusals
@@ -194,19 +221,42 @@ def llm_scanner(
             compaction=compaction,
             depth=depth,
         ):
-            prompt = await render_scanner_prompt(
-                template=template,
-                template_variables=template_variables,
-                transcript=transcript,
-                messages=segment.messages_str,
-                question=question,
-                answer=resolved_answer,
-            )
+            prompt: str | list[ChatMessage]
+            call_config: GenerateConfig | None
+            if isinstance(resolved_template, tuple):
+                prefix_str, suffix_str = await _render_split_prompt(
+                    templates=resolved_template,
+                    template_variables=template_variables,
+                    transcript=transcript,
+                    messages=segment.messages_str,
+                    question=question,
+                    answer=resolved_answer,
+                )
+                prompt = [
+                    ChatMessageUser(
+                        content=[
+                            ContentText(text=prefix_str),
+                            ContentText(text=suffix_str),
+                        ]
+                    )
+                ]
+                call_config = GenerateConfig(cache_prompt=True)
+            else:
+                prompt = await render_scanner_prompt(
+                    template=resolved_template,
+                    template_variables=template_variables,
+                    transcript=transcript,
+                    messages=segment.messages_str,
+                    question=question,
+                    answer=resolved_answer,
+                )
+                call_config = None
             results.append(
                 await generate_answer(
                     prompt,
                     answer,
                     model=resolved_model,
+                    config=call_config,
                     retry_refusals=retry_refusals,
                     extract_refs=extract_references,
                     value_to_float=value_to_float,
@@ -237,6 +287,69 @@ def llm_scanner(
     return scan
 
 
+async def _resolve_template_kwargs(
+    *,
+    template_variables: dict[str, Any] | Callable[[Transcript], dict[str, Any]] | None,
+    transcript: Transcript,
+    messages: str,
+    question: str | Callable[[Transcript], Awaitable[str]] | None,
+    answer: Answer,
+) -> dict[str, Any]:
+    """Resolve template kwargs once. Awaits any async question callable."""
+    template_variables = template_variables or {}
+    if callable(template_variables):
+        template_variables = template_variables(transcript)
+
+    return {
+        "messages": messages,
+        "question": question
+        if isinstance(question, str | None)
+        else await question(transcript),
+        "answer_prompt": answer.prompt,
+        "answer_format": answer.format,
+        "date": transcript.date,
+        "task_set": transcript.task_set,
+        "task_id": transcript.task_id,
+        "task_repeat": transcript.task_repeat,
+        "agent": transcript.agent,
+        "agent_args": transcript.agent_args,
+        "model": transcript.model,
+        "model_options": transcript.model_options,
+        "score": transcript.score,
+        "success": transcript.success,
+        "message_count": transcript.message_count,
+        "total_time": transcript.total_time,
+        "total_tokens": transcript.total_tokens,
+        "error": transcript.error,
+        "limit": transcript.limit,
+        # backward compatibility for existing templates
+        # TODO: remove this once users have updated
+        "metadata": transcript.metadata
+        | {
+            "task_name": transcript.task_set,
+            "score": transcript.score,
+            "model": transcript.model,
+            "solver": transcript.agent,
+            "error": transcript.error,
+            "limit": transcript.limit,
+        },
+        **template_variables,
+    }
+
+
+def _render_template(template: str, kwargs: dict[str, Any]) -> str:
+    # keep_trailing_newline=True preserves whitespace as written so the split
+    # render ((prefix, suffix) -> two strings concatenated) produces the same
+    # bytes as the combined render of `prefix + suffix`. Without it, Jinja
+    # silently strips one trailing newline per render, dropping the blank
+    # line between the prefix and suffix when rendered separately.
+    return (
+        Environment(undefined=StrictOnUseUndefined, keep_trailing_newline=True)
+        .from_string(template)
+        .render(**kwargs)
+    )
+
+
 async def render_scanner_prompt(
     *,
     template: str,
@@ -262,47 +375,32 @@ async def render_scanner_prompt(
     Returns:
         Rendered prompt string with all variables substituted.
     """
-    # resolve variables
-    template_variables = template_variables or {}
-    if callable(template_variables):
-        template_variables = template_variables(transcript)
-
-    return (
-        Environment(undefined=StrictOnUseUndefined)
-        .from_string(template)
-        .render(
-            messages=messages,
-            question=question
-            if isinstance(question, str | None)
-            else await question(transcript),
-            answer_prompt=answer.prompt,
-            answer_format=answer.format,
-            date=transcript.date,
-            task_set=transcript.task_set,
-            task_id=transcript.task_id,
-            task_repeat=transcript.task_repeat,
-            agent=transcript.agent,
-            agent_args=transcript.agent_args,
-            model=transcript.model,
-            model_options=transcript.model_options,
-            score=transcript.score,
-            success=transcript.success,
-            message_count=transcript.message_count,
-            total_time=transcript.total_time,
-            total_tokens=transcript.total_tokens,
-            error=transcript.error,
-            limit=transcript.limit,
-            metadata=transcript.metadata
-            # backward compatibility for existing templates
-            # TODO: remove this once users have updated
-            | {
-                "task_name": transcript.task_set,
-                "score": transcript.score,
-                "model": transcript.model,
-                "solver": transcript.agent,
-                "error": transcript.error,
-                "limit": transcript.limit,
-            },
-            **template_variables,
-        )
+    kwargs = await _resolve_template_kwargs(
+        template_variables=template_variables,
+        transcript=transcript,
+        messages=messages,
+        question=question,
+        answer=answer,
     )
+    return _render_template(template, kwargs)
+
+
+async def _render_split_prompt(
+    *,
+    templates: tuple[str, str],
+    template_variables: dict[str, Any] | Callable[[Transcript], dict[str, Any]] | None,
+    transcript: Transcript,
+    messages: str,
+    question: str | Callable[[Transcript], Awaitable[str]] | None,
+    answer: Answer,
+) -> tuple[str, str]:
+    """Render the prefix and suffix templates with a single shared kwarg resolution."""
+    kwargs = await _resolve_template_kwargs(
+        template_variables=template_variables,
+        transcript=transcript,
+        messages=messages,
+        question=question,
+        answer=answer,
+    )
+    prefix, suffix = templates
+    return _render_template(prefix, kwargs), _render_template(suffix, kwargs)

--- a/src/inspect_scout/_llm_scanner/prompt.py
+++ b/src/inspect_scout/_llm_scanner/prompt.py
@@ -1,4 +1,4 @@
-DEFAULT_SCANNER_TEMPLATE = """
+DEFAULT_SCANNER_TEMPLATE_PREFIX = """
 You are an expert in LLM transcript analysis. Here is an LLM transcript you will be analyzing to answer a question:
 
 [BEGIN TRANSCRIPT]
@@ -7,7 +7,9 @@ You are an expert in LLM transcript analysis. Here is an LLM transcript you will
 ===================================
 [END TRANSCRIPT]
 
-{{ answer_prompt }}
+"""
+
+DEFAULT_SCANNER_TEMPLATE_SUFFIX = """{{ answer_prompt }}
 
 {{ question }}
 
@@ -15,6 +17,10 @@ Your answer should include an explanation of your assessment. It should include 
 
 {{ answer_format }}
 """
+
+DEFAULT_SCANNER_TEMPLATE = (
+    DEFAULT_SCANNER_TEMPLATE_PREFIX + DEFAULT_SCANNER_TEMPLATE_SUFFIX
+)
 
 
 ANSWER_FORMAT_PREAMBLE = (

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -606,17 +606,24 @@ async def _scan_async_inner(
                         union_transcript = await reader.read(
                             job.transcript_info, union_content
                         )
-                        return (
-                            True,
-                            [
-                                ScannerJob(
-                                    union_transcript=union_transcript,
-                                    scanner=scanners_list[idx],
-                                    scanner_name=scanner_names_list[idx],
-                                )
-                                for idx in job.scanner_indices
-                            ],
+
+                        def _make_job(idx: int) -> ScannerJob:
+                            return ScannerJob(
+                                union_transcript=union_transcript,
+                                scanner=scanners_list[idx],
+                                scanner_name=scanner_names_list[idx],
+                            )
+
+                        # Run the first scanner alone for each transcript;
+                        # release the rest only after it completes. This lets
+                        # the lead's generate call populate the prompt cache
+                        # so followers hit the warm cache.
+                        ordered_indices = sorted(job.scanner_indices)
+                        lead_idx, *follower_indices = ordered_indices
+                        lead = _make_job(lead_idx)._replace(
+                            followers=tuple(_make_job(idx) for idx in follower_indices)
                         )
+                        return (True, [lead])
                     except Exception as ex:  # pylint: disable=W0718
                         # Create error ResultReport for each affected scanner
                         return (

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -625,11 +625,9 @@ async def _scan_async_inner(
                         lead_idx, *follower_indices = sorted(job.scanner_indices)
                         lead = _make_job(
                             lead_idx,
-                            followers=tuple(
-                                _make_job(idx) for idx in follower_indices
-                            ),
+                            followers=tuple(_make_job(idx) for idx in follower_indices),
                         )
-                        return (True, [lead])
+                        return (True, lead)
                     except Exception as ex:  # pylint: disable=W0718
                         # Create error ResultReport for each affected scanner
                         return (

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -607,21 +607,27 @@ async def _scan_async_inner(
                             job.transcript_info, union_content
                         )
 
-                        def _make_job(idx: int) -> ScannerJob:
+                        def _make_job(
+                            idx: int,
+                            followers: tuple[ScannerJob, ...] = (),
+                        ) -> ScannerJob:
                             return ScannerJob(
                                 union_transcript=union_transcript,
                                 scanner=scanners_list[idx],
                                 scanner_name=scanner_names_list[idx],
+                                followers=followers,
                             )
 
                         # Run the first scanner alone for each transcript;
                         # release the rest only after it completes. This lets
                         # the lead's generate call populate the prompt cache
                         # so followers hit the warm cache.
-                        ordered_indices = sorted(job.scanner_indices)
-                        lead_idx, *follower_indices = ordered_indices
-                        lead = _make_job(lead_idx)._replace(
-                            followers=tuple(_make_job(idx) for idx in follower_indices)
+                        lead_idx, *follower_indices = sorted(job.scanner_indices)
+                        lead = _make_job(
+                            lead_idx,
+                            followers=tuple(
+                                _make_job(idx) for idx in follower_indices
+                            ),
                         )
                         return (True, [lead])
                     except Exception as ex:  # pylint: disable=W0718

--- a/tests/llm_scanner/test_anthropic_cache_control.py
+++ b/tests/llm_scanner/test_anthropic_cache_control.py
@@ -1,0 +1,161 @@
+"""Validate Anthropic cache_control placement for llm_scanner prompts.
+
+This is the end-to-end claim that scout's two-block prompt structure plus
+inspect_ai's Anthropic provider produce a request with `cache_control:
+ephemeral` on the shared prefix block — the boundary that lets cross-scanner
+prompt caching kick in.
+"""
+
+import pytest
+from inspect_ai._util.content import ContentText
+from inspect_ai.model import ChatMessageUser, GenerateConfig
+from inspect_ai.model._providers.anthropic import AnthropicAPI
+from inspect_scout._llm_scanner._llm_scanner import _render_split_prompt
+from inspect_scout._llm_scanner.answer import _BoolAnswer
+from inspect_scout._llm_scanner.prompt import (
+    DEFAULT_SCANNER_TEMPLATE_PREFIX,
+    DEFAULT_SCANNER_TEMPLATE_SUFFIX,
+)
+from inspect_scout._transcript.types import Transcript
+
+
+def _make_transcript(transcript_id: str = "t1") -> Transcript:
+    return Transcript(
+        transcript_id=transcript_id,
+        source_type="test",
+        source_id="src",
+        source_uri="test://uri",
+        messages=[],
+        metadata={},
+    )
+
+
+async def _render_default_user_message(
+    *,
+    messages: str,
+    question: str,
+) -> ChatMessageUser:
+    """Build the user message llm_scanner emits on the default-template path."""
+    prefix_str, suffix_str = await _render_split_prompt(
+        templates=(DEFAULT_SCANNER_TEMPLATE_PREFIX, DEFAULT_SCANNER_TEMPLATE_SUFFIX),
+        template_variables=None,
+        transcript=_make_transcript(),
+        messages=messages,
+        question=question,
+        answer=_BoolAnswer(),
+    )
+    return ChatMessageUser(
+        content=[
+            ContentText(text=prefix_str),
+            ContentText(text=suffix_str),
+        ]
+    )
+
+
+def _anthropic_api() -> AnthropicAPI:
+    # Fake api_key — we never call generate, only resolve_chat_input which
+    # is a pure transformation.
+    return AnthropicAPI(model_name="claude-opus-4-7", api_key="sk-test")
+
+
+@pytest.mark.anyio
+async def test_default_template_marks_prefix_block_for_anthropic_cache() -> None:
+    """Prefix block gets cache_control: ephemeral; suffix block does not.
+
+    Anthropic's auto-cache marks the last block server-side, so we only need
+    an explicit marker on the second-to-last.
+    """
+    user_msg = await _render_default_user_message(
+        messages="[M1] sample", question="Was it helpful?"
+    )
+    api = _anthropic_api()
+
+    (
+        system_param,
+        tools_params,
+        _mcp,
+        message_params,
+        cache_prompt,
+    ) = await api.resolve_chat_input(
+        input=[user_msg],
+        tools=[],
+        config=GenerateConfig(cache_prompt=True),
+    )
+
+    assert cache_prompt is True
+    assert system_param is None
+    assert tools_params == []
+    assert len(message_params) == 1
+
+    content = message_params[0]["content"]
+    assert isinstance(content, list)
+    assert len(content) == 2
+
+    prefix_block, suffix_block = content
+    assert prefix_block.get("cache_control") == {"type": "ephemeral"}
+    assert "cache_control" not in suffix_block
+
+
+@pytest.mark.anyio
+async def test_two_scanners_produce_byte_identical_prefix_block() -> None:
+    """Two scanners on same transcript produce identical prefix bytes.
+
+    Cross-scanner cache hit requires byte-identical prefix bytes for the
+    same transcript. Two scanners with different questions but the same
+    transcript must serialize to the same prefix TextBlockParam text.
+    """
+    api = _anthropic_api()
+
+    msg_a = await _render_default_user_message(
+        messages="[M1] shared transcript", question="Question A?"
+    )
+    msg_b = await _render_default_user_message(
+        messages="[M1] shared transcript", question="Question B?"
+    )
+
+    (_s, _t, _m, params_a, _c) = await api.resolve_chat_input(
+        input=[msg_a], tools=[], config=GenerateConfig(cache_prompt=True)
+    )
+    (_s2, _t2, _m2, params_b, _c2) = await api.resolve_chat_input(
+        input=[msg_b], tools=[], config=GenerateConfig(cache_prompt=True)
+    )
+
+    content_a = params_a[0]["content"]
+    content_b = params_b[0]["content"]
+    assert isinstance(content_a, list) and isinstance(content_b, list)
+
+    prefix_a, suffix_a = content_a
+    prefix_b, suffix_b = content_b
+
+    # Same text bytes → same cache key on Anthropic's side.
+    assert prefix_a["text"] == prefix_b["text"]
+    # Both marked.
+    assert prefix_a.get("cache_control") == {"type": "ephemeral"}
+    assert prefix_b.get("cache_control") == {"type": "ephemeral"}
+
+    # Suffix bytes must differ (the per-scanner question is here).
+    assert suffix_a["text"] != suffix_b["text"]
+
+
+@pytest.mark.anyio
+async def test_cache_prompt_false_disables_marker() -> None:
+    """cache_prompt=False suppresses the marker.
+
+    If a caller explicitly sets cache_prompt=False, no cache_control is
+    added even though the message structure supports it.
+    """
+    user_msg = await _render_default_user_message(
+        messages="[M1] sample", question="Was it helpful?"
+    )
+    api = _anthropic_api()
+
+    (_s, _t, _m, message_params, cache_prompt) = await api.resolve_chat_input(
+        input=[user_msg],
+        tools=[],
+        config=GenerateConfig(cache_prompt=False),
+    )
+
+    assert cache_prompt is False
+    content = message_params[0]["content"]
+    for block in content:
+        assert "cache_control" not in block

--- a/tests/llm_scanner/test_prompt_split.py
+++ b/tests/llm_scanner/test_prompt_split.py
@@ -1,0 +1,145 @@
+"""Tests for split-template rendering used by the prompt-cache path."""
+
+from typing import Any
+
+import pytest
+from inspect_ai.model import ChatMessage
+from inspect_scout._llm_scanner._llm_scanner import (
+    _render_split_prompt,
+    render_scanner_prompt,
+)
+from inspect_scout._llm_scanner.answer import _BoolAnswer
+from inspect_scout._llm_scanner.prompt import (
+    DEFAULT_SCANNER_TEMPLATE,
+    DEFAULT_SCANNER_TEMPLATE_PREFIX,
+    DEFAULT_SCANNER_TEMPLATE_SUFFIX,
+)
+from inspect_scout._transcript.types import Transcript
+from pydantic import JsonValue
+
+
+def _create_transcript(
+    messages: list[ChatMessage] | None = None,
+    model: str | None = None,
+    score: JsonValue = None,
+    metadata: dict[str, JsonValue] | None = None,
+) -> Transcript:
+    return Transcript(
+        transcript_id="test-id",
+        source_type="test",
+        source_id="test-source",
+        source_uri="test://uri",
+        model=model,
+        score=score,
+        messages=messages or [],
+        metadata=metadata or {},
+    )
+
+
+def test_default_template_concat_equals_combined() -> None:
+    """Combined template must equal split halves concatenated.
+
+    Byte-for-byte. This invariant is what lets `template=None` be a no-behavior-
+    change refactor for users who happened to import DEFAULT_SCANNER_TEMPLATE.
+    """
+    assert (
+        DEFAULT_SCANNER_TEMPLATE_PREFIX + DEFAULT_SCANNER_TEMPLATE_SUFFIX
+        == DEFAULT_SCANNER_TEMPLATE
+    )
+
+
+@pytest.mark.anyio
+async def test_split_render_concatenation_matches_single_render() -> None:
+    """Split-and-concat render must equal combined render.
+
+    Rendering the two halves separately and concatenating produces the same
+    string as rendering the combined template once.
+    """
+    transcript = _create_transcript()
+    kwargs: dict[str, Any] = dict(
+        template_variables=None,
+        transcript=transcript,
+        messages="[M1] hi",
+        question="Was it helpful?",
+        answer=_BoolAnswer(),
+    )
+
+    prefix, suffix = await _render_split_prompt(
+        templates=(DEFAULT_SCANNER_TEMPLATE_PREFIX, DEFAULT_SCANNER_TEMPLATE_SUFFIX),
+        **kwargs,
+    )
+    combined = await render_scanner_prompt(
+        template=DEFAULT_SCANNER_TEMPLATE,
+        **kwargs,
+    )
+    assert prefix + suffix == combined
+
+
+@pytest.mark.anyio
+async def test_split_render_prefix_isolates_messages() -> None:
+    """Prefix block contains messages, suffix contains question.
+
+    The prefix block is the cacheable boundary — it should contain the
+    transcript messages but none of the per-scanner question/answer text.
+    """
+    transcript = _create_transcript()
+    prefix, suffix = await _render_split_prompt(
+        templates=(DEFAULT_SCANNER_TEMPLATE_PREFIX, DEFAULT_SCANNER_TEMPLATE_SUFFIX),
+        template_variables=None,
+        transcript=transcript,
+        messages="[M1] sample message",
+        question="A unique scanner question?",
+        answer=_BoolAnswer(),
+    )
+
+    assert "sample message" in prefix
+    assert "scanner question" not in prefix
+
+    assert "scanner question" in suffix
+    assert "sample message" not in suffix
+
+
+@pytest.mark.anyio
+async def test_split_render_determinism_across_scanners_same_transcript() -> None:
+    """Prefix bytes must be identical across scanners on the same transcript.
+
+    Two scanners with different questions but the same transcript must
+    produce byte-identical prefix content. This is the property that lets
+    cross-scanner prompt caching work.
+    """
+    transcript = _create_transcript(metadata={"key": "val"})
+    common_kwargs: dict[str, Any] = dict(
+        templates=(DEFAULT_SCANNER_TEMPLATE_PREFIX, DEFAULT_SCANNER_TEMPLATE_SUFFIX),
+        template_variables=None,
+        transcript=transcript,
+        messages="[M1] hi",
+        answer=_BoolAnswer(),
+    )
+
+    prefix_a, _ = await _render_split_prompt(question="Question A?", **common_kwargs)
+    prefix_b, _ = await _render_split_prompt(question="Question B?", **common_kwargs)
+    assert prefix_a == prefix_b
+
+
+@pytest.mark.anyio
+async def test_split_render_custom_tuple_template() -> None:
+    """Custom tuple templates render with full kwargs in both halves.
+
+    User-supplied tuple templates render with the full kwarg bag in both
+    halves.
+    """
+    transcript = _create_transcript(metadata={"name": "Alice"})
+    prefix_template = "META: {{ metadata.name }} | MSGS: {{ messages }}"
+    suffix_template = "Q: {{ question }} ({{ answer_format }})"
+
+    prefix, suffix = await _render_split_prompt(
+        templates=(prefix_template, suffix_template),
+        template_variables=None,
+        transcript=transcript,
+        messages="msgs-here",
+        question="Was it good?",
+        answer=_BoolAnswer(),
+    )
+
+    assert prefix == "META: Alice | MSGS: msgs-here"
+    assert "Q: Was it good?" in suffix

--- a/tests/llm_scanner/test_template_forms.py
+++ b/tests/llm_scanner/test_template_forms.py
@@ -1,0 +1,140 @@
+"""Integration tests for the cache-aware llm_scanner template forms.
+
+Verifies llm_scanner produces the right message structure for each template
+form (default, tuple, legacy string).
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageUser,
+    GenerateConfig,
+    ModelOutput,
+)
+from inspect_ai.tool import ToolChoice, ToolInfo
+from inspect_scout import Scanner, llm_scanner, scan, scanner, transcripts_db
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+from tests.scan.test_scan_e2e import create_minimal_transcript
+
+CAPTURED: list[tuple[list[ChatMessage], GenerateConfig]] = []
+
+
+def _capture_outputs(
+    input: list[ChatMessage],
+    tools: list[ToolInfo],
+    tool_choice: ToolChoice,
+    config: GenerateConfig,
+) -> ModelOutput:
+    CAPTURED.append((list(input), config))
+    return ModelOutput.from_content(
+        model="mockllm", content="Looks fine.\n\nANSWER: yes"
+    )
+
+
+def _setup_transcripts(db_path: Path, count: int) -> None:
+    async def _insert() -> None:
+        async with transcripts_db(str(db_path)) as db:
+            await db.insert(
+                [create_minimal_transcript(f"t-{i:03d}", i) for i in range(count)]
+            )
+
+    asyncio.run(_insert())
+
+
+def _run_scan(
+    template: Any,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "db"
+    scans_path = tmp_path / "scans"
+    db_path.mkdir()
+    scans_path.mkdir()
+    _setup_transcripts(db_path, count=1)
+
+    @scanner(name="ts_scanner", messages="all")
+    def _factory() -> Scanner[Transcript]:
+        return llm_scanner(
+            question="Was it helpful?", answer="boolean", template=template
+        )
+
+    CAPTURED.clear()
+    scan(
+        scanners=[_factory()],
+        transcripts=transcripts_from(str(db_path)),
+        scans=str(scans_path),
+        max_processes=1,
+        model="mockllm/model",
+        model_args={"custom_outputs": _capture_outputs},
+        display="none",
+    )
+
+
+def test_default_template_sends_two_blocks_with_cache_prompt() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _run_scan(template=None, tmp_path=Path(tmpdir))
+
+    assert len(CAPTURED) == 1
+    messages, config = CAPTURED[0]
+    assert config.cache_prompt is True
+
+    assert len(messages) == 1
+    msg = messages[0]
+    assert isinstance(msg, ChatMessageUser)
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 2
+    assert all(isinstance(b, ContentText) for b in msg.content)
+
+    prefix_text = msg.content[0].text  # type: ignore[union-attr]
+    suffix_text = msg.content[1].text  # type: ignore[union-attr]
+    assert "BEGIN TRANSCRIPT" in prefix_text
+    assert "Was it helpful?" not in prefix_text
+    assert "Was it helpful?" in suffix_text
+
+
+def test_custom_tuple_template_sends_two_blocks_with_cache_prompt() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _run_scan(
+            template=(
+                "PREFIX: {{ messages }}",
+                "SUFFIX: {{ question }} {{ answer_format }}",
+            ),
+            tmp_path=Path(tmpdir),
+        )
+
+    assert len(CAPTURED) == 1
+    messages, config = CAPTURED[0]
+    assert config.cache_prompt is True
+
+    msg = messages[0]
+    assert isinstance(msg.content, list) and len(msg.content) == 2
+    prefix_text = msg.content[0].text  # type: ignore[union-attr]
+    suffix_text = msg.content[1].text  # type: ignore[union-attr]
+    assert prefix_text.startswith("PREFIX: ")
+    assert suffix_text.startswith("SUFFIX: Was it helpful?")
+
+
+def test_legacy_string_template_sends_single_block_no_cache_prompt() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _run_scan(
+            template="LEGACY: {{ messages }} | {{ question }}",
+            tmp_path=Path(tmpdir),
+        )
+
+    assert len(CAPTURED) == 1
+    messages, config = CAPTURED[0]
+    # Legacy path must not enable cache_prompt — keep today's behavior.
+    assert config.cache_prompt is None
+
+    msg = messages[0]
+    assert isinstance(msg, ChatMessageUser)
+    # Single string content (today's behavior).
+    assert isinstance(msg.content, str)
+    assert msg.content.startswith("LEGACY: ")
+    assert "Was it helpful?" in msg.content

--- a/tests/scan/test_cache_warmup.py
+++ b/tests/scan/test_cache_warmup.py
@@ -1,0 +1,136 @@
+"""Tests for unconditional per-transcript scanner gating.
+
+The first scanner for each transcript runs alone; followers are only released
+after it completes. This lets the prompt cache populate from the lead's
+generate call so followers hit the warm cache. Always-on; no opt-out.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+from inspect_scout import Result, Scanner, scan, scanner, transcripts_db
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+from tests.scan.test_scan_e2e import create_minimal_transcript
+
+
+@scanner(name="ts_recorder", messages="all")
+def ts_recorder_factory(label: str, sleep_s: float = 0.05) -> Scanner[Transcript]:
+    """Scanner that records its start/end times into a per-process registry."""
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        start = time.monotonic()
+        await asyncio.sleep(sleep_s)
+        end = time.monotonic()
+        TIMINGS.setdefault(transcript.transcript_id, []).append((label, start, end))
+        return Result(value=True, explanation=label)
+
+    return scan_transcript
+
+
+# Module-level registry; tests run in single-process mode so this is sufficient.
+TIMINGS: dict[str, list[tuple[str, float, float]]] = {}
+
+
+def _setup_transcripts(db_path: Path, count: int) -> None:
+    async def _insert() -> None:
+        async with transcripts_db(str(db_path)) as db:
+            await db.insert(
+                [create_minimal_transcript(f"t-{i:03d}", i) for i in range(count)]
+            )
+
+    asyncio.run(_insert())
+
+
+@pytest.fixture(autouse=True)
+def _clear_timings() -> None:
+    TIMINGS.clear()
+
+
+def test_first_scanner_runs_before_followers(tmp_path: Path) -> None:
+    """Follower starts only after lead completes."""
+    db_path = tmp_path / "db"
+    scans_path = tmp_path / "scans"
+    db_path.mkdir()
+    scans_path.mkdir()
+    _setup_transcripts(db_path, count=1)
+
+    status = scan(
+        scanners=[
+            ("lead", ts_recorder_factory("lead", sleep_s=0.1)),
+            ("follower", ts_recorder_factory("follower", sleep_s=0.01)),
+        ],
+        transcripts=transcripts_from(str(db_path)),
+        scans=str(scans_path),
+        max_processes=1,
+        display="none",
+    )
+
+    assert status.complete
+
+    events = TIMINGS["t-000"]
+    assert len(events) == 2
+    by_label = {label: (start, end) for label, start, end in events}
+    lead_start, lead_end = by_label["lead"]
+    follower_start, _ = by_label["follower"]
+    assert follower_start >= lead_end, (
+        f"follower started at {follower_start} but lead ended at {lead_end}"
+    )
+
+
+@scanner(name="raising_scanner", messages="all")
+def raising_scanner_factory() -> Scanner[Transcript]:
+    """Scanner that always raises — to verify follower release on lead failure."""
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        raise RuntimeError("boom")
+
+    return scan_transcript
+
+
+def test_followers_release_when_lead_fails(tmp_path: Path) -> None:
+    """If the lead raises, followers must still run."""
+    db_path = tmp_path / "db"
+    scans_path = tmp_path / "scans"
+    db_path.mkdir()
+    scans_path.mkdir()
+    _setup_transcripts(db_path, count=1)
+
+    scan(
+        scanners=[
+            ("lead", raising_scanner_factory()),
+            ("follower", ts_recorder_factory("follower", sleep_s=0.01)),
+        ],
+        transcripts=transcripts_from(str(db_path)),
+        scans=str(scans_path),
+        max_processes=1,
+        display="none",
+    )
+
+    # Lead's exception is recorded as an error, but the follower must still run.
+    assert "t-000" in TIMINGS
+    labels = [label for label, _, _ in TIMINGS["t-000"]]
+    assert "follower" in labels
+
+
+def test_single_scanner_completes(tmp_path: Path) -> None:
+    """Single-scanner config: gate is effectively a no-op, scan completes."""
+    db_path = tmp_path / "db"
+    scans_path = tmp_path / "scans"
+    db_path.mkdir()
+    scans_path.mkdir()
+    _setup_transcripts(db_path, count=2)
+
+    status = scan(
+        scanners=[("only", ts_recorder_factory("only", sleep_s=0.01))],
+        transcripts=transcripts_from(str(db_path)),
+        scans=str(scans_path),
+        max_processes=1,
+        display="none",
+    )
+
+    assert status.complete
+    assert len(TIMINGS) == 2


### PR DESCRIPTION
## Summary

Two changes that together let multi-scanner runs against the same transcripts realize prompt-cache hits across scanners on Anthropic.

### 1. Always-on per-transcript scanner gating

For each transcript, the first scanner runs alone; subsequent scanners are released only after it completes. Implemented via `ScannerJob.followers` + a one-line release in `single_process.py::_perform_scan`'s `finally`. Strategy stays generic; multi-process unaffected (workers run `single_process` internally). No flag, no opt-out — applies to every scan.

### 2. Two-block cacheable user message

`llm_scanner` now renders the default template as two `ContentText` blocks within a single `ChatMessageUser` and sets `cache_prompt=True`:
- Block 0: preamble + `{{ messages }}` (shared, cacheable).
- Block 1: `{{ answer_prompt }}` + `{{ question }}` + format (per-scanner).

inspect_ai's Anthropic provider stamps `cache_control` on `content[-2]` of the last message (the shared prefix block), so the lead writes the cache once and followers hit it on the shared prefix.

`template` parameter extended to accept `str | tuple[str, str] | None`:
- `None` (default): structured 2-block render with caching.
- `tuple[str, str]`: user-supplied `(prefix, suffix)`, structured 2-block with caching.
- `str` (legacy): unchanged single-string single-block behavior, no `cache_prompt` mutation.

`DEFAULT_SCANNER_TEMPLATE` is now `PREFIX + SUFFIX` (byte-identical to the old constant, so external imports keep working).

## Cross-provider impact
- Anthropic: cache marker placed on the shared prefix block by inspect_ai's auto placement; cross-scanner cache hits work as designed.
- OpenAI / Gemini / Bedrock / Vertex / others: multi-block text-only user message is universally supported; tokenizes equivalently to a single concatenated string. `cache_prompt` is silently ignored. No behavior shift.
