### PR TITLE
Clean up old TypeScript settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,9 +229,6 @@ scout.local.yaml
 
 /.luarc.json
 
-# node
-/src/inspect_scout/_view/www/node_modules
-
 # test data
 /examples/test-db
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,15 +10,6 @@
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[css]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
I cleaned up mentions typescript and css from VS Code settings.

I also removed `/src/inspect_scout/_view/www/node_modules` from `.gitignore` since that `www` path is no longer around.

I didn't see any prettier configs to remove!

fixes #364
