### PR TITLE
Add span_tools() to extract ToolInfo from transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Transcript: Add `span_tools()` alongside `span_messages()` to extract the union of `ToolInfo` definitions (deduped by name, last-seen wins) from a `Timeline`/`TimelineSpan`/`list[Event]`. Useful for callers that replay or interrogate a recorded conversation and need to re-declare the tools that were in scope.
 - Scan results: Fix `TypeError: int() argument must be ... not 'NAType'` raised by `_expand_resultset_rows` when aligning an all-NA pyarrow column to a non-nullable numpy numeric dtype. Falls back to object dtype when the target dtype cannot hold NA.
 - LLM Scanner: On timeline scans, reduce within-span chunks to one Result per span before wrapping in a resultset; custom reducers now fire on chunked spans (#431).
 - LLM Scanner: `ResultReducer.llm()` now uses the synthesizer's own reasoning as the reduced `Result.explanation`, instead of a `[Segment N]` concat of the per-chunk explanations. The synthesis prompt also instructs the model to preserve `[M1]`-style message citations so the reduced explanation stays traceable to the merged references.

--- a/docs/reference/transcript.qmd
+++ b/docs/reference/transcript.qmd
@@ -34,6 +34,7 @@ reference: "inspect_scout"
 ### timeline_messages
 ### segment_messages
 ### span_messages
+### span_tools
 ### MessagesSegment
 ### TimelineMessages
 

--- a/src/inspect_scout/__init__.py
+++ b/src/inspect_scout/__init__.py
@@ -69,6 +69,7 @@ from ._transcript.messages import (
     MessagesSegment,
     segment_messages,
     span_messages,
+    span_tools,
     transcript_messages,
 )
 from ._transcript.sample_metadata import SampleMetadata
@@ -171,6 +172,7 @@ __all__ = [
     "message_numbering",
     "messages_as_str",
     "span_messages",
+    "span_tools",
     "segment_messages",
     "MessagesSegment",
     "transcript_messages",

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -21,6 +21,7 @@ from inspect_ai.event import (
 from inspect_ai.model import ChatMessage, Model, get_model
 from inspect_ai.model._chat_message import ChatMessageBase
 from inspect_ai.model._model_info import get_model_info
+from inspect_ai.tool import ToolInfo
 
 from inspect_scout._scanner.extract import MessagesAsStr
 
@@ -409,6 +410,51 @@ def span_messages(
         merged.extend(_segment_messages(current_model_events_merge[-1]))
 
     return merged
+
+
+def span_tools(source: Timeline | TimelineSpan | list[Event]) -> list[ToolInfo]:
+    """Extract the tool definitions that were in scope across a span.
+
+    Companion to ``span_messages()``: where that function reconstructs
+    the message history from ``ModelEvent`` inputs/outputs, this
+    function reconstructs the set of tools that were declared to the
+    model. Callers that want to continue or interrogate a recorded
+    conversation typically need both — the messages to replay and the
+    tool definitions to re-declare.
+
+    Iterates ``ModelEvent.tools`` across the source and returns the
+    union of ``ToolInfo`` definitions, deduplicated by name. When a
+    tool name appears more than once (e.g. tools added or redefined
+    mid-conversation), the last-seen definition wins.
+
+    Args:
+        source: A ``Timeline`` (extracts ``.root``), ``TimelineSpan``
+            (events extracted from its content), or a raw list of
+            events. Non-``ModelEvent`` events are ignored.
+
+    Returns:
+        Deduplicated list of ``ToolInfo`` in first-seen order, with
+        each entry holding the last-seen definition for that name.
+        Empty list if no ``ModelEvent`` declared any tools.
+    """
+    # Normalize Timeline to TimelineSpan
+    if isinstance(source, Timeline):
+        source = source.root
+
+    # Extract events from TimelineSpan if needed
+    if isinstance(source, TimelineSpan):
+        events = [
+            item.event for item in source.content if isinstance(item, TimelineEvent)
+        ]
+    else:
+        events = source
+
+    tools: dict[str, ToolInfo] = {}
+    for event in events:
+        if isinstance(event, ModelEvent):
+            for tool in event.tools:
+                tools[tool.name] = tool
+    return list(tools.values())
 
 
 def _segment_messages(model_event: ModelEvent) -> list[ChatMessage]:

--- a/tests/transcript/test_messages.py
+++ b/tests/transcript/test_messages.py
@@ -16,11 +16,13 @@ from inspect_ai.model import (
 )
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ChatCompletionChoice
+from inspect_ai.tool import ToolInfo
 from inspect_scout._scanner.extract import message_numbering
 from inspect_scout._transcript.messages import (
     MessagesSegment,
     segment_messages,
     span_messages,
+    span_tools,
     transcript_messages,
 )
 from inspect_scout._transcript.timeline import (
@@ -38,6 +40,7 @@ def _make_model_event(
     input: Sequence[ChatMessage],
     output_content: str = "response",
     uuid: str | None = None,
+    tools: list[ToolInfo] | None = None,
 ) -> ModelEvent:
     """Create a ModelEvent with the given input and output."""
     return ModelEvent(
@@ -45,7 +48,7 @@ def _make_model_event(
         timestamp=datetime(2024, 1, 1),
         model="test-model",
         input=list(input),
-        tools=[],
+        tools=tools or [],
         tool_choice="auto",
         config=GenerateConfig(),
         output=ModelOutput(
@@ -470,6 +473,50 @@ def test_span_messages_compaction_last_with_trim() -> None:
     assert result[0] is _asst1
     assert result[-1].text == "After"
     assert len(result) == 4  # a1, u2, u3, output
+
+
+# -- span_tools tests --
+
+
+def _tool(name: str, description: str = "") -> ToolInfo:
+    return ToolInfo(name=name, description=description or f"{name} tool")
+
+
+def test_span_tools_dedup_last_wins() -> None:
+    """Tools are deduped by name across ModelEvents, last definition wins."""
+    t_search_v1 = _tool("search", "v1")
+    t_search_v2 = _tool("search", "v2")
+    t_write = _tool("write")
+    events: list[Event] = [
+        _make_model_event(input=[_user1], tools=[t_search_v1]),
+        _make_tool_event(),  # ignored
+        _make_model_event(input=[_user2], tools=[t_search_v2, t_write]),
+    ]
+
+    result = span_tools(events)
+
+    assert [t.name for t in result] == ["search", "write"]
+    assert result[0].description == "v2"  # last-seen wins
+    assert result[1] is t_write
+
+
+def test_span_tools_from_timeline_span() -> None:
+    """Accepts TimelineSpan and extracts tools from its ModelEvents."""
+    t_bash = _tool("bash")
+    span = _make_timeline_span(
+        "Agent",
+        events=[_make_model_event(input=[_user1], tools=[t_bash])],
+    )
+
+    result = span_tools(span)
+
+    assert result == [t_bash]
+
+
+def test_span_tools_empty() -> None:
+    """No ModelEvents (or none with tools) → empty list."""
+    assert span_tools([]) == []
+    assert span_tools([_make_model_event(input=[_user1])]) == []
 
 
 # -- segment_messages tests --


### PR DESCRIPTION
## Summary
- Adds `span_tools(source: Timeline | TimelineSpan | list[Event]) -> list[ToolInfo]` next to `span_messages()` in `_transcript/messages.py`, exported from `inspect_scout`.
- Iterates `ModelEvent.tools` across the source and returns the union of tool definitions, deduped by name (last-seen wins, since tools can be added/redefined mid-conversation).
- Callers that replay or ask probe questions about a recorded conversation (e.g. needham probe-question evals, prefill continuation) need both the message history *and* the tool defs that were in scope. This replaces bespoke `tools_from_events` helpers downstream.

## Test plan
- [x] `uv run make check` (ruff + mypy)
- [x] `uv run pytest tests/transcript/test_messages.py -q` — 57 passed, including 3 new `span_tools` tests (dedup/last-wins, TimelineSpan input, empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)