### PR TITLE
fix: don't truncate text_progress text on wide terminals

### DIFF
--- a/src/inspect_scout/_display/rich.py
+++ b/src/inspect_scout/_display/rich.py
@@ -229,7 +229,7 @@ class TextProgressRich(TextProgress):
             ),
             TextColumn(
                 "[meta]{task.fields[text]}[/meta]",
-                table_column=Column(width=40, no_wrap=True),
+                table_column=Column(ratio=1, no_wrap=True, overflow="ellipsis"),
             ),
             TextColumn(f"[meta]{count_fmt}[/meta]") if self._count else TextColumn(""),
             TimeElapsedColumn(),

--- a/tests/display/test_rich.py
+++ b/tests/display/test_rich.py
@@ -1,0 +1,75 @@
+import io
+import re
+
+import pytest
+from inspect_scout._display.rich import TextProgressRich
+from rich.console import Console
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _make_console(buffer: io.StringIO, width: int) -> Console:
+    return Console(
+        file=buffer,
+        width=width,
+        force_terminal=True,
+        color_system=None,
+        legacy_windows=False,
+    )
+
+
+@pytest.fixture
+def captured_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    console = _make_console(buffer, width=200)
+    # rich.progress imports get_console at module import time, so patch it
+    # at the module where Progress resolves it.
+    monkeypatch.setattr("rich.progress.get_console", lambda: console)
+    return console, buffer
+
+
+def test_long_text_is_not_truncated_on_wide_terminal(
+    captured_console: tuple[Console, io.StringIO],
+) -> None:
+    """A long text value should not be ellipsized when the terminal is wide."""
+    _, buffer = captured_console
+    long_path = (
+        "file:///Users/foo/reuse/logs/very/specific/transcript_2024_01_01_long.eval"
+    )
+
+    progress = TextProgressRich("Indexing", count=True)
+    with progress:
+        progress.update(long_path)
+        progress._progress.refresh()
+
+    visible = ANSI_RE.sub("", buffer.getvalue())
+    assert long_path in visible, (
+        f"Long path was truncated; visible output was:\n{visible!r}"
+    )
+
+
+def test_progress_display_is_cleared_on_exit(
+    captured_console: tuple[Console, io.StringIO],
+) -> None:
+    """On context exit, the rendered progress region should be cleared from the terminal."""
+    _, buffer = captured_console
+
+    progress = TextProgressRich("Indexing", count=True)
+    with progress:
+        progress.update("/some/log/path.eval")
+        progress._progress.refresh()
+        # Confirm the line was actually rendered while active.
+        assert "Indexing" in ANSI_RE.sub("", buffer.getvalue())
+
+    # When transient cleanup is wired up, Rich's Live emits cursor-up + erase-line
+    # ANSI codes at the very tail of the buffer to wipe the rendered region.
+    # Without transient cleanup, the buffer tail is just a show-cursor sequence
+    # following the last rendered frame.
+    output = buffer.getvalue()
+    assert re.search(r"\x1b\[\d*A\x1b\[2K\Z", output), (
+        "Expected cursor-up + erase-line ANSI sequence at end of buffer "
+        "(transient cleanup); progress region was not cleared on exit. "
+        f"Buffer tail: {output[-120:]!r}"
+    )


### PR DESCRIPTION
Fixes: #413 

## Summary
- `TextProgressRich`'s text column was hard-pinned to `width=40`, so the indexing spinner ellipsized paths even on wide terminals (e.g. `file:///Users/.../reuse/lo…`). Switched to `ratio=1` with `overflow="ellipsis"` so the column claims leftover horizontal space and only truncates when content actually overflows.
- Added captured-output tests under `tests/display/test_rich.py` covering both the long-path rendering and the existing `transient=True` cleanup behavior, by patching `rich.progress.get_console` to a `Console` writing to an in-memory `StringIO`.

## Test plan
- [x] `pytest tests/display/` (26 passed)
- [x] `ruff check` and `mypy` clean on touched files
- [ ] Spot-check `scout scan ... -T <logs>` in a wide terminal and confirm the full path renders and the spinner clears on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)