### PR TITLE
fix: exit non-zero when --fail-on-error and scan does not complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ scout.local.yaml
 
 # Claude Code
 **/.claude/settings.local.json
+**/.claude/*.lock
 
 /.luarc.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: Exit non-zero when `--fail-on-error` and scan does not complete.
+
 ## 0.4.28 (29 April 2026)
 
 - LLM Scanner: Send default-template prompts as two content blocks (preamble + transcript / per-scanner tail) with `cache_prompt=True`. On Anthropic, the shared-prefix block is marked for caching so multiple scanners on the same transcript share a cache entry.

--- a/src/inspect_scout/_cli/scan.py
+++ b/src/inspect_scout/_cli/scan.py
@@ -689,7 +689,7 @@ def scan_command(
     )
 
     # run scan
-    scan(
+    status = scan(
         scanners=scanjob,
         transcripts=tx,
         scans=scans,
@@ -710,6 +710,11 @@ def scan_command(
         log_level=scan_log_level,
         dry_run=dry_run,
     )
+
+    # exit non-zero when the user asked us to fail on error and the scan
+    # didn't complete cleanly
+    if common["fail_on_error"] and not status.complete:
+        ctx.exit(1)
 
 
 def _parse_comma_separated(value: str | None) -> list[str] | None:

--- a/src/inspect_scout/_cli/scan_resume.py
+++ b/src/inspect_scout/_cli/scan_resume.py
@@ -10,7 +10,9 @@ from .scan import scan_command
 @scan_command.command("resume")
 @click.argument("scan_location", nargs=1)
 @common_options
+@click.pass_context
 def scan_resume_command(
+    ctx: click.Context,
     scan_location: str,
     **common: Unpack[CommonOptions],
 ) -> None:
@@ -18,4 +20,9 @@ def scan_resume_command(
     # Process common options
     process_common_options(common)
 
-    scan_resume(scan_location, fail_on_error=common["fail_on_error"])
+    status = scan_resume(scan_location, fail_on_error=common["fail_on_error"])
+
+    # exit non-zero when the user asked us to fail on error and the scan
+    # didn't complete cleanly
+    if common["fail_on_error"] and not status.complete:
+        ctx.exit(1)

--- a/tests/cli/broken_scanner.py
+++ b/tests/cli/broken_scanner.py
@@ -1,0 +1,11 @@
+"""A scanner that always fails — used by CLI exit-code tests."""
+
+from inspect_scout import Result, Scanner, Transcript, scanner
+
+
+@scanner(messages="all")
+def always_fails() -> Scanner[Transcript]:
+    async def scan(transcript: Transcript) -> Result:
+        raise RuntimeError("intentional scanner failure")
+
+    return scan

--- a/tests/cli/test_scan_exit_code.py
+++ b/tests/cli/test_scan_exit_code.py
@@ -1,0 +1,48 @@
+"""Tests for CLI exit codes from `scout scan`."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+from inspect_scout._cli.main import scout
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+BROKEN_SCANNER = Path(__file__).parent / "broken_scanner.py"
+
+
+def _invoke_scan(tmp_path: Path, *, fail_on_error: bool) -> int:
+    scans_dir = tmp_path / "scans"
+
+    args = [
+        "scan",
+        str(BROKEN_SCANNER),
+        "-T",
+        str(LOGS_DIR),
+        "--scans",
+        str(scans_dir),
+        "--limit",
+        "1",
+        "--max-processes",
+        "1",
+        "--display",
+        "none",
+        "--model",
+        "mockllm/model",
+    ]
+    if fail_on_error:
+        args.append("--fail-on-error")
+
+    runner = CliRunner()
+    result = runner.invoke(scout, args, catch_exceptions=False)
+    return result.exit_code
+
+
+def test_scan_fail_on_error_exits_nonzero(tmp_path: Path) -> None:
+    """`scout scan --fail-on-error` must exit non-zero when a scanner fails."""
+    assert _invoke_scan(tmp_path, fail_on_error=True) != 0
+
+
+def test_scan_without_fail_on_error_exits_zero_on_scanner_error(
+    tmp_path: Path,
+) -> None:
+    """Without `--fail-on-error` scanner errors are captured into results and exit is 0."""
+    assert _invoke_scan(tmp_path, fail_on_error=False) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import importlib.util
+import logging
 import os
 import subprocess
 from typing import Any, Callable, TypeVar, cast
@@ -146,3 +147,20 @@ def reset_observe_providers() -> Any:
     reset_providers()
     yield
     reset_providers()
+
+
+@pytest.fixture(autouse=True)
+def restore_inspect_scout_log_propagation() -> Any:
+    """Ensure the ``inspect_scout`` logger propagates to root for caplog.
+
+    Why: ``inspect_ai._util.logger.init_logger`` sets
+    ``propagate = False`` on the ``inspect_scout`` logger when the CLI
+    initializes logging. That mutation persists for the lifetime of the
+    worker process and prevents pytest's caplog (whose handler is on the
+    root logger) from seeing records emitted by ``inspect_scout`` loggers
+    in tests that run later in the same worker.
+    """
+    logger = logging.getLogger("inspect_scout")
+    logger.propagate = True
+    yield
+    logger.propagate = True


### PR DESCRIPTION
## Summary
- `scout scan --fail-on-error` was exiting 0 even when a scanner raised, because the CLI discarded the `Status` returned by `scan()`.
- Capture the `Status` and `ctx.exit(1)` when `fail_on_error` is set and the scan didn't complete cleanly. Same fix applied to `scout scan resume`.
- Behavior without `--fail-on-error` is unchanged: scanner errors stay captured into results and exit code stays 0.

## Test plan
- [x] `tests/cli/test_scan_exit_code.py::test_scan_fail_on_error_exits_nonzero` — invokes the CLI against an always-failing scanner with `--fail-on-error` and asserts non-zero exit code (fails on `main`, passes with this fix).
- [x] `tests/cli/test_scan_exit_code.py::test_scan_without_fail_on_error_exits_zero_on_scanner_error` — locks in the unchanged behavior without the flag.
- [x] Existing `tests/cli/` suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)