### PR TITLE
Always run search for POST requests

### DIFF
--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -225,19 +225,6 @@ def create_search_router() -> APIRouter:
             events=request.events,
         )
 
-        # Check cache
-        with _search_result_store() as store:
-            cached = store.get(key)
-        if cached:
-            _save_search_input(
-                _search_input_from_request(
-                    request,
-                    search_id=sid,
-                    created_at=datetime.now(timezone.utc).isoformat(),
-                )
-            )
-            return SEARCH_RESULT_ADAPTER.validate_json(cached)
-
         # Load transcript
         async with transcripts_view(transcript_dir) as view:
             condition = Column("transcript_id") == id

--- a/tests/view/test_api_v2_search.py
+++ b/tests/view/test_api_v2_search.py
@@ -191,10 +191,10 @@ class TestSearchEndpoint:
             )
             assert missing_response.status_code == 404
 
-    def test_llm_search_uses_cache(
+    def test_llm_search_always_runs(
         self, client: TestClient, transcript_location: Path, tmp_path: Path
     ) -> None:
-        """Identical LLM searches return the cached saved search."""
+        """Identical LLM POST searches each run the scanner and produce a new saved search."""
         llm_calls: list[dict[str, str | None]] = []
 
         def fake_llm_scanner(
@@ -254,18 +254,20 @@ class TestSearchEndpoint:
         assert second_response.status_code == 200
         first = first_response.json()
         second = second_response.json()
-        assert first == second
-        assert first["value"] == "The assistant says the needle is in the haystack."
-        assert first["explanation"] == "LLM summary."
-        assert first["references"] == []
-        assert llm_calls == [
-            {
-                "question": "Where is the needle?",
-                "answer": "string",
-                "template": LLM_SEARCH_TEMPLATE,
-                "model": "openai/gpt-5.4-mini",
-            }
-        ]
+        assert first["uuid"] != second["uuid"]
+        for response in (first, second):
+            assert (
+                response["value"] == "The assistant says the needle is in the haystack."
+            )
+            assert response["explanation"] == "LLM summary."
+            assert response["references"] == []
+        expected_call = {
+            "question": "Where is the needle?",
+            "answer": "string",
+            "template": LLM_SEARCH_TEMPLATE,
+            "model": "openai/gpt-5.4-mini",
+        }
+        assert llm_calls == [expected_call, expected_call]
 
     @pytest.mark.parametrize(
         ("payload", "field_name"),


### PR DESCRIPTION
This is an internal change to the Search API (#407). We have a GET endpoint to get cached search results for a given transcript. Anytime we make a POST request, we should truly run the search instead of ever returning cached results.