### PR TITLE
Fix scan_results_df crash on numeric resultsets with empty rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scan results: Fix `TypeError: int() argument must be ... not 'NAType'` raised by `_expand_resultset_rows` when aligning an all-NA pyarrow column to a non-nullable numpy numeric dtype. Falls back to object dtype when the target dtype cannot hold NA.
 - LLM Scanner: On timeline scans, reduce within-span chunks to one Result per span before wrapping in a resultset; custom reducers now fire on chunked spans (#431).
 - LLM Scanner: `ResultReducer.llm()` now uses the synthesizer's own reasoning as the reduced `Result.explanation`, instead of a `[Segment N]` concat of the per-chunk explanations. The synthesis prompt also instructs the model to preserve `[M1]`-style message citations so the reduced explanation stays traceable to the merged references.
 

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -588,8 +588,12 @@ def _expand_resultset_rows(df: pd.DataFrame) -> pd.DataFrame:
                 # Add column with correct dtype
                 df_aligned[col] = pd.Series(dtype=column_dtypes[col])
             elif df_aligned[col].isna().all() and col in column_dtypes:
-                # Column exists but is all-NA - ensure it has the right dtype
-                df_aligned[col] = df_aligned[col].astype(column_dtypes[col])
+                # All-NA pyarrow column → non-nullable numpy numeric fails on
+                # int(pd.NA); fall back to object so concat can handle it.
+                try:
+                    df_aligned[col] = df_aligned[col].astype(column_dtypes[col])
+                except (TypeError, ValueError):
+                    df_aligned[col] = df_aligned[col].astype(object)
 
         aligned_rows.append(df_aligned)
 

--- a/tests/test_resultset_expansion.py
+++ b/tests/test_resultset_expansion.py
@@ -1,10 +1,17 @@
 """Tests for resultset expansion in scan_results_df and scan_results_db."""
 
+import json
 import tempfile
 from pathlib import Path
 
+import pandas as pd
+import pyarrow as pa
 from inspect_scout import Result, Scanner, scan, scanner
-from inspect_scout._scanresults import scan_results_db, scan_results_df
+from inspect_scout._scanresults import (
+    _expand_resultset_rows,
+    scan_results_db,
+    scan_results_df,
+)
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
 
@@ -716,3 +723,40 @@ def test_duckdb_resultset_expansion_with_references() -> None:
         assert len(event_refs_3) == 2
 
         results_db.conn.close()
+
+
+def test_resultset_expansion_handles_pyarrow_all_na_with_numeric_target() -> None:
+    """Regression: numeric resultset + all-NA pyarrow column used to TypeError."""
+    str_dtype = pd.ArrowDtype(pa.large_string())
+    str_cols = [
+        "uuid",
+        "label",
+        "value",
+        "value_type",
+        "answer",
+        "explanation",
+        "metadata",
+        "validation_target",
+        "validation_result",
+        "scan_model_usage",
+    ]
+    na_template = {col: pd.NA for col in str_cols}
+    df = pd.DataFrame(
+        [
+            {
+                **na_template,
+                "value": json.dumps([{"label": "foo", "value": 0}]),
+                "value_type": "resultset",
+                "scan_total_tokens": 0,
+            },
+            {
+                **na_template,
+                "value_type": "boolean",
+                "scan_total_tokens": 0,
+            },
+        ]
+    ).astype({col: str_dtype for col in str_cols})
+
+    # Must not raise.
+    result = _expand_resultset_rows(df)
+    assert len(result) == 2


### PR DESCRIPTION
## Summary

`scan_results_df` (and any downstream consumer) crashes with `TypeError: int() argument must be ... not 'NAType'` when a scan combines a resultset whose values are numeric with at least one row whose pyarrow-backed `value` column is all-NA (e.g. a scanner that timed out, or a non-resultset row mixed in). The dtype-alignment loop picks `numpy.int64` as the target dtype from the numeric result, then tries to `astype()` the all-NA pyarrow array onto it, which routes through `to_numpy(na_value=pd.NA)` and explodes.

Fall back to `object` dtype when the target dtype can't represent NA. That matches the existing fallback used when a column is missing entirely from one of the dataframes, and lets the downstream `pd.concat` handle the values without further coercion.