### PR TITLE
Add splice() / splice_to_timeline() for branched timelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,9 @@ allow-direct-references = true
 [tool.uv]
 managed = true
 
+[tool.uv.sources]
+inspect-ai = { path = "../inspect_ai", editable = true }
+
 [tool.ruff]
 extend-exclude = ["docs"]
 src = ["."]

--- a/src/inspect_scout/__init__.py
+++ b/src/inspect_scout/__init__.py
@@ -72,6 +72,7 @@ from ._transcript.messages import (
     transcript_messages,
 )
 from ._transcript.sample_metadata import SampleMetadata
+from ._transcript.splice import splice, splice_to_timeline
 from ._transcript.timeline import (
     TimelineMessages,
     timeline_messages,
@@ -148,6 +149,8 @@ __all__ = [
     "SampleMetadata",
     # timeline
     "TimelineMessages",
+    "splice",
+    "splice_to_timeline",
     "timeline_messages",
     # scanner
     "Error",

--- a/src/inspect_scout/_transcript/splice.py
+++ b/src/inspect_scout/_transcript/splice.py
@@ -30,6 +30,11 @@ def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
             if not anchor:
                 out.clear()
                 continue
+            # TODO: replay extends past the anchor through trailing
+            # deterministic steps, so events between the anchor and where
+            # replay actually ends are dropped from both this prefix and the
+            # child's delta. Empty for current targets; revisit alongside the
+            # auditor-replay refactor.
             cut = _index_of_anchor(events, anchor)
             events = events[: cut + 1] if cut is not None else events
         out.extend(_strip_suffix(e, node.id) for e in events)

--- a/src/inspect_scout/_transcript/splice.py
+++ b/src/inspect_scout/_transcript/splice.py
@@ -1,7 +1,4 @@
-"""Reconstruct a branch's full event stream from a delta-encoded `Timeline`.
-
-A petri-style branched `Timeline` stores each branch's `.content` as the post-replay delta only — events emitted after the branch's `BranchEvent` boundary, with span IDs suffixed `:{branch_span_id}`. `splice()` walks the ancestor chain, takes each ancestor's events up to the `AnchorEvent` matching the next child's `branched_from`, strips the per-segment trajectory suffix, and concatenates. Because span IDs are deterministic per-(parent, name) occurrence, the stripped stream is well-formed: a `SpanBegin` opened in an ancestor's prefix is closed by the matching `SpanEnd` in a descendant's delta.
-"""
+"""Reconstruct a branch's full event stream from a delta-encoded `Timeline`."""
 
 from inspect_ai.event import (
     AnchorEvent,
@@ -18,17 +15,9 @@ __all__ = ["splice", "splice_to_timeline"]
 
 
 def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
-    """Reconstruct `target`'s full event stream by splicing ancestor prefixes.
+    """Reconstruct `target`'s full event stream by concatenating ancestor prefixes.
 
-    Args:
-        timeline: The `Timeline` containing `target` (used to resolve the ancestor chain from `timeline.root`).
-        target: The branch span to reconstruct. May be `timeline.root` itself.
-
-    Returns:
-        A well-formed, suffix-stripped event list equivalent to what a standalone (unbranched) run of `target`'s lineage would have produced.
-
-    Raises:
-        ValueError: If `target` is not reachable from `timeline.root`.
+    For each ancestor, take events up to the `AnchorEvent` matching the next child's `branched_from`, strip the `:{span_id}` suffix from span IDs, and concatenate. The result is what a standalone unbranched run of `target`'s lineage would have produced.
     """
     chain = _ancestor_chain(timeline.root, target)
     out: list[Event] = []
@@ -48,10 +37,7 @@ def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
 
 
 def splice_to_timeline(timeline: Timeline, target: TimelineSpan) -> Timeline:
-    """Splice `target` and rebuild it as a standalone (unbranched) `Timeline`.
-
-    Convenience for post-hoc scanners and the viewer punch-down: the result has the same span structure (sub-agent lanes, nested spans) that an unbranched eval of `target`'s lineage would have produced.
-    """
+    """Splice `target` and rebuild it as a standalone (unbranched) `Timeline`."""
     return timeline_build(events=splice(timeline, target), name=target.name)
 
 

--- a/src/inspect_scout/_transcript/splice.py
+++ b/src/inspect_scout/_transcript/splice.py
@@ -36,7 +36,11 @@ def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
             # child's delta. Empty for current targets; revisit alongside the
             # auditor-replay refactor.
             cut = _index_of_anchor(events, anchor)
-            events = events[: cut + 1] if cut is not None else events
+            if cut is None:
+                raise ValueError(
+                    f"splice: anchor {anchor!r} not found in {node.name} ({node.id})"
+                )
+            events = events[: cut + 1]
         out.extend(_strip_suffix(e, node.id) for e in events)
     return out
 

--- a/src/inspect_scout/_transcript/splice.py
+++ b/src/inspect_scout/_transcript/splice.py
@@ -1,0 +1,98 @@
+"""Reconstruct a branch's full event stream from a delta-encoded `Timeline`.
+
+A petri-style branched `Timeline` stores each branch's `.content` as the post-replay delta only — events emitted after the branch's `BranchEvent` boundary, with span IDs suffixed `:{branch_span_id}`. `splice()` walks the ancestor chain, takes each ancestor's events up to the `AnchorEvent` matching the next child's `branched_from`, strips the per-segment trajectory suffix, and concatenates. Because span IDs are deterministic per-(parent, name) occurrence, the stripped stream is well-formed: a `SpanBegin` opened in an ancestor's prefix is closed by the matching `SpanEnd` in a descendant's delta.
+"""
+
+from inspect_ai.event import (
+    AnchorEvent,
+    Event,
+    SpanBeginEvent,
+    SpanEndEvent,
+    Timeline,
+    TimelineEvent,
+    TimelineSpan,
+    timeline_build,
+)
+
+__all__ = ["splice", "splice_to_timeline"]
+
+
+def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
+    """Reconstruct `target`'s full event stream by splicing ancestor prefixes.
+
+    Args:
+        timeline: The `Timeline` containing `target` (used to resolve the ancestor chain from `timeline.root`).
+        target: The branch span to reconstruct. May be `timeline.root` itself.
+
+    Returns:
+        A well-formed, suffix-stripped event list equivalent to what a standalone (unbranched) run of `target`'s lineage would have produced.
+
+    Raises:
+        ValueError: If `target` is not reachable from `timeline.root`.
+    """
+    chain = _ancestor_chain(timeline.root, target)
+    out: list[Event] = []
+    for i, node in enumerate(chain):
+        events = [
+            item.event for item in node.content if isinstance(item, TimelineEvent)
+        ]
+        if i + 1 < len(chain):
+            anchor = chain[i + 1].branched_from
+            if not anchor:
+                out.clear()
+                continue
+            cut = _index_of_anchor(events, anchor)
+            events = events[: cut + 1] if cut is not None else events
+        out.extend(_strip_suffix(e, node.id) for e in events)
+    return out
+
+
+def splice_to_timeline(timeline: Timeline, target: TimelineSpan) -> Timeline:
+    """Splice `target` and rebuild it as a standalone (unbranched) `Timeline`.
+
+    Convenience for post-hoc scanners and the viewer punch-down: the result has the same span structure (sub-agent lanes, nested spans) that an unbranched eval of `target`'s lineage would have produced.
+    """
+    return timeline_build(events=splice(timeline, target), name=target.name)
+
+
+def _ancestor_chain(root: TimelineSpan, target: TimelineSpan) -> list[TimelineSpan]:
+    path: list[TimelineSpan] = []
+
+    def walk(node: TimelineSpan) -> bool:
+        path.append(node)
+        if node is target or node.id == target.id:
+            return True
+        for child in node.branches:
+            if walk(child):
+                return True
+        path.pop()
+        return False
+
+    if not walk(root):
+        raise ValueError(
+            f"TimelineSpan {target.id!r} is not reachable from timeline root"
+        )
+    return path
+
+
+def _index_of_anchor(events: list[Event], anchor_id: str) -> int | None:
+    for i, e in enumerate(events):
+        if isinstance(e, AnchorEvent) and e.anchor_id == anchor_id:
+            return i
+    return None
+
+
+def _strip_suffix(event: Event, trajectory_id: str) -> Event:
+    """Return a copy of `event` with `:{trajectory_id}` stripped from span-ID fields."""
+    suffix = f":{trajectory_id}"
+    update: dict[str, str] = {}
+    if event.span_id is not None and event.span_id.endswith(suffix):
+        update["span_id"] = event.span_id.removesuffix(suffix)
+    if isinstance(event, (SpanBeginEvent, SpanEndEvent)) and event.id.endswith(suffix):
+        update["id"] = event.id.removesuffix(suffix)
+    if isinstance(event, SpanBeginEvent) and event.parent_id is not None:
+        if event.parent_id.endswith(suffix):
+            update["parent_id"] = event.parent_id.removesuffix(suffix)
+        elif event.parent_id == trajectory_id:
+            update["parent_id"] = ""
+    return event.model_copy(update=update) if update else event

--- a/src/inspect_scout/_transcript/splice.py
+++ b/src/inspect_scout/_transcript/splice.py
@@ -11,8 +11,6 @@ from inspect_ai.event import (
     timeline_build,
 )
 
-__all__ = ["splice", "splice_to_timeline"]
-
 
 def splice(timeline: Timeline, target: TimelineSpan) -> list[Event]:
     """Reconstruct `target`'s full event stream by concatenating ancestor prefixes.

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -123,6 +123,93 @@
         "title": "AdaptiveConcurrency",
         "type": "object"
       },
+      "AnchorEvent": {
+        "description": "Marks a rollback-able point in a replayable trajectory.\n\nEmitted by an orchestrator immediately after a step it can later roll\nback to (a staged message, a model generate, etc.). Carries no content;\n``anchor_id`` is the addressable identifier that ``TimelineSpan.branched_from``\nreferences. Hidden from the viewer transcript by default.",
+        "properties": {
+          "anchor_id": {
+            "title": "Anchor Id",
+            "type": "string"
+          },
+          "event": {
+            "const": "anchor",
+            "default": "anchor",
+            "title": "Event",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "pending": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "working_start": {
+            "title": "Working Start",
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "working_start",
+          "event",
+          "anchor_id"
+        ],
+        "title": "AnchorEvent",
+        "type": "object"
+      },
       "AppConfig": {
         "additionalProperties": false,
         "description": "Application configuration returned by GET /config.",
@@ -636,7 +723,7 @@
         "type": "object"
       },
       "BranchEvent": {
-        "description": "Branch in conversation history.",
+        "description": "Marks where a branched trajectory's unique content begins.\n\nEmitted at the point where a branch transitions from replaying its\nparent's prefix to live execution. Events before this in the trajectory's\nspan are replay-phase re-execution; events after are the branch's\ngenuine new content.",
         "properties": {
           "event": {
             "const": "branch",
@@ -644,12 +731,8 @@
             "title": "Event",
             "type": "string"
           },
-          "from_message": {
-            "title": "From Message",
-            "type": "string"
-          },
-          "from_span": {
-            "title": "From Span",
+          "from_anchor": {
+            "title": "From Anchor",
             "type": "string"
           },
           "metadata": {
@@ -710,8 +793,7 @@
           "timestamp",
           "working_start",
           "event",
-          "from_span",
-          "from_message"
+          "from_anchor"
         ],
         "title": "BranchEvent",
         "type": "object"
@@ -4578,6 +4660,9 @@
                   "$ref": "#/components/schemas/ToolEvent"
                 },
                 {
+                  "$ref": "#/components/schemas/AnchorEvent"
+                },
+                {
                   "$ref": "#/components/schemas/ApprovalEvent"
                 },
                 {
@@ -7629,6 +7714,9 @@
                 "$ref": "#/components/schemas/ToolEvent"
               },
               {
+                "$ref": "#/components/schemas/AnchorEvent"
+              },
+              {
                 "$ref": "#/components/schemas/ApprovalEvent"
               },
               {
@@ -7690,6 +7778,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/ToolEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnchorEvent"
                     },
                     {
                       "$ref": "#/components/schemas/ApprovalEvent"
@@ -9911,6 +10002,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ToolEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/AnchorEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ApprovalEvent"

--- a/tests/transcript/test_splice.py
+++ b/tests/transcript/test_splice.py
@@ -1,0 +1,147 @@
+"""Unit tests for `splice()` and `splice_to_timeline()`."""
+
+import pytest
+from inspect_ai.event import (
+    AnchorEvent,
+    Event,
+    ModelEvent,
+    SpanBeginEvent,
+    SpanEndEvent,
+    Timeline,
+    TimelineEvent,
+    TimelineSpan,
+)
+from inspect_ai.model import ChatMessageAssistant, ModelOutput
+from inspect_scout import splice, splice_to_timeline
+
+
+def _model(completion: str) -> ModelEvent:
+    return ModelEvent(
+        model="mock",
+        input=[],
+        tools=[],
+        tool_choice="auto",
+        config={},  # type: ignore[arg-type]
+        output=ModelOutput.from_message(ChatMessageAssistant(content=completion)),
+    )
+
+
+def _span(
+    *,
+    id: str,
+    branched_from: str | None = None,
+    content: list[Event],
+    branches: list[TimelineSpan] | None = None,
+) -> TimelineSpan:
+    return TimelineSpan(
+        id=id,
+        name="trajectory",
+        span_type="branch",
+        branched_from=branched_from,
+        content=[TimelineEvent(event=e) for e in content],
+        branches=branches or [],
+    )
+
+
+def _completions(events: list[Event]) -> list[str]:
+    return [e.output.completion for e in events if isinstance(e, ModelEvent)]
+
+
+def _tl(root: TimelineSpan) -> Timeline:
+    return Timeline(name="t", description="", root=root)
+
+
+class TestAncestorChain:
+    def test_root_only(self) -> None:
+        root = _span(id="r", content=[_model("R1")])
+        assert _completions(splice(_tl(root), root)) == ["R1"]
+
+    def test_single_branch_cuts_at_anchor(self) -> None:
+        b = _span(id="b", branched_from="A", content=[_model("B1")])
+        root = _span(
+            id="r",
+            content=[_model("R1"), AnchorEvent(anchor_id="A"), _model("R2")],
+            branches=[b],
+        )
+        assert _completions(splice(_tl(root), b)) == ["R1", "B1"]
+
+    def test_nested_branch(self) -> None:
+        c = _span(id="c", branched_from="B", content=[_model("C1")])
+        b = _span(
+            id="b",
+            branched_from="A",
+            content=[_model("B1"), AnchorEvent(anchor_id="B"), _model("B2")],
+            branches=[c],
+        )
+        root = _span(
+            id="r",
+            content=[_model("R1"), AnchorEvent(anchor_id="A")],
+            branches=[b],
+        )
+        assert _completions(splice(_tl(root), c)) == ["R1", "B1", "C1"]
+
+    def test_restart_clears_ancestor_prefix(self) -> None:
+        b = _span(id="b", branched_from="", content=[_model("B1")])
+        root = _span(id="r", content=[_model("R1")], branches=[b])
+        assert _completions(splice(_tl(root), b)) == ["B1"]
+
+    def test_anchor_not_found_includes_full_ancestor(self) -> None:
+        b = _span(id="b", branched_from="missing", content=[_model("B1")])
+        root = _span(id="r", content=[_model("R1"), _model("R2")], branches=[b])
+        assert _completions(splice(_tl(root), b)) == ["R1", "R2", "B1"]
+
+    def test_unreachable_target_raises(self) -> None:
+        root = _span(id="r", content=[])
+        orphan = _span(id="o", content=[])
+        with pytest.raises(ValueError, match="not reachable"):
+            splice(_tl(root), orphan)
+
+
+class TestSuffixStripping:
+    def test_span_ids_stripped_per_segment(self) -> None:
+        b = _span(
+            id="B",
+            branched_from="A",
+            content=[
+                SpanEndEvent(id="x#0:B"),
+                SpanBeginEvent(id="x#1:B", name="x", parent_id="B"),
+                SpanEndEvent(id="x#1:B"),
+            ],
+        )
+        root = _span(
+            id="R",
+            content=[
+                SpanBeginEvent(id="x#0:R", name="x", parent_id="R"),
+                AnchorEvent(anchor_id="A", span_id="x#0:R"),
+            ],
+            branches=[b],
+        )
+        events = splice(_tl(root), b)
+        ids = [e.id for e in events if isinstance(e, (SpanBeginEvent, SpanEndEvent))]
+        assert ids == ["x#0", "x#0", "x#1", "x#1"]
+
+    def test_parent_id_at_trajectory_root_normalized(self) -> None:
+        root = _span(
+            id="R",
+            content=[SpanBeginEvent(id="x#0:R", name="x", parent_id="R")],
+        )
+        [e] = splice(_tl(root), root)
+        assert isinstance(e, SpanBeginEvent)
+        assert e.parent_id == ""
+
+
+class TestSpliceToTimeline:
+    def test_builds_timeline_from_spliced_events(self) -> None:
+        b = _span(id="b", branched_from="A", content=[_model("B1")])
+        root = _span(
+            id="r",
+            content=[_model("R1"), AnchorEvent(anchor_id="A")],
+            branches=[b],
+        )
+        result = splice_to_timeline(_tl(root), b)
+        events = [
+            item.event
+            for item in result.root.content
+            if isinstance(item, TimelineEvent)
+        ]
+        assert _completions(events) == ["R1", "B1"]

--- a/tests/transcript/test_splice.py
+++ b/tests/transcript/test_splice.py
@@ -85,10 +85,11 @@ class TestAncestorChain:
         root = _span(id="r", content=[_model("R1")], branches=[b])
         assert _completions(splice(_tl(root), b)) == ["B1"]
 
-    def test_anchor_not_found_includes_full_ancestor(self) -> None:
+    def test_anchor_not_found_raises(self) -> None:
         b = _span(id="b", branched_from="missing", content=[_model("B1")])
         root = _span(id="r", content=[_model("R1"), _model("R2")], branches=[b])
-        assert _completions(splice(_tl(root), b)) == ["R1", "R2", "B1"]
+        with pytest.raises(ValueError, match="anchor 'missing' not found"):
+            splice(_tl(root), b)
 
     def test_unreachable_target_raises(self) -> None:
         root = _span(id="r", content=[])


### PR DESCRIPTION
## Summary

Reconstruct a branch's full event stream from a delta-encoded `Timeline` (each branch's `.content` is post-replay-only with span IDs suffixed `:{branch_id}`). Walks the ancestor chain, takes each ancestor's events up to the `AnchorEvent` matching the next child's `branched_from`, strips the per-segment trajectory suffix, and concatenates. Result is a well-formed event stream that `timeline_build()` rebuilds into the same structure a standalone unbranched eval would have produced.

Also regenerates `_view/openapi.json` for `AnchorEvent` / `from_anchor` schema changes.

## Dependencies

Requires UKGovernmentBEIS/inspect_ai#3819 (`AnchorEvent`, `BranchEvent.from_anchor`). `pyproject.toml` temporarily points `inspect-ai` at a local sibling checkout — revert before merge once the inspect_ai release is available.

## Related

- petri redesign: meridianlabs-ai/inspect_petri (branch `timeline-tree-tests`)
- viewer: meridianlabs-ai/ts-mono#174

## Test plan

- [x] `tests/transcript/test_splice.py` (9 passed)
- [x] pyright on `splice.py`
- [x] petri e2e `test_splice.py` well-formedness checks against custom targets (5 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)