### PR TITLE
add documentation for Harbor

### DIFF
--- a/docs/db_importing.qmd
+++ b/docs/db_importing.qmd
@@ -13,11 +13,13 @@ You can populate a transcript database in a variety of ways depending on where y
 
 3. [Claude Code](#claude-code): Read transcript data from local Claude Code sessions.
 
-4. [Transcript API](#transcript-api): Python API for creating and inserting transcripts.
+4. [Harbor](#harbor): Read transcript data from Harbor agent trajectory files.
 
-5. [Arrow Import](#arrow-import): Efficient direct insertion using `RecordBatchReader`.
+5. [Transcript API](#transcript-api): Python API for creating and inserting transcripts.
 
-6. [Parquet Data Lake](#parquet-data-lake): Use an existing data lake not created using Inspect Scout.
+6. [Arrow Import](#arrow-import): Efficient direct insertion using `RecordBatchReader`.
+
+7. [Parquet Data Lake](#parquet-data-lake): Use an existing data lake not created using Inspect Scout.
 
 
 We'll cover each of these in turn below. Before proceeding though you should be sure to familiarize yourself with the [Database Schema](db_schema.qmd) and make a plan for how you want to map your data into it.
@@ -274,6 +276,53 @@ Claude Code transcripts are mapped to the database schema as follows:
 | `task_set` | Project directory path |
 | `task_id` | Session slug (conversation summary) |
 | `agent` | `"claude-code"` |
+
+
+## Harbor
+
+[Harbor](https://harborframework.com/) is an agent evaluation framework whose installed agents emit [ATIF (Agent Trajectory Interchange Format)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trajectory files. Scout can import these trajectories via the `inspect-harbor` package, with filtering by session ID and/or time range.
+
+To import ATIF transcripts, first install `inspect-harbor` with the `scout` extra:
+
+```bash
+pip install "inspect-harbor[scout]"
+```
+
+Then, use the `atif()` function to import trajectories. For example:
+
+```python
+from inspect_harbor import atif
+from inspect_scout import transcripts_db
+
+async with transcripts_db("s3://my-transcript-db/") as db:
+    await db.insert(atif(path="path/to/harbor-runs"))
+```
+
+You can narrow the import by specifying a session ID, time range, or limit:
+
+```python
+# Import a specific trajectory by session ID
+await db.insert(atif(
+    path="path/to/harbor-runs",
+    session_id="abc123-def456",
+))
+
+# Import trajectories from a time range (by file modification time)
+from datetime import datetime
+await db.insert(atif(
+    path="path/to/harbor-runs",
+    from_time=datetime(2026, 1, 1),
+    to_time=datetime(2026, 6, 30),
+))
+
+# Limit number of transcripts
+await db.insert(atif(
+    path="path/to/harbor-runs",
+    limit=100,
+))
+```
+
+The `atif()` source reads trajectories produced by Harbor's own runner (e.g. `harbor run --agent claude_code`). When Harbor tasks are run via Inspect AI through `inspect_harbor`, the output is an Inspect eval log instead — see [Inspect Logs](#inspect-logs).
 
 
 ## Transcript API

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -13,7 +13,7 @@ margin-footer: |
 Welcome to Inspect Scout, a tool for in-depth analysis of AI agent transcripts. With Scout, you can easily:
 
 1.  Detect issues like misconfigured environments, refusals, and evaluation awareness using LLM-based or pattern-based scanners.
-2.  Analyze transcripts from Inspect, Arize Phoenix, LangSmith, Logfire, MLFLow, W&B Weave, Claude Code, or custom sources via the capture and import APIs.
+2.  Analyze transcripts from Inspect, Arize Phoenix, LangSmith, Logfire, MLFLow, W&B Weave, Claude Code, Harbor, or custom sources via the capture and import APIs.
 3.  Develop scanners interactively, exploring transcripts and scan results visually in Scout View.
 4.  Validate scanner accuracy against human-labeled examples.
 5.  Handle complex scanning requirements like multi-agent transcripts, compaction, and context-window chunking.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The documentation at https://meridianlabs-ai.github.io/inspect_scout/ and https://meridianlabs-ai.github.io/inspect_scout/db_importing.html does not list Harbor.

### What is the new behavior?

It lists Harbor.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I ran `cd docs` and then `quarto preview`.