### PR TITLE
observe: capture partial response when SDK stream errors mid-iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Observe: Stream-capture wrappers now emit the accumulated partial response when the underlying SDK stream raises mid-iteration (e.g. `overloaded_error`, connection reset, content-filter `error` SSE event). The resulting `ModelEvent` carries the partial output with `error` set; OpenAI mid-stream errors whose `code` indicates moderation (`invalid_prompt`, `content_policy_violation`, `content_filter`, `cyber_policy`) are mapped to `stop_reason="content_filter"`.
+
 ## 0.4.32 (06 May 2026)
 
 - LLM Scanner: Redefine `depth` semantics for timeline scanning. `depth` now counts levels of *scannable* spans (top-level agents/solvers and their scannable descendants).

--- a/src/inspect_scout/_observe/providers/anthropic.py
+++ b/src/inspect_scout/_observe/providers/anthropic.py
@@ -128,6 +128,7 @@ class AnthropicProvider:
 
         request = data["request"]
         response = data["response"]
+        error = data.get("error")
 
         # Extract system message if present
         system_message = request.get("system")
@@ -185,6 +186,7 @@ class AnthropicProvider:
             tool_choice=tool_choice if tool_choice else "auto",
             config=config,
             output=output,
+            error=repr(error) if error is not None else None,
         )
 
 
@@ -312,16 +314,22 @@ class AnthropicStreamCapture(ObjectProxy):  # type: ignore[misc]
         self._self_accumulator = AnthropicStreamAccumulator()
 
     def __iter__(self) -> Iterator[Any]:
-        for event in self.__wrapped__:
-            self._self_accumulator.accumulate_event(event)
-            yield event
-
-        self._self_emit(
-            {
+        error: Exception | None = None
+        try:
+            for event in self.__wrapped__:
+                self._self_accumulator.accumulate_event(event)
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            data: dict[str, Any] = {
                 "request": self._self_request_kwargs,
                 "response": self._self_accumulator.accumulated,
             }
-        )
+            if error is not None:
+                data["error"] = error
+            self._self_emit(data)
 
 
 class AnthropicAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
@@ -339,16 +347,22 @@ class AnthropicAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
         self._self_accumulator = AnthropicStreamAccumulator()
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        async for event in self.__wrapped__:
-            self._self_accumulator.accumulate_event(event)
-            yield event
-
-        self._self_emit(
-            {
+        error: Exception | None = None
+        try:
+            async for event in self.__wrapped__:
+                self._self_accumulator.accumulate_event(event)
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            data: dict[str, Any] = {
                 "request": self._self_request_kwargs,
                 "response": self._self_accumulator.accumulated,
             }
-        )
+            if error is not None:
+                data["error"] = error
+            self._self_emit(data)
 
 
 class AnthropicStreamManagerCapture(ObjectProxy):  # type: ignore[misc]
@@ -386,38 +400,62 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy):  # type: ignore[misc]
         super().__init__(stream)
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
-        self._self_final_message: Any = None
+        self._self_emitted: bool = False
 
-    def _emit_if_needed(self, message: Any) -> None:
-        """Emit the message if not already emitted."""
-        if self._self_final_message is None:
-            self._self_final_message = message
-            self._self_emit(
-                {
-                    "request": self._self_request_kwargs,
-                    "response": message,
-                }
-            )
+    def _emit_if_needed(self, message: Any, error: Exception | None = None) -> None:
+        """Emit once with the given message and optional error."""
+        if self._self_emitted:
+            return
+        self._self_emitted = True
+        data: dict[str, Any] = {
+            "request": self._self_request_kwargs,
+            "response": message,
+        }
+        if error is not None:
+            data["error"] = error
+        self._self_emit(data)
+
+    def _snapshot(self) -> Any:
+        """Return the SDK's partial message snapshot, if exposed."""
+        return getattr(self.__wrapped__, "current_message_snapshot", None)
 
     def __iter__(self) -> Iterator[Any]:
-        for event in self.__wrapped__:
-            yield event
-
-        if hasattr(self.__wrapped__, "get_final_message"):
-            self._emit_if_needed(self.__wrapped__.get_final_message())
+        error: Exception | None = None
+        try:
+            for event in self.__wrapped__:
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if error is not None:
+                self._emit_if_needed(self._snapshot(), error)
+            elif hasattr(self.__wrapped__, "get_final_message"):
+                self._emit_if_needed(self.__wrapped__.get_final_message())
 
     @property
     def text_stream(self) -> Iterator[str]:
         """Pass through text_stream property."""
-        for text in self.__wrapped__.text_stream:
-            yield text
-
-        if hasattr(self.__wrapped__, "get_final_message"):
-            self._emit_if_needed(self.__wrapped__.get_final_message())
+        error: Exception | None = None
+        try:
+            for text in self.__wrapped__.text_stream:
+                yield text
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if error is not None:
+                self._emit_if_needed(self._snapshot(), error)
+            elif hasattr(self.__wrapped__, "get_final_message"):
+                self._emit_if_needed(self.__wrapped__.get_final_message())
 
     def get_final_message(self) -> Any:
         """Get final message and ensure emission."""
-        message = self.__wrapped__.get_final_message()
+        try:
+            message = self.__wrapped__.get_final_message()
+        except Exception as e:
+            self._emit_if_needed(self._snapshot(), e)
+            raise
         self._emit_if_needed(message)
         return message
 
@@ -467,25 +505,38 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy):  # type: ignore[mi
         super().__init__(stream)
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
-        self._self_final_message: Any = None
+        self._self_emitted: bool = False
 
-    def _emit_if_needed(self, message: Any) -> None:
-        """Emit the message if not already emitted."""
-        if self._self_final_message is None:
-            self._self_final_message = message
-            self._self_emit(
-                {
-                    "request": self._self_request_kwargs,
-                    "response": message,
-                }
-            )
+    def _emit_if_needed(self, message: Any, error: Exception | None = None) -> None:
+        """Emit once with the given message and optional error."""
+        if self._self_emitted:
+            return
+        self._self_emitted = True
+        data: dict[str, Any] = {
+            "request": self._self_request_kwargs,
+            "response": message,
+        }
+        if error is not None:
+            data["error"] = error
+        self._self_emit(data)
+
+    def _snapshot(self) -> Any:
+        """Return the SDK's partial message snapshot, if exposed."""
+        return getattr(self.__wrapped__, "current_message_snapshot", None)
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        async for event in self.__wrapped__:
-            yield event
-
-        if hasattr(self.__wrapped__, "get_final_message"):
-            self._emit_if_needed(await self.__wrapped__.get_final_message())
+        error: Exception | None = None
+        try:
+            async for event in self.__wrapped__:
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if error is not None:
+                self._emit_if_needed(self._snapshot(), error)
+            elif hasattr(self.__wrapped__, "get_final_message"):
+                self._emit_if_needed(await self.__wrapped__.get_final_message())
 
     @property
     def text_stream(self) -> AsyncIterator[str]:
@@ -493,17 +544,28 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy):  # type: ignore[mi
         parent = self
 
         async def _text_stream() -> AsyncIterator[str]:
-            async for text in parent.__wrapped__.text_stream:
-                yield text
-
-            if hasattr(parent.__wrapped__, "get_final_message"):
-                parent._emit_if_needed(await parent.__wrapped__.get_final_message())
+            error: Exception | None = None
+            try:
+                async for text in parent.__wrapped__.text_stream:
+                    yield text
+            except Exception as e:
+                error = e
+                raise
+            finally:
+                if error is not None:
+                    parent._emit_if_needed(parent._snapshot(), error)
+                elif hasattr(parent.__wrapped__, "get_final_message"):
+                    parent._emit_if_needed(await parent.__wrapped__.get_final_message())
 
         return _text_stream()
 
     async def get_final_message(self) -> Any:
         """Get final message and ensure emission."""
-        message = await self.__wrapped__.get_final_message()
+        try:
+            message = await self.__wrapped__.get_final_message()
+        except Exception as e:
+            self._emit_if_needed(self._snapshot(), e)
+            raise
         self._emit_if_needed(message)
         return message
 

--- a/src/inspect_scout/_observe/providers/google.py
+++ b/src/inspect_scout/_observe/providers/google.py
@@ -341,6 +341,7 @@ class GoogleProvider:
 
         request = data["request"]
         response = data["response"]
+        error = data.get("error")
         # For streaming, we accumulate parts across chunks
         accumulated_parts = data.get("accumulated_parts")
 
@@ -427,6 +428,7 @@ class GoogleProvider:
             tool_choice=tool_choice if tool_choice else "auto",
             config=config,
             output=output,
+            error=repr(error) if error is not None else None,
         )
 
 
@@ -604,12 +606,20 @@ class GoogleStreamCapture:
         self._accumulator = GoogleStreamAccumulator()
 
     def __iter__(self) -> Iterator[Any]:
-        for chunk in self._stream:
-            self._accumulator.accumulate_chunk(chunk)
-            yield chunk
-
-        if self._accumulator.last_chunk is not None:
-            self._emit(self._accumulator.get_response_data(self._request_kwargs))
+        error: Exception | None = None
+        try:
+            for chunk in self._stream:
+                self._accumulator.accumulate_chunk(chunk)
+                yield chunk
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._accumulator.last_chunk is not None:
+                data = self._accumulator.get_response_data(self._request_kwargs)
+                if error is not None:
+                    data["error"] = error
+                self._emit(data)
 
 
 class GoogleAsyncStreamCapture:
@@ -627,9 +637,17 @@ class GoogleAsyncStreamCapture:
         self._accumulator = GoogleStreamAccumulator()
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        async for chunk in self._stream:
-            self._accumulator.accumulate_chunk(chunk)
-            yield chunk
-
-        if self._accumulator.last_chunk is not None:
-            self._emit(self._accumulator.get_response_data(self._request_kwargs))
+        error: Exception | None = None
+        try:
+            async for chunk in self._stream:
+                self._accumulator.accumulate_chunk(chunk)
+                yield chunk
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._accumulator.last_chunk is not None:
+                data = self._accumulator.get_response_data(self._request_kwargs)
+                if error is not None:
+                    data["error"] = error
+                self._emit(data)

--- a/src/inspect_scout/_observe/providers/openai.py
+++ b/src/inspect_scout/_observe/providers/openai.py
@@ -3,12 +3,32 @@
 from typing import Any, AsyncIterator, Iterator
 
 from inspect_ai.event import Event, ModelEvent
+from inspect_ai.model import StopReason
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
 from wrapt import ObjectProxy  # type: ignore[import-untyped]
 
 from .provider import ObserveEmit
+
+
+def _stop_reason_from_openai_error(error: Exception) -> StopReason | None:
+    """Map an OpenAI ``APIError`` raised mid-stream to an inspect ``StopReason``.
+
+    Mirrors the error-code detection in
+    ``inspect_ai.model._openai.openai_handle_bad_request``.
+    """
+    code = getattr(error, "code", None)
+    if code in (
+        "invalid_prompt",
+        "content_policy_violation",
+        "content_filter",
+        "cyber_policy",
+    ):
+        return "content_filter"
+    if code == "context_length_exceeded":
+        return "model_length"
+    return None
 
 
 class OpenAIProvider:
@@ -139,11 +159,21 @@ class OpenAIProvider:
         request = data["request"]
         response = data["response"]
         api = data.get("api", "completions")
+        error = data.get("error")
 
         if api == "responses":
-            return await self._build_responses_event(request, response)
+            event = await self._build_responses_event(request, response)
         else:
-            return await self._build_completions_event(request, response)
+            event = await self._build_completions_event(request, response)
+
+        if error is not None:
+            event.error = repr(error)
+            stop_reason = _stop_reason_from_openai_error(error)
+            if stop_reason is not None:
+                for choice in event.output.choices:
+                    if choice.stop_reason == "unknown":
+                        choice.stop_reason = stop_reason
+        return event
 
     async def _build_completions_event(
         self, request: dict[str, Any], response: Any
@@ -160,7 +190,21 @@ class OpenAIProvider:
             request.get("messages", []),
             model=request.get("model"),
         )
+
+        # A stream that errored mid-way has choices with finish_reason=None,
+        # which ChatCompletion.model_validate rejects. Fill a placeholder so the
+        # converter runs, then mark the resulting stop_reason as 'unknown'.
+        unfinished: set[int] = set()
+        if isinstance(response, dict):
+            for choice in response.get("choices", []):
+                if choice.get("finish_reason") is None:
+                    unfinished.add(choice.get("index", 0))
+                    choice["finish_reason"] = "stop"
+
         output = await model_output_from_openai(response)
+        for i in unfinished:
+            if i < len(output.choices):
+                output.choices[i].stop_reason = "unknown"
 
         tools: list[ToolInfo] = []
         tool_choice: ToolChoice | None = None
@@ -359,17 +403,23 @@ class OpenAIChatStreamCapture(ObjectProxy):  # type: ignore[misc]
         self._self_accumulator = OpenAIChatStreamAccumulator()
 
     def __iter__(self) -> Iterator[Any]:
-        for chunk in self.__wrapped__:
-            self._self_accumulator.accumulate_chunk(chunk)
-            yield chunk
-
-        self._self_emit(
-            {
+        error: Exception | None = None
+        try:
+            for chunk in self.__wrapped__:
+                self._self_accumulator.accumulate_chunk(chunk)
+                yield chunk
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            data: dict[str, Any] = {
                 "request": self._self_request_kwargs,
                 "response": self._self_accumulator.get_response(),
                 "api": "completions",
             }
-        )
+            if error is not None:
+                data["error"] = error
+            self._self_emit(data)
 
 
 class OpenAIChatAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
@@ -387,17 +437,23 @@ class OpenAIChatAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
         self._self_accumulator = OpenAIChatStreamAccumulator()
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        async for chunk in self.__wrapped__:
-            self._self_accumulator.accumulate_chunk(chunk)
-            yield chunk
-
-        self._self_emit(
-            {
+        error: Exception | None = None
+        try:
+            async for chunk in self.__wrapped__:
+                self._self_accumulator.accumulate_chunk(chunk)
+                yield chunk
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            data: dict[str, Any] = {
                 "request": self._self_request_kwargs,
                 "response": self._self_accumulator.get_response(),
                 "api": "completions",
             }
-        )
+            if error is not None:
+                data["error"] = error
+            self._self_emit(data)
 
 
 class OpenAIResponsesStreamCapture(ObjectProxy):  # type: ignore[misc]
@@ -412,28 +468,31 @@ class OpenAIResponsesStreamCapture(ObjectProxy):  # type: ignore[misc]
         super().__init__(stream)
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
-        self._self_complete_response: Any = None
+        self._self_response_snapshot: Any = None
 
     def __iter__(self) -> Iterator[Any]:
-        for event in self.__wrapped__:
-            # Capture response from completed or incomplete events
-            if hasattr(event, "type") and event.type in (
-                "response.completed",
-                "response.incomplete",
-            ):
+        error: Exception | None = None
+        try:
+            for event in self.__wrapped__:
+                # Track the latest Response snapshot from any lifecycle event
+                # (created/queued/in_progress/completed/incomplete/failed) so a
+                # mid-stream error still has something to emit.
                 if hasattr(event, "response"):
-                    self._self_complete_response = event.response
-            yield event
-
-        # Stream complete - emit if we captured a response
-        if self._self_complete_response is not None:
-            self._self_emit(
-                {
+                    self._self_response_snapshot = event.response
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._self_response_snapshot is not None:
+                data: dict[str, Any] = {
                     "request": self._self_request_kwargs,
-                    "response": self._self_complete_response,
+                    "response": self._self_response_snapshot,
                     "api": "responses",
                 }
-            )
+                if error is not None:
+                    data["error"] = error
+                self._self_emit(data)
 
 
 class OpenAIResponsesAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
@@ -448,24 +507,28 @@ class OpenAIResponsesAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
         super().__init__(stream)
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
-        self._self_complete_response: Any = None
+        self._self_response_snapshot: Any = None
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        async for event in self.__wrapped__:
-            # Capture response from completed or incomplete events
-            if hasattr(event, "type") and event.type in (
-                "response.completed",
-                "response.incomplete",
-            ):
+        error: Exception | None = None
+        try:
+            async for event in self.__wrapped__:
+                # Track the latest Response snapshot from any lifecycle event
+                # (created/queued/in_progress/completed/incomplete/failed) so a
+                # mid-stream error still has something to emit.
                 if hasattr(event, "response"):
-                    self._self_complete_response = event.response
-            yield event
-
-        if self._self_complete_response is not None:
-            self._self_emit(
-                {
+                    self._self_response_snapshot = event.response
+                yield event
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._self_response_snapshot is not None:
+                data: dict[str, Any] = {
                     "request": self._self_request_kwargs,
-                    "response": self._self_complete_response,
+                    "response": self._self_response_snapshot,
                     "api": "responses",
                 }
-            )
+                if error is not None:
+                    data["error"] = error
+                self._self_emit(data)

--- a/tests/observe/test_observe_stream_errors.py
+++ b/tests/observe/test_observe_stream_errors.py
@@ -1,0 +1,743 @@
+"""Tests for stream-capture wrappers when the underlying stream errors mid-way.
+
+When an SDK stream raises after yielding some chunks (overloaded, connection
+reset, server-sent ``error`` event), the capture wrapper should still emit
+whatever was accumulated, tagged with the exception, so the partial generation
+is recorded as a ``ModelEvent`` with ``error`` set rather than dropped.
+
+These are unit tests over the wrapper classes themselves (the narrowest public
+surface for this behaviour) using real SDK event/chunk/exception types. The
+end-to-end happy path is covered by ``test_observe_providers.py``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable, Iterator
+
+import httpx
+import pytest
+
+
+def _record_emit() -> tuple[list[dict[str, Any]], Callable[[dict[str, Any]], None]]:
+    """Return a (captures, emit) pair where emit appends to captures."""
+    captures: list[dict[str, Any]] = []
+    return captures, captures.append
+
+
+@dataclass
+class StreamErrorCase:
+    """One stream-wrapper variant under test."""
+
+    id: str
+    wrapper_cls: type
+    chunks: list[Any]
+    error: Exception
+    request: dict[str, Any]
+    verify_partial: Callable[[dict[str, Any]], None]
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic — create(stream=True) wrappers
+# --------------------------------------------------------------------------- #
+
+
+def _anthropic_text_chunks() -> list[Any]:
+    from anthropic.types import (
+        ContentBlockDeltaEvent,
+        ContentBlockStartEvent,
+        Message,
+        MessageStartEvent,
+        TextBlock,
+        TextDelta,
+        Usage,
+    )
+
+    return [
+        MessageStartEvent(
+            type="message_start",
+            message=Message(
+                id="msg_test",
+                type="message",
+                role="assistant",
+                model="claude-test",
+                content=[],
+                stop_reason=None,
+                stop_sequence=None,
+                usage=Usage(input_tokens=12, output_tokens=0),
+            ),
+        ),
+        ContentBlockStartEvent(
+            type="content_block_start",
+            index=0,
+            content_block=TextBlock(type="text", text=""),
+        ),
+        ContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=TextDelta(type="text_delta", text="Hello "),
+        ),
+        ContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=TextDelta(type="text_delta", text="wor"),
+        ),
+    ]
+
+
+def _anthropic_error() -> Exception:
+    import anthropic
+
+    return anthropic.APIConnectionError(
+        message="overloaded_error", request=httpx.Request("POST", "http://test")
+    )
+
+
+def _verify_anthropic_partial(data: dict[str, Any]) -> None:
+    response = data["response"]
+    assert response["id"] == "msg_test"
+    assert response["model"] == "claude-test"
+    assert response["content"][0]["type"] == "text"
+    assert response["content"][0]["text"] == "Hello wor"
+    assert response["usage"]["input_tokens"] == 12
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI — Chat Completions wrappers
+# --------------------------------------------------------------------------- #
+
+
+def _openai_chat_chunks() -> list[Any]:
+    from openai.types.chat import ChatCompletionChunk
+    from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
+
+    return [
+        ChatCompletionChunk(
+            id="cmpl_test",
+            object="chat.completion.chunk",
+            created=0,
+            model="gpt-test",
+            choices=[
+                Choice(index=0, delta=ChoiceDelta(role="assistant", content="Hello "))
+            ],
+        ),
+        ChatCompletionChunk(
+            id="cmpl_test",
+            object="chat.completion.chunk",
+            created=0,
+            model="gpt-test",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="wor"))],
+        ),
+    ]
+
+
+def _openai_error() -> Exception:
+    import openai
+
+    return openai.APIConnectionError(
+        message="connection reset", request=httpx.Request("POST", "http://test")
+    )
+
+
+def _verify_openai_chat_partial(data: dict[str, Any]) -> None:
+    assert data["api"] == "completions"
+    response = data["response"]
+    assert response["id"] == "cmpl_test"
+    assert response["model"] == "gpt-test"
+    assert response["choices"][0]["message"]["content"] == "Hello wor"
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI — Responses API wrappers
+# --------------------------------------------------------------------------- #
+
+
+def _openai_responses_chunks() -> list[Any]:
+    from openai.types.responses import (
+        Response,
+        ResponseCreatedEvent,
+        ResponseTextDeltaEvent,
+    )
+
+    response_snapshot = Response(
+        id="resp_test",
+        object="response",
+        created_at=0,
+        model="gpt-test",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        status="in_progress",
+    )
+    return [
+        ResponseCreatedEvent(
+            type="response.created", sequence_number=0, response=response_snapshot
+        ),
+        ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            sequence_number=1,
+            content_index=0,
+            output_index=0,
+            item_id="item_0",
+            logprobs=[],
+            delta="Hello ",
+        ),
+    ]
+
+
+def _verify_openai_responses_partial(data: dict[str, Any]) -> None:
+    assert data["api"] == "responses"
+    # The Responses wrapper tracks the latest event-carried response snapshot,
+    # so on mid-stream error we should at least get the response.created one.
+    assert data["response"].id == "resp_test"
+    assert data["response"].status == "in_progress"
+
+
+# --------------------------------------------------------------------------- #
+# Google — generate_content_stream wrappers
+# --------------------------------------------------------------------------- #
+
+
+def _google_chunks() -> list[Any]:
+    from google.genai.types import Candidate, Content, GenerateContentResponse, Part
+
+    def chunk(text: str) -> GenerateContentResponse:
+        return GenerateContentResponse(
+            candidates=[
+                Candidate(
+                    index=0, content=Content(role="model", parts=[Part(text=text)])
+                )
+            ]
+        )
+
+    return [chunk("Hello "), chunk("wor")]
+
+
+def _google_error() -> Exception:
+    from google.genai.errors import ServerError
+
+    return ServerError(503, {"error": {"message": "overloaded"}})
+
+
+def _verify_google_partial(data: dict[str, Any]) -> None:
+    parts = data["accumulated_parts"][0]
+    assert "".join(p.text for p in parts) == "Hello wor"
+    assert data["response"] is not None  # last_chunk
+
+
+# --------------------------------------------------------------------------- #
+# Test tables
+# --------------------------------------------------------------------------- #
+
+
+def _sync_cases() -> list[StreamErrorCase]:
+    from inspect_scout._observe.providers.anthropic import AnthropicStreamCapture
+    from inspect_scout._observe.providers.google import GoogleStreamCapture
+    from inspect_scout._observe.providers.openai import (
+        OpenAIChatStreamCapture,
+        OpenAIResponsesStreamCapture,
+    )
+
+    return [
+        StreamErrorCase(
+            id="anthropic-create",
+            wrapper_cls=AnthropicStreamCapture,
+            chunks=_anthropic_text_chunks(),
+            error=_anthropic_error(),
+            request={"model": "claude-test", "messages": []},
+            verify_partial=_verify_anthropic_partial,
+        ),
+        StreamErrorCase(
+            id="openai-chat",
+            wrapper_cls=OpenAIChatStreamCapture,
+            chunks=_openai_chat_chunks(),
+            error=_openai_error(),
+            request={"model": "gpt-test", "messages": []},
+            verify_partial=_verify_openai_chat_partial,
+        ),
+        StreamErrorCase(
+            id="openai-responses",
+            wrapper_cls=OpenAIResponsesStreamCapture,
+            chunks=_openai_responses_chunks(),
+            error=_openai_error(),
+            request={"model": "gpt-test", "input": "hi"},
+            verify_partial=_verify_openai_responses_partial,
+        ),
+        StreamErrorCase(
+            id="google",
+            wrapper_cls=GoogleStreamCapture,
+            chunks=_google_chunks(),
+            error=_google_error(),
+            request={"model": "gemini-test", "contents": []},
+            verify_partial=_verify_google_partial,
+        ),
+    ]
+
+
+def _async_cases() -> list[StreamErrorCase]:
+    from inspect_scout._observe.providers.anthropic import AnthropicAsyncStreamCapture
+    from inspect_scout._observe.providers.google import GoogleAsyncStreamCapture
+    from inspect_scout._observe.providers.openai import (
+        OpenAIChatAsyncStreamCapture,
+        OpenAIResponsesAsyncStreamCapture,
+    )
+
+    return [
+        StreamErrorCase(
+            id="anthropic-create",
+            wrapper_cls=AnthropicAsyncStreamCapture,
+            chunks=_anthropic_text_chunks(),
+            error=_anthropic_error(),
+            request={"model": "claude-test", "messages": []},
+            verify_partial=_verify_anthropic_partial,
+        ),
+        StreamErrorCase(
+            id="openai-chat",
+            wrapper_cls=OpenAIChatAsyncStreamCapture,
+            chunks=_openai_chat_chunks(),
+            error=_openai_error(),
+            request={"model": "gpt-test", "messages": []},
+            verify_partial=_verify_openai_chat_partial,
+        ),
+        StreamErrorCase(
+            id="openai-responses",
+            wrapper_cls=OpenAIResponsesAsyncStreamCapture,
+            chunks=_openai_responses_chunks(),
+            error=_openai_error(),
+            request={"model": "gpt-test", "input": "hi"},
+            verify_partial=_verify_openai_responses_partial,
+        ),
+        StreamErrorCase(
+            id="google",
+            wrapper_cls=GoogleAsyncStreamCapture,
+            chunks=_google_chunks(),
+            error=_google_error(),
+            request={"model": "gemini-test", "contents": []},
+            verify_partial=_verify_google_partial,
+        ),
+    ]
+
+
+SYNC_CASES = _sync_cases()
+ASYNC_CASES = _async_cases()
+
+
+# --------------------------------------------------------------------------- #
+# Sync stream wrappers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("case", SYNC_CASES, ids=lambda c: c.id)
+def test_sync_stream_emits_partial_on_error(case: StreamErrorCase) -> None:
+    """A mid-stream exception still emits the accumulated partial response."""
+    captures, emit = _record_emit()
+
+    def failing_stream() -> Iterator[Any]:
+        yield from case.chunks
+        raise case.error
+
+    wrapper = case.wrapper_cls(failing_stream(), case.request, emit)
+
+    seen: list[Any] = []
+    with pytest.raises(type(case.error)):
+        for chunk in wrapper:
+            seen.append(chunk)
+
+    # Caller saw all pre-error chunks unchanged.
+    assert seen == case.chunks
+
+    # Exactly one capture, carrying request + partial response + error.
+    assert len(captures) == 1
+    data = captures[0]
+    assert data["request"] is case.request
+    assert data["error"] is case.error
+    case.verify_partial(data)
+
+
+@pytest.mark.parametrize("case", SYNC_CASES, ids=lambda c: c.id)
+def test_sync_stream_emits_once_on_success(case: StreamErrorCase) -> None:
+    """Clean completion still emits exactly once with no error key (regression)."""
+    captures, emit = _record_emit()
+
+    wrapper = case.wrapper_cls(iter(case.chunks), case.request, emit)
+    for _ in wrapper:
+        pass
+
+    assert len(captures) == 1
+    assert "error" not in captures[0]
+    assert captures[0]["request"] is case.request
+
+
+@pytest.mark.parametrize("case", SYNC_CASES, ids=lambda c: c.id)
+def test_sync_stream_emits_partial_on_consumer_break(case: StreamErrorCase) -> None:
+    """If the caller stops consuming early, the partial is still captured."""
+    captures, emit = _record_emit()
+
+    wrapper = case.wrapper_cls(iter(case.chunks), case.request, emit)
+    gen = iter(wrapper)
+    next(gen)
+    gen.close()
+
+    assert len(captures) == 1
+    assert "error" not in captures[0]
+
+
+# --------------------------------------------------------------------------- #
+# Async stream wrappers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ASYNC_CASES, ids=lambda c: c.id)
+async def test_async_stream_emits_partial_on_error(case: StreamErrorCase) -> None:
+    """A mid-stream exception still emits the accumulated partial response."""
+    captures, emit = _record_emit()
+
+    async def failing_stream() -> AsyncIterator[Any]:
+        for chunk in case.chunks:
+            yield chunk
+        raise case.error
+
+    wrapper = case.wrapper_cls(failing_stream(), case.request, emit)
+
+    seen: list[Any] = []
+    with pytest.raises(type(case.error)):
+        async for chunk in wrapper:
+            seen.append(chunk)
+
+    assert seen == case.chunks
+    assert len(captures) == 1
+    data = captures[0]
+    assert data["request"] is case.request
+    assert data["error"] is case.error
+    case.verify_partial(data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ASYNC_CASES, ids=lambda c: c.id)
+async def test_async_stream_emits_once_on_success(case: StreamErrorCase) -> None:
+    """Clean completion still emits exactly once with no error key (regression)."""
+    captures, emit = _record_emit()
+
+    async def stream() -> AsyncIterator[Any]:
+        for chunk in case.chunks:
+            yield chunk
+
+    wrapper = case.wrapper_cls(stream(), case.request, emit)
+    async for _ in wrapper:
+        pass
+
+    assert len(captures) == 1
+    assert "error" not in captures[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ASYNC_CASES, ids=lambda c: c.id)
+async def test_async_stream_emits_partial_on_consumer_break(
+    case: StreamErrorCase,
+) -> None:
+    """If the caller stops consuming early, the partial is still captured."""
+    captures, emit = _record_emit()
+
+    async def stream() -> AsyncIterator[Any]:
+        for chunk in case.chunks:
+            yield chunk
+
+    wrapper = case.wrapper_cls(stream(), case.request, emit)
+    agen = wrapper.__aiter__()
+    await agen.__anext__()
+    await agen.aclose()
+
+    assert len(captures) == 1
+    assert "error" not in captures[0]
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic .stream() manager wrappers
+# --------------------------------------------------------------------------- #
+
+
+class _FakeAnthropicMessageStream:
+    """Minimal stand-in for ``anthropic.lib.streaming.MessageStream``.
+
+    Only implements what ``AnthropicStreamManagerCaptureContext`` reads:
+    iteration, ``text_stream``, ``get_final_message()`` and the
+    ``current_message_snapshot`` property the SDK exposes for partial state.
+    """
+
+    def __init__(self, events: list[Any], error: Exception | None) -> None:
+        self._events = events
+        self._error = error
+        from anthropic.types import Message, Usage
+
+        self._snapshot = Message(
+            id="msg_test",
+            type="message",
+            role="assistant",
+            model="claude-test",
+            content=[],
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=12, output_tokens=0),
+        )
+
+    @property
+    def current_message_snapshot(self) -> Any:
+        return self._snapshot
+
+    def __iter__(self) -> Iterator[Any]:
+        for ev in self._events:
+            self._apply(ev)
+            yield ev
+        if self._error is not None:
+            raise self._error
+
+    @property
+    def text_stream(self) -> Iterator[str]:
+        for ev in self:
+            if getattr(ev, "type", None) == "content_block_delta":
+                yield ev.delta.text
+
+    def get_final_message(self) -> Any:
+        for _ in self:
+            pass
+        return self._snapshot
+
+    def _apply(self, ev: Any) -> None:
+        from anthropic.types import TextBlock
+
+        if getattr(ev, "type", None) == "content_block_start":
+            self._snapshot = self._snapshot.model_copy(
+                update={"content": [TextBlock(type="text", text="")]}
+            )
+        elif getattr(ev, "type", None) == "content_block_delta":
+            block = self._snapshot.content[0]
+            assert block.type == "text"
+            self._snapshot = self._snapshot.model_copy(
+                update={
+                    "content": [TextBlock(type="text", text=block.text + ev.delta.text)]
+                }
+            )
+
+
+class _FakeAnthropicAsyncMessageStream:
+    """Async variant of :class:`_FakeAnthropicMessageStream`."""
+
+    def __init__(self, events: list[Any], error: Exception | None) -> None:
+        self._sync = _FakeAnthropicMessageStream(events, error)
+
+    @property
+    def current_message_snapshot(self) -> Any:
+        return self._sync.current_message_snapshot
+
+    async def __aiter__(self) -> AsyncIterator[Any]:
+        for ev in self._sync:
+            yield ev
+
+    @property
+    def text_stream(self) -> AsyncIterator[str]:
+        async def _gen() -> AsyncIterator[str]:
+            for text in self._sync.text_stream:
+                yield text
+
+        return _gen()
+
+    async def get_final_message(self) -> Any:
+        async for _ in self:
+            pass
+        return self._sync.current_message_snapshot
+
+
+def _anthropic_manager_partial_text(data: dict[str, Any]) -> str:
+    msg = data["response"]
+    return "".join(b.text for b in msg.content if b.type == "text")
+
+
+@pytest.mark.parametrize("via", ["iter", "text_stream", "get_final_message"])
+def test_anthropic_sync_stream_manager_emits_partial_on_error(via: str) -> None:
+    """``messages.stream()`` (sync) emits the SDK snapshot on mid-stream error."""
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicStreamManagerCaptureContext,
+    )
+
+    captures, emit = _record_emit()
+    error = _anthropic_error()
+    inner = _FakeAnthropicMessageStream(_anthropic_text_chunks(), error)
+    ctx = AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+
+    with pytest.raises(type(error)):
+        if via == "iter":
+            for _ in ctx:
+                pass
+        elif via == "text_stream":
+            for _ in ctx.text_stream:
+                pass
+        else:
+            ctx.get_final_message()
+
+    assert len(captures) == 1
+    assert captures[0]["error"] is error
+    assert _anthropic_manager_partial_text(captures[0]) == "Hello wor"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("via", ["aiter", "text_stream", "get_final_message"])
+async def test_anthropic_async_stream_manager_emits_partial_on_error(via: str) -> None:
+    """``messages.stream()`` (async) emits the SDK snapshot on mid-stream error."""
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicAsyncStreamManagerCaptureContext,
+    )
+
+    captures, emit = _record_emit()
+    error = _anthropic_error()
+    inner = _FakeAnthropicAsyncMessageStream(_anthropic_text_chunks(), error)
+    ctx = AnthropicAsyncStreamManagerCaptureContext(
+        inner, {"model": "claude-test"}, emit
+    )
+
+    with pytest.raises(type(error)):
+        if via == "aiter":
+            async for _ in ctx:
+                pass
+        elif via == "text_stream":
+            async for _ in ctx.text_stream:
+                pass
+        else:
+            await ctx.get_final_message()
+
+    assert len(captures) == 1
+    assert captures[0]["error"] is error
+    assert _anthropic_manager_partial_text(captures[0]) == "Hello wor"
+
+
+def test_anthropic_sync_stream_manager_no_double_emit() -> None:
+    """Iterating then calling ``get_final_message()`` still emits once."""
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicStreamManagerCaptureContext,
+    )
+
+    captures, emit = _record_emit()
+    inner = _FakeAnthropicMessageStream(_anthropic_text_chunks(), error=None)
+    ctx = AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+
+    for _ in ctx:
+        pass
+    ctx.get_final_message()
+
+    assert len(captures) == 1
+    assert "error" not in captures[0]
+
+
+# --------------------------------------------------------------------------- #
+# build_event propagates the error key onto ModelEvent.error
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_anthropic_build_event_carries_error() -> None:
+    from inspect_ai.event import ModelEvent
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicProvider,
+        AnthropicStreamAccumulator,
+    )
+
+    acc = AnthropicStreamAccumulator()
+    for ev in _anthropic_text_chunks():
+        acc.accumulate_event(ev)
+
+    error = _anthropic_error()
+    event = await AnthropicProvider().build_event(
+        {
+            "request": {"model": "claude-test", "messages": []},
+            "response": acc.accumulated,
+            "error": error,
+        }
+    )
+    assert isinstance(event, ModelEvent)
+    assert event.error == repr(error)
+    assert event.output is not None
+
+
+def _openai_moderation_error() -> Exception:
+    """An ``APIError`` matching what the SDK raises for an SSE ``error`` event.
+
+    Mirrors the shape OpenAI sends when the streaming safety classifier fires
+    after content has already been emitted (``code='invalid_prompt'``).
+    """
+    import openai
+
+    err = openai.APIError(
+        "limited access for safety reasons",
+        request=httpx.Request("POST", "http://test"),
+        body={
+            "type": "invalid_request_error",
+            "code": "invalid_prompt",
+            "message": "limited access for safety reasons",
+            "param": None,
+        },
+    )
+    err.code = "invalid_prompt"
+    err.type = "invalid_request_error"
+    return err
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_factory, expected_stop",
+    [
+        (_openai_moderation_error, "content_filter"),
+        (_openai_error, "unknown"),
+    ],
+    ids=["content_filter", "connection_error"],
+)
+async def test_openai_build_event_carries_error(
+    error_factory: Callable[[], Exception], expected_stop: str
+) -> None:
+    from inspect_ai.event import ModelEvent
+    from inspect_scout._observe.providers.openai import (
+        OpenAIChatStreamAccumulator,
+        OpenAIProvider,
+    )
+
+    acc = OpenAIChatStreamAccumulator()
+    for chunk in _openai_chat_chunks():
+        acc.accumulate_chunk(chunk)
+
+    error = error_factory()
+    event = await OpenAIProvider().build_event(
+        {
+            "request": {"model": "gpt-test", "messages": []},
+            "response": acc.get_response(),
+            "api": "completions",
+            "error": error,
+        }
+    )
+    assert isinstance(event, ModelEvent)
+    assert event.error == repr(error)
+    # Partial response (no finish_reason chunk arrived) is still converted,
+    # with stop_reason inferred from the error where possible.
+    assert event.output.choices[0].message.text == "Hello wor"
+    assert event.output.choices[0].stop_reason == expected_stop
+
+
+@pytest.mark.asyncio
+async def test_google_build_event_carries_error() -> None:
+    from inspect_ai.event import ModelEvent
+    from inspect_scout._observe.providers.google import (
+        GoogleProvider,
+        GoogleStreamAccumulator,
+    )
+
+    acc = GoogleStreamAccumulator()
+    for chunk in _google_chunks():
+        acc.accumulate_chunk(chunk)
+
+    error = _google_error()
+    event = await GoogleProvider().build_event(
+        {
+            **acc.get_response_data({"model": "gemini-test", "contents": []}),
+            "error": error,
+        }
+    )
+    assert isinstance(event, ModelEvent)
+    assert event.error == repr(error)
+    assert event.output is not None


### PR DESCRIPTION
## Summary

The `@observe` stream-capture wrappers only call `emit()` after the
`for`/`async for` loop completes cleanly. If the SDK raises mid-stream
(overloaded, connection reset, or an SSE `error` event), the accumulated
partial output is dropped: the transcript records `error=str(exc)` but
no `ModelEvent` for that call.

This PR wraps every iteration path in `try/except Exception/finally` so
`emit()` always fires with `{request, response: <accumulated>, error: exc}`
and the exception re-raises unchanged. `build_event()` propagates the
`error` key onto `ModelEvent.error`.

## Coverage

All stream wrapper variants across the three SDK providers:

| Provider | Wrapper | Paths |
|---|---|---|
| anthropic | `Anthropic{,Async}StreamCapture` | `__iter__` / `__aiter__` |
| anthropic | `Anthropic{,Async}StreamManagerCaptureContext` | `__iter__` / `__aiter__` / `text_stream` / `get_final_message` |
| openai | `OpenAIChat{,Async}StreamCapture` | `__iter__` / `__aiter__` |
| openai | `OpenAIResponses{,Async}StreamCapture` | `__iter__` / `__aiter__` |
| google | `Google{,Async}StreamCapture` | `__iter__` / `__aiter__` |

(`InspectProvider` has no stream wrappers.)

## Additional changes needed for the partial to survive `build_event`

- **Anthropic `.stream()` manager wrappers** don't run their own
  accumulator; on error they now read the SDK's
  `current_message_snapshot` property.
- **OpenAI Responses** wrappers previously only captured
  `event.response` from `response.completed`/`response.incomplete`. On a
  mid-stream error those never arrive, so the wrapper now tracks the
  latest snapshot from any event carrying `.response`
  (`created`/`queued`/`in_progress`/`failed`/...).
- **OpenAI Chat** partials have `finish_reason=None`, which
  `ChatCompletion.model_validate` rejects. `_build_completions_event`
  now fills a placeholder for validation and sets the resulting
  `stop_reason='unknown'` (the placeholder is not persisted —
  `finish_reason` is read only by `as_stop_reason`, which is then
  overwritten).
- **OpenAI error → `stop_reason`**: when the captured error has
  `code ∈ {invalid_prompt, content_policy_violation, content_filter,
  cyber_policy}`, the unfinished choice's `stop_reason` is set to
  `'content_filter'` instead of `'unknown'`, mirroring
  `inspect_ai.model._openai.openai_handle_bad_request`.

## Behaviour change on early consumer exit

Because `finally` runs on `GeneratorExit`, a caller that `break`s out of
the stream early now also gets the partial captured (without an `error`
key). Previously this case emitted nothing.

## Tests

`tests/observe/test_observe_stream_errors.py` — table-driven over every
wrapper variant, using real SDK event/chunk/exception types (no HTTP
mocking). Covers: error mid-stream, clean completion (regression), early
consumer break, Anthropic `.stream()` manager via each entry point, and
`build_event` carrying `error` + `stop_reason` inference.