### PR TITLE
fix: erase TextProgress on exit

### DIFF
--- a/src/inspect_scout/_display/rich.py
+++ b/src/inspect_scout/_display/rich.py
@@ -233,6 +233,7 @@ class TextProgressRich(TextProgress):
             ),
             TextColumn(f"[meta]{count_fmt}[/meta]") if self._count else TextColumn(""),
             TimeElapsedColumn(),
+            transient=True,
         )
         self._task_id = self._progress.add_task(
             caption,


### PR DESCRIPTION
## Summary
- `TextProgressRich` never finalized its task; on context exit `Progress.stop()` left a frozen mid-animation spinner and indeterminate bar in scrollback (most visible during transcript indexing).
- Construct the `Progress` with `transient=True` so the lines clear on exit, matching `ScanDisplayRich`.