### PR TITLE
POST /search includes search ID in response

### DIFF
--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -87,7 +87,7 @@ async def segment_messages(
     if isinstance(source, TimelineSpan):
         messages = span_messages(source, compaction=compaction)
     elif source and isinstance(source[0], ChatMessageBase):
-        messages = list(source)  # type: ignore[arg-type]
+        messages = list(source)
     elif source:
         messages = span_messages(source, compaction=compaction)  # type: ignore[arg-type]
     else:

--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -26,8 +26,9 @@ from ._api_v2_types import (
     SearchInput,
     SearchInputListResponse,
     SearchRequest,
+    SearchResponse,
 )
-from ._server_common import decode_base64url
+from ._server_common import InspectPydanticJSONResponse, decode_base64url
 
 LLM_SEARCH_TEMPLATE = """\
 You are a search assistant for LLM transcript analysis. A user is searching \
@@ -205,12 +206,17 @@ def create_search_router() -> APIRouter:
         items = [SEARCH_INPUT_ADAPTER.validate_json(value) for _, value in rows[:count]]
         return SearchInputListResponse(items=items)
 
-    @router.post("/transcripts/{dir}/{id}/search", summary="Search a transcript")
+    @router.post(
+        "/transcripts/{dir}/{id}/search",
+        response_model=SearchResponse,
+        response_class=InspectPydanticJSONResponse,
+        summary="Search a transcript",
+    )
     async def search(
         request: SearchRequest,
         dir: str = Path(description="Transcripts directory (base64url-encoded)"),
         id: str = Path(description="Transcript ID"),
-    ) -> Result:
+    ) -> SearchResponse:
         """Search a transcript using grep or LLM-based search.
 
         Returns cached results if the same search was run before.
@@ -277,7 +283,7 @@ def create_search_router() -> APIRouter:
         with _search_result_store() as store:
             store.put(key, output.model_dump_json())
 
-        return output
+        return SearchResponse(id=sid, result=output)
 
     @router.get(
         "/transcripts/{dir}/{id}/searches/{search_id}",

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -15,7 +15,7 @@ from .._query.order_by import OrderBy
 from .._recorder.active_scans_store import ActiveScanInfo
 from .._recorder.recorder import Status as RecorderStatus
 from .._recorder.summary import Summary
-from .._scanner.result import Error
+from .._scanner.result import Error, Result
 from .._scanspec import ScanSpec
 from .._transcript.types import EventFilter, MessageFilter, TranscriptInfo
 
@@ -366,3 +366,11 @@ class SearchInputListResponse:
     """Response from the list search inputs endpoint."""
 
     items: list[SearchInput]
+
+
+@dataclass
+class SearchResponse:
+    """Response from running a transcript search."""
+
+    id: str
+    result: Result

--- a/src/inspect_scout/_view/dist/assets/index-9GCioygf.js
+++ b/src/inspect_scout/_view/dist/assets/index-9GCioygf.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f817969e48da6690e1a40c2df4248b41f7d76e0ac4da1841e5b04ce10b695d81
-size 3150563

--- a/src/inspect_scout/_view/dist/assets/index-YGPzp3O7.js
+++ b/src/inspect_scout/_view/dist/assets/index-YGPzp3O7.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:999ed9cf6dd4c1dd879331ff0699a87b1c27e6a6fd0c5822dc0b426795bb842f
+size 3150672

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c983595fa0478bc781073ac2730a94ce03b0638d9de79a6f74fb96d1a256d0b
+oid sha256:b25e14cace060720d946eccbfd9a1e389a24b1700873e1c602e27fddf18fccdc
 size 1129

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -8617,6 +8617,24 @@
         "title": "SearchInputListResponse",
         "type": "object"
       },
+      "SearchResponse": {
+        "description": "Response from running a transcript search.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "result": {
+            "$ref": "#/components/schemas/Result"
+          }
+        },
+        "required": [
+          "id",
+          "result"
+        ],
+        "title": "SearchResponse",
+        "type": "object"
+      },
       "SpanBeginEvent": {
         "description": "Mark the beginning of a transcript span.",
         "properties": {
@@ -12327,7 +12345,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Result"
+                  "$ref": "#/components/schemas/SearchResponse"
                 }
               }
             },

--- a/tests/view/test_api_v2_search.py
+++ b/tests/view/test_api_v2_search.py
@@ -153,9 +153,10 @@ class TestSearchEndpoint:
 
             assert create_response.status_code == 200
             created = create_response.json()
-            assert created["value"] == 1
-            assert created["explanation"] == "Matched one message."
-            assert created["references"] == []
+            created_result = created["result"]
+            assert created_result["value"] == 1
+            assert created_result["explanation"] == "Matched one message."
+            assert created_result["references"] == []
             assert grep_calls == [
                 {
                     "query": "needle",
@@ -170,6 +171,7 @@ class TestSearchEndpoint:
             listed = list_response.json()["items"]
             assert len(listed) == 1
             search_id = listed[0]["search_id"]
+            assert created["id"] == search_id
             assert listed[0] == {
                 "created_at": listed[0]["created_at"],
                 "ignore_case": False,
@@ -184,7 +186,7 @@ class TestSearchEndpoint:
                 f"/transcripts/{encoded_dir}/t001/searches/{search_id}?messages=all"
             )
             assert get_response.status_code == 200
-            assert get_response.json() == created
+            assert get_response.json() == created_result
 
             missing_response = client.get(
                 f"/transcripts/{encoded_dir}/t001/searches/{search_id}?events=all"
@@ -254,13 +256,15 @@ class TestSearchEndpoint:
         assert second_response.status_code == 200
         first = first_response.json()
         second = second_response.json()
-        assert first["uuid"] != second["uuid"]
+        assert first["id"] == second["id"]
+        assert first["result"]["uuid"] != second["result"]["uuid"]
         for response in (first, second):
+            result = response["result"]
             assert (
-                response["value"] == "The assistant says the needle is in the haystack."
+                result["value"] == "The assistant says the needle is in the haystack."
             )
-            assert response["explanation"] == "LLM summary."
-            assert response["references"] == []
+            assert result["explanation"] == "LLM summary."
+            assert result["references"] == []
         expected_call = {
             "question": "Where is the needle?",
             "answer": "string",


### PR DESCRIPTION
You could `GET /searches` and see a list of recent searches, including their IDs. However when you create a new search, you wouldn't immediately get the ID back in the response, but now, the response does include that ID.