### PR TITLE
(WIP) Fix orphan tool_use in structured_generate retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Structured generate: Warn model for orphan tool_use in structured_generate retry loop.
+
 ## 0.4.35 (16 May 2026)
 
 - LLM Scanner: `generate_answer()` and `structured_generate()` accept `context_tools` — additional `ToolInfo` definitions declared in the request but never invoked (`tool_choice` forces the answer tool for structured answers and is `"none"` for textual answers). This lets callers pass a `prompt` containing prior `tool_use` blocks (e.g. when asking a follow-up question about an existing transcript) without the API rejecting the request for referencing undeclared tools.

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -4,6 +4,7 @@ from typing import Any, Awaitable, Callable, Literal, cast, overload
 from inspect_ai._util._async import tg_collect
 from inspect_ai._util.content import ContentText
 from inspect_ai.model import (
+    CachePolicy,
     ChatMessage,
     ChatMessageUser,
     GenerateConfig,
@@ -49,6 +50,7 @@ def llm_scanner(
     preprocessor: MessagesPreprocessor[Transcript] | None = None,
     model: str | Model | None = None,
     model_role: str | None = None,
+    cache: bool | CachePolicy | None = None,
     retry_refusals: bool | int = 3,
     name: str | None = None,
     content: TranscriptContent | None = None,
@@ -72,6 +74,7 @@ def llm_scanner(
     preprocessor: MessagesPreprocessor[Transcript] | None = None,
     model: str | Model | None = None,
     model_role: str | None = None,
+    cache: bool | CachePolicy | None = None,
     retry_refusals: bool | int = 3,
     name: str | None = None,
     content: TranscriptContent | None = None,
@@ -95,6 +98,7 @@ def llm_scanner(
     preprocessor: MessagesPreprocessor[Transcript] | None = None,
     model: str | Model | None = None,
     model_role: str | None = None,
+    cache: bool | CachePolicy | None = None,
     retry_refusals: bool | int = 3,
     name: str | None = None,
     content: TranscriptContent | None = None,
@@ -154,6 +158,10 @@ def llm_scanner(
             When set, the model is resolved via ``get_model(model, role=model_role)``
             at scan time, allowing deferred role resolution when roles are not yet
             available at scanner construction time.
+        cache: Response caching policy for the judge model call. Pass
+            ``True`` for default caching, a :class:`CachePolicy` for explicit
+            expiry/scope, or ``None`` (default) for no caching. Threaded
+            through to ``model.generate()`` via ``GenerateConfig.cache``.
         retry_refusals: Retry model refusals. Pass an ``int`` for number of retries (defaults to 3). Pass ``False`` to not retry refusals. If the limit of refusals is exceeded then a ``RuntimeError`` is raised.
         name: Scanner name.
             Use this to assign a name when passing ``llm_scanner()`` directly to ``scan()`` rather than delegating to it from another scanner.
@@ -242,7 +250,7 @@ def llm_scanner(
                         ]
                     )
                 ]
-                call_config = GenerateConfig(cache_prompt=True)
+                call_config = GenerateConfig(cache_prompt=True, cache=cache)
             else:
                 prompt = await render_scanner_prompt(
                     template=resolved_template,
@@ -252,7 +260,9 @@ def llm_scanner(
                     question=question,
                     answer=resolved_answer,
                 )
-                call_config = None
+                call_config = (
+                    GenerateConfig(cache=cache) if cache is not None else None
+                )
             return await generate_answer(
                 prompt,
                 answer,

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -90,27 +90,17 @@ async def structured_generate(
         )
         messages.append(output.message)
 
-        # if there we no tool calls then we need to insert a user message to
-        # tell the model to keep going
-        if len(output.message.tool_calls or []) == 0:
-            messages.append(
-                ChatMessageUser(
-                    content=f"Please use the {answer_tool}() tool to report your answer."
-                )
-            )
-
-        # check for a call to the 'answer' tool
+        tool_calls = output.message.tool_calls or []
         answer_tool_call = next(
-            (
-                tool_call
-                for tool_call in (output.message.tool_calls or [])
-                if tool_call.function == answer_tool
-            ),
-            None,
+            (tc for tc in tool_calls if tc.function == answer_tool), None
         )
-        if answer_tool_call:
-            # execute the tool calls (this will take care of validating the
-            # answer tool parameters and providing feedback for invalid cases)
+
+        if tool_calls:
+            # execute every tool call so each tool_use is paired with a
+            # tool_result before we re-generate (otherwise the next API call
+            # is rejected with "tool_use ids were found without tool_result
+            # blocks immediately after"). this also validates the answer
+            # tool parameters and provides feedback for invalid cases.
             execute_messages, execute_output = await execute_tools(
                 messages=messages, tools=[answer_tooldef]
             )
@@ -118,14 +108,30 @@ async def structured_generate(
             if execute_output is not None:
                 output = execute_output
 
-            # exit if there was a successful call of the answer tool
-            if isinstance(messages[-1], ChatMessageTool):
-                tool_message = messages[-1]
-                if tool_message.error is None:
-                    # set the value to the object return by the model and break
+            # exit if the answer tool was called and executed without error
+            if answer_tool_call is not None:
+                answer_result = next(
+                    (
+                        m
+                        for m in execute_messages
+                        if isinstance(m, ChatMessageTool)
+                        and m.tool_call_id == answer_tool_call.id
+                    ),
+                    None,
+                )
+                if answer_result is not None and answer_result.error is None:
                     value = answer_tool_call.arguments
                     output.completion = to_json_str_safe(answer_tool_call.arguments)
                     break
+
+        # the model either made no tool calls or called the wrong tool —
+        # nudge it toward the answer tool before retrying
+        if answer_tool_call is None:
+            messages.append(
+                ChatMessageUser(
+                    content=f"Please use the {answer_tool}() tool to report your answer."
+                )
+            )
 
         # keep going
         attempts += 1

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -59,10 +59,17 @@ async def structured_generate(
 
     # create a dynamic tool definition for the answer tool
     # use module-level function to ensure picklability
+    answer_description = "Use this tool to submit your final answer."
+    if context_tools:
+        answer_description += (
+            f" This is the only tool you should call — the other tools "
+            f"are shown so you can interpret prior tool calls in the "
+            f"conversation, but they are not available to invoke here."
+        )
     answer_tooldef = ToolDef(
         tool=_answer_tool_impl,
         name=answer_tool,
-        description="Use this tool to submit your final answer.",
+        description=answer_description,
         parameters=ToolParams(
             type="object",
             properties=schema.properties or {},

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -20,12 +20,12 @@ from inspect_ai.model import (
     GenerateConfig,
     Model,
     ModelOutput,
+    execute_tools,
     get_model,
 )
 from inspect_ai.scorer import ValueToFloat
 from inspect_ai.tool import (
     Tool,
-    ToolCallError,
     ToolDef,
     ToolFunction,
     ToolInfo,
@@ -33,7 +33,6 @@ from inspect_ai.tool import (
     ToolSource,
 )
 from inspect_ai.util import JSONSchema
-from jsonschema import Draft7Validator
 from pydantic import BaseModel, Field, create_model
 
 from inspect_scout._llm_scanner.types import AnswerStructured
@@ -57,36 +56,42 @@ async def structured_generate(
     # resolve model
     model = get_model(model)
 
-    # the answer tool is a pure declaration — we never execute it, we just
-    # want the model to call it so we can read the arguments
-    answer_tool = answer_tool or "answer"
-    answer_info = ToolInfo(
+    # create a dynamic tool definition for the answer tool
+    # use module-level function to ensure picklability
+    answer_tooldef = ToolDef(
+        tool=_answer_tool_impl,
         name=answer_tool,
-        description=(
-            "Use this tool to submit your final answer. "
-            "This is the only tool you should call."
-        ),
+        description="Use this tool to submit your final answer.",
         parameters=ToolParams(
             type="object",
             properties=schema.properties or {},
             required=schema.required or [],
         ),
     )
-    validator = Draft7Validator(schema.model_dump(exclude_none=True))
+
+    # wrap each context tool in a stub that preserves name/description/schema
+    # but whose body just tells the model to call answer() instead. these are
+    # declarations the model needs to see for the input transcript to be
+    # API-valid; we never want them executed for real.
+    executable_tools: list[ToolDef | ToolSource] = [
+        *(_context_tool_stub(t, answer_tooldef.name) for t in context_tools),
+        answer_tooldef,
+    ]
 
     # setup initial values for messages and output (we will return these)
     value: dict[str, Any] | None = None
     messages = input.copy()
     output: ModelOutput
 
-    # generate until we get a valid answer() call (or run out of attempts)
+    # setup a generate loop that will run until a successful call to the
+    # answer tool is made
     attempts = 0
     while attempts < max_attempts:
         output = await generate_retry_refusals(
             model,
             input=messages,
-            tools=[*context_tools, answer_info],
-            tool_choice=ToolFunction(answer_tool),
+            tools=executable_tools,
+            tool_choice=ToolFunction(answer_tooldef.name),
             config=(config or GenerateConfig()).merge(
                 GenerateConfig(parallel_tool_calls=False)
             ),
@@ -94,53 +99,84 @@ async def structured_generate(
         )
         messages.append(output.message)
 
-        # Pair every tool_use with a tool_result so the conversation stays
-        # well-formed for the next API call. Validate answer() arguments
-        # inline against the schema; reject anything else. context_tools are
-        # declarations only (ToolInfo, no callable) — never executed.
-        valid_answer: dict[str, Any] | None = None
-        tool_calls = output.message.tool_calls or []
-        for tc in tool_calls:
-            error: ToolCallError | None
-            if tc.function != answer_tool:
-                error = ToolCallError(
-                    "unknown",
-                    f"'{tc.function}' is not callable here; "
-                    f"call {answer_tool}() to submit your answer.",
-                )
-            elif schema_errors := list(validator.iter_errors(tc.arguments)):
-                error = ToolCallError(
-                    "parsing", "; ".join(e.message for e in schema_errors)
-                )
-            else:
-                error = None
-                if valid_answer is None:
-                    valid_answer = tc.arguments
-            messages.append(
-                ChatMessageTool(
-                    tool_call_id=tc.id,
-                    function=tc.function,
-                    content="",
-                    error=error,
-                )
+        # execute every tool call so each tool_use is paired with a
+        # tool_result before the next generate. this validates answer()
+        # arguments against the schema, returns "not callable here" for
+        # context-tool stubs, and reports "not found" for hallucinated tools.
+        execute_messages, execute_output = await execute_tools(
+            messages=messages, tools=executable_tools
+        )
+        messages.extend(execute_messages)
+        if execute_output is not None:
+            output = execute_output
+
+        # check for a successful call to the 'answer' tool
+        answer_tool_call = next(
+            (
+                tool_call
+                for tool_call in (output.message.tool_calls or [])
+                if tool_call.function == answer_tool
+            ),
+            None,
+        )
+        if answer_tool_call:
+            answer_result = next(
+                (
+                    m
+                    for m in execute_messages
+                    if isinstance(m, ChatMessageTool)
+                    and m.tool_call_id == answer_tool_call.id
+                ),
+                None,
             )
+            if answer_result is not None and answer_result.error is None:
+                # set the value to the object returned by the model and break
+                value = answer_tool_call.arguments
+                output.completion = to_json_str_safe(answer_tool_call.arguments)
+                break
 
-        if valid_answer is not None:
-            value = valid_answer
-            output.completion = to_json_str_safe(valid_answer)
-            break
-
-        # no answer at all → nudge; otherwise the tool errors are the feedback
-        if not tool_calls:
+        # if there were no tool calls then we need to insert a user message to
+        # tell the model to keep going (otherwise the tool results above are
+        # the feedback)
+        if len(output.message.tool_calls or []) == 0:
             messages.append(
                 ChatMessageUser(
                     content=f"Please use the {answer_tool}() tool to report your answer."
                 )
             )
 
+        # keep going
         attempts += 1
 
+    # return results
     return value, messages, output
+
+
+def _context_tool_stub(
+    tool: Tool | ToolDef | ToolInfo | ToolSource, answer_tool: str
+) -> ToolDef | ToolSource:
+    """Clone a context tool's name/description/schema onto a non-callable stub.
+
+    The stub accepts any arguments and returns a string redirecting the model
+    to the answer tool, so ``execute_tools`` can pair the ``tool_use`` with a
+    ``tool_result`` without running anything real.
+    """
+    if isinstance(tool, ToolSource):
+        return tool
+    info = tool if isinstance(tool, (ToolDef, ToolInfo)) else ToolDef(tool)
+
+    async def stub(**kwargs: Any) -> str:
+        return (
+            f"'{info.name}' is not callable here — please respond using the "
+            f"{answer_tool}() tool."
+        )
+
+    return ToolDef(
+        tool=stub,
+        name=info.name,
+        description=info.description,
+        parameters=info.parameters,
+    )
 
 
 ST = TypeVar("ST", bound=BaseModel)
@@ -495,3 +531,13 @@ def augment_type_with_explanation(type: Type[ST]) -> Type[ST]:
     )
 
     return augmented_type  # type: ignore
+
+
+# Module-level tool function for picklability in multiprocessing
+async def _answer_tool_impl(**kwargs: Any) -> str:
+    """Implementation of the answer tool for structured generation.
+
+    This is defined at module level rather than as a local function
+    to ensure it can be pickled when using multiprocessing.
+    """
+    return ""

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -176,6 +176,7 @@ def _context_tool_stub(
         name=info.name,
         description=info.description,
         parameters=info.parameters,
+        options=info.options,
     )
 
 

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -20,7 +20,6 @@ from inspect_ai.model import (
     GenerateConfig,
     Model,
     ModelOutput,
-    execute_tools,
     get_model,
 )
 from inspect_ai.scorer import ValueToFloat
@@ -34,6 +33,7 @@ from inspect_ai.tool import (
     ToolSource,
 )
 from inspect_ai.util import JSONSchema
+from jsonschema import Draft7Validator
 from pydantic import BaseModel, Field, create_model
 
 from inspect_scout._llm_scanner.types import AnswerStructured
@@ -57,40 +57,36 @@ async def structured_generate(
     # resolve model
     model = get_model(model)
 
-    # create a dynamic tool definition for the answer tool
-    # use module-level function to ensure picklability
-    answer_description = "Use this tool to submit your final answer."
-    if context_tools:
-        answer_description += (
-            f" This is the only tool you should call — the other tools "
-            f"are shown so you can interpret prior tool calls in the "
-            f"conversation, but they are not available to invoke here."
-        )
-    answer_tooldef = ToolDef(
-        tool=_answer_tool_impl,
+    # the answer tool is a pure declaration — we never execute it, we just
+    # want the model to call it so we can read the arguments
+    answer_tool = answer_tool or "answer"
+    answer_info = ToolInfo(
         name=answer_tool,
-        description=answer_description,
+        description=(
+            "Use this tool to submit your final answer. "
+            "This is the only tool you should call."
+        ),
         parameters=ToolParams(
             type="object",
             properties=schema.properties or {},
             required=schema.required or [],
         ),
     )
+    validator = Draft7Validator(schema.model_dump(exclude_none=True))
 
     # setup initial values for messages and output (we will return these)
     value: dict[str, Any] | None = None
     messages = input.copy()
     output: ModelOutput
 
-    # setup a generate loop that will run until a successful call to the
-    # anwser tool is made
+    # generate until we get a valid answer() call (or run out of attempts)
     attempts = 0
     while attempts < max_attempts:
         output = await generate_retry_refusals(
             model,
             input=messages,
-            tools=[*context_tools, answer_tooldef],
-            tool_choice=ToolFunction(answer_tooldef.name),
+            tools=[*context_tools, answer_info],
+            tool_choice=ToolFunction(answer_tool),
             config=(config or GenerateConfig()).merge(
                 GenerateConfig(parallel_tool_calls=False)
             ),
@@ -98,53 +94,52 @@ async def structured_generate(
         )
         messages.append(output.message)
 
+        # Pair every tool_use with a tool_result so the conversation stays
+        # well-formed for the next API call. Validate answer() arguments
+        # inline against the schema; reject anything else. context_tools are
+        # declarations only (ToolInfo, no callable) — never executed.
+        valid_answer: dict[str, Any] | None = None
         tool_calls = output.message.tool_calls or []
-        answer_calls = [tc for tc in tool_calls if tc.function == answer_tool]
-        other_calls = [tc for tc in tool_calls if tc.function != answer_tool]
-
-        if len(answer_calls) == 1 and not other_calls:
-            # exactly one answer call — validate via execute_tools
-            execute_messages, execute_output = await execute_tools(
-                messages=messages, tools=[answer_tooldef]
-            )
-            messages.extend(execute_messages)
-            if execute_output is not None:
-                output = execute_output
-            answer_result = execute_messages[-1]
-            assert isinstance(answer_result, ChatMessageTool)
-            if answer_result.error is None:
-                value = answer_calls[0].arguments
-                output.completion = to_json_str_safe(answer_calls[0].arguments)
-                break
-        else:
-            # No tool calls, or wrong/extra tool(s). Pair every tool_use
-            # with a stub error result so the next API call isn't rejected
-            # with "tool_use ids were found without tool_result blocks
-            # immediately after". context_tools are declarations only
-            # (ToolInfo, no executable) — never try to run them.
-            for tc in tool_calls:
-                messages.append(
-                    ChatMessageTool(
-                        tool_call_id=tc.id,
-                        function=tc.function,
-                        content="",
-                        error=ToolCallError(
-                            "not_available",
-                            f"Tool '{tc.function}' is not available here — "
-                            f"respond using only a single {answer_tool}() call.",
-                        ),
-                    )
+        for tc in tool_calls:
+            error: ToolCallError | None
+            if tc.function != answer_tool:
+                error = ToolCallError(
+                    "unknown",
+                    f"'{tc.function}' is not callable here; "
+                    f"call {answer_tool}() to submit your answer.",
                 )
+            elif schema_errors := list(validator.iter_errors(tc.arguments)):
+                error = ToolCallError(
+                    "parsing", "; ".join(e.message for e in schema_errors)
+                )
+            else:
+                error = None
+                if valid_answer is None:
+                    valid_answer = tc.arguments
+            messages.append(
+                ChatMessageTool(
+                    tool_call_id=tc.id,
+                    function=tc.function,
+                    content="",
+                    error=error,
+                )
+            )
+
+        if valid_answer is not None:
+            value = valid_answer
+            output.completion = to_json_str_safe(valid_answer)
+            break
+
+        # no answer at all → nudge; otherwise the tool errors are the feedback
+        if not tool_calls:
             messages.append(
                 ChatMessageUser(
                     content=f"Please use the {answer_tool}() tool to report your answer."
                 )
             )
 
-        # keep going
         attempts += 1
 
-    # return resultd
     return value, messages, output
 
 
@@ -500,13 +495,3 @@ def augment_type_with_explanation(type: Type[ST]) -> Type[ST]:
     )
 
     return augmented_type  # type: ignore
-
-
-# Module-level tool function for picklability in multiprocessing
-async def _answer_tool_impl(**kwargs: Any) -> str:
-    """Implementation of the answer tool for structured generation.
-
-    This is defined at module level rather than as a local function
-    to ensure it can be pickled when using multiprocessing.
-    """
-    return ""

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -26,6 +26,7 @@ from inspect_ai.model import (
 from inspect_ai.scorer import ValueToFloat
 from inspect_ai.tool import (
     Tool,
+    ToolCallError,
     ToolDef,
     ToolFunction,
     ToolInfo,
@@ -91,42 +92,42 @@ async def structured_generate(
         messages.append(output.message)
 
         tool_calls = output.message.tool_calls or []
-        answer_tool_call = next(
-            (tc for tc in tool_calls if tc.function == answer_tool), None
-        )
+        answer_calls = [tc for tc in tool_calls if tc.function == answer_tool]
+        other_calls = [tc for tc in tool_calls if tc.function != answer_tool]
 
-        if tool_calls:
-            # execute every tool call so each tool_use is paired with a
-            # tool_result before we re-generate (otherwise the next API call
-            # is rejected with "tool_use ids were found without tool_result
-            # blocks immediately after"). this also validates the answer
-            # tool parameters and provides feedback for invalid cases.
+        if len(answer_calls) == 1 and not other_calls:
+            # exactly one answer call — validate via execute_tools
             execute_messages, execute_output = await execute_tools(
                 messages=messages, tools=[answer_tooldef]
             )
             messages.extend(execute_messages)
             if execute_output is not None:
                 output = execute_output
-
-            # exit if the answer tool was called and executed without error
-            if answer_tool_call is not None:
-                answer_result = next(
-                    (
-                        m
-                        for m in execute_messages
-                        if isinstance(m, ChatMessageTool)
-                        and m.tool_call_id == answer_tool_call.id
-                    ),
-                    None,
+            answer_result = execute_messages[-1]
+            assert isinstance(answer_result, ChatMessageTool)
+            if answer_result.error is None:
+                value = answer_calls[0].arguments
+                output.completion = to_json_str_safe(answer_calls[0].arguments)
+                break
+        else:
+            # No tool calls, or wrong/extra tool(s). Pair every tool_use
+            # with a stub error result so the next API call isn't rejected
+            # with "tool_use ids were found without tool_result blocks
+            # immediately after". context_tools are declarations only
+            # (ToolInfo, no executable) — never try to run them.
+            for tc in tool_calls:
+                messages.append(
+                    ChatMessageTool(
+                        tool_call_id=tc.id,
+                        function=tc.function,
+                        content="",
+                        error=ToolCallError(
+                            "not_available",
+                            f"Tool '{tc.function}' is not available here — "
+                            f"respond using only a single {answer_tool}() call.",
+                        ),
+                    )
                 )
-                if answer_result is not None and answer_result.error is None:
-                    value = answer_tool_call.arguments
-                    output.completion = to_json_str_safe(answer_tool_call.arguments)
-                    break
-
-        # the model either made no tool calls or called the wrong tool —
-        # nudge it toward the answer tool before retrying
-        if answer_tool_call is None:
             messages.append(
                 ChatMessageUser(
                     content=f"Please use the {answer_tool}() tool to report your answer."

--- a/tests/llm_scanner/test_structured_generate.py
+++ b/tests/llm_scanner/test_structured_generate.py
@@ -1,0 +1,146 @@
+"""Tests for structured_generate retry loop — message pairing across attempts.
+
+The retry loop appends the model's assistant message (which may carry
+``tool_use`` blocks) to the running conversation before deciding whether
+to break or retry. Every ``tool_use`` it appends MUST be followed by a
+matching ``tool_result`` before the next generate, otherwise the next
+API call is rejected with::
+
+    BadRequestError: messages.N: 'tool_use' ids were found without
+    'tool_result' blocks immediately after
+
+These tests drive ``structured_generate`` through its retry paths with a
+mocked generate and assert that the ``input`` passed to each subsequent
+generate is well-formed (every assistant tool_call has a following
+ChatMessageTool with the same ``tool_call_id``).
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageTool,
+    ModelOutput,
+)
+from inspect_ai.tool import ToolCall
+from inspect_ai.util import JSONSchema
+from inspect_scout._llm_scanner.structured import structured_generate
+
+
+def _assistant_tool_call(
+    call_id: str, function: str, arguments: dict[str, Any]
+) -> ModelOutput:
+    """ModelOutput whose message carries a single tool call."""
+    msg = ChatMessageAssistant(
+        content="",
+        tool_calls=[ToolCall(id=call_id, function=function, arguments=arguments)],
+    )
+    return ModelOutput.from_message(msg)
+
+
+class RecordingGenerate:
+    """Stand-in for ``generate_retry_refusals`` that snapshots ``input`` at
+    call time (the real list is mutated in place, so a plain mock would only
+    show the final state)."""
+
+    def __init__(self, outputs: list[ModelOutput]) -> None:
+        self._outputs = iter(outputs)
+        self.inputs: list[list[ChatMessage]] = []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> ModelOutput:
+        self.inputs.append(list(kwargs["input"]))
+        return next(self._outputs)
+
+
+def _assert_tool_calls_paired(messages: list[ChatMessage]) -> None:
+    """Every assistant tool_call must be immediately followed by ChatMessageTool(s)
+    that cover all of its tool_call_ids — the invariant the Anthropic API enforces.
+    """
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if isinstance(msg, ChatMessageAssistant) and msg.tool_calls:
+            want = {tc.id for tc in msg.tool_calls}
+            got: set[str] = set()
+            j = i + 1
+            while j < len(messages):
+                follow = messages[j]
+                if not isinstance(follow, ChatMessageTool):
+                    break
+                tcid = follow.tool_call_id
+                got.update(tcid if isinstance(tcid, list) else [tcid or ""])
+                j += 1
+            missing = want - got
+            assert not missing, (
+                f"orphan tool_use id(s) {missing} at messages[{i}] "
+                f"(roles: {[m.role for m in messages]})"
+            )
+            i = j
+        else:
+            i += 1
+
+
+SCHEMA = JSONSchema.model_validate(
+    {
+        "type": "object",
+        "properties": {
+            "explanation": {"type": "string", "description": "why"},
+            "score": {"type": "integer", "description": "the score"},
+        },
+        "required": ["explanation", "score"],
+    }
+)
+
+
+@pytest.mark.anyio
+async def test_structured_generate_retry_pairs_invalid_answer_call() -> None:
+    """First attempt: answer() called with bad args (validation error).
+    Second attempt: answer() called with good args.
+    The second generate must receive a conversation where the first
+    tool_use is paired with a tool_result.
+    """
+    gen = RecordingGenerate(
+        [
+            _assistant_tool_call("c1", "answer", {"explanation": "x"}),
+            _assistant_tool_call("c2", "answer", {"explanation": "x", "score": 5}),
+        ]
+    )
+    with patch(
+        "inspect_scout._llm_scanner.structured.generate_retry_refusals", new=gen
+    ):
+        value, messages, _ = await structured_generate(
+            input="rate this", schema=SCHEMA, model="mockllm/model"
+        )
+
+    assert len(gen.inputs) == 2
+    _assert_tool_calls_paired(gen.inputs[1])
+    _assert_tool_calls_paired(messages)
+    assert value == {"explanation": "x", "score": 5}
+
+
+@pytest.mark.anyio
+async def test_structured_generate_retry_pairs_non_answer_call() -> None:
+    """First attempt: model ignores tool_choice and calls some other tool.
+    The retry loop must still pair that tool_use with a tool_result before
+    re-generating, otherwise the next API call is rejected.
+    """
+    gen = RecordingGenerate(
+        [
+            _assistant_tool_call("c1", "lookup", {"q": "hello"}),
+            _assistant_tool_call("c2", "answer", {"explanation": "x", "score": 5}),
+        ]
+    )
+    with patch(
+        "inspect_scout._llm_scanner.structured.generate_retry_refusals", new=gen
+    ):
+        value, messages, _ = await structured_generate(
+            input="rate this", schema=SCHEMA, model="mockllm/model"
+        )
+
+    assert len(gen.inputs) == 2
+    _assert_tool_calls_paired(gen.inputs[1])
+    _assert_tool_calls_paired(messages)
+    assert value == {"explanation": "x", "score": 5}

--- a/tests/llm_scanner/test_structured_generate.py
+++ b/tests/llm_scanner/test_structured_generate.py
@@ -30,21 +30,22 @@ from inspect_ai.util import JSONSchema
 from inspect_scout._llm_scanner.structured import structured_generate
 
 
-def _assistant_tool_call(
-    call_id: str, function: str, arguments: dict[str, Any]
-) -> ModelOutput:
-    """ModelOutput whose message carries a single tool call."""
-    msg = ChatMessageAssistant(
-        content="",
-        tool_calls=[ToolCall(id=call_id, function=function, arguments=arguments)],
-    )
+def _assistant_with_calls(*calls: ToolCall) -> ModelOutput:
+    """ModelOutput whose assistant message carries ``calls`` (possibly none)."""
+    msg = ChatMessageAssistant(content="", tool_calls=list(calls) or None)
     return ModelOutput.from_message(msg)
 
 
+def _tc(call_id: str, function: str, arguments: dict[str, Any]) -> ToolCall:
+    return ToolCall(id=call_id, function=function, arguments=arguments)
+
+
 class RecordingGenerate:
-    """Stand-in for ``generate_retry_refusals`` that snapshots ``input`` at
-    call time (the real list is mutated in place, so a plain mock would only
-    show the final state)."""
+    """Stand-in for ``generate_retry_refusals`` that snapshots ``input`` per call.
+
+    The real list is mutated in place, so a plain mock would only show the
+    final state.
+    """
 
     def __init__(self, outputs: list[ModelOutput]) -> None:
         self._outputs = iter(outputs)
@@ -56,8 +57,9 @@ class RecordingGenerate:
 
 
 def _assert_tool_calls_paired(messages: list[ChatMessage]) -> None:
-    """Every assistant tool_call must be immediately followed by ChatMessageTool(s)
-    that cover all of its tool_call_ids — the invariant the Anthropic API enforces.
+    """Assert every assistant tool_call is followed by a matching ChatMessageTool.
+
+    This is the invariant the Anthropic API enforces on the next request.
     """
     i = 0
     while i < len(messages):
@@ -70,8 +72,7 @@ def _assert_tool_calls_paired(messages: list[ChatMessage]) -> None:
                 follow = messages[j]
                 if not isinstance(follow, ChatMessageTool):
                     break
-                tcid = follow.tool_call_id
-                got.update(tcid if isinstance(tcid, list) else [tcid or ""])
+                got.add(follow.tool_call_id or "")
                 j += 1
             missing = want - got
             assert not missing, (
@@ -81,6 +82,13 @@ def _assert_tool_calls_paired(messages: list[ChatMessage]) -> None:
             i = j
         else:
             i += 1
+
+
+def _tool_result(messages: list[ChatMessage], call_id: str) -> ChatMessageTool:
+    for m in messages:
+        if isinstance(m, ChatMessageTool) and m.tool_call_id == call_id:
+            return m
+    raise AssertionError(f"no tool result for {call_id}")
 
 
 SCHEMA = JSONSchema.model_validate(
@@ -94,53 +102,109 @@ SCHEMA = JSONSchema.model_validate(
     }
 )
 
+VALID = {"explanation": "x", "score": 5}
 
-@pytest.mark.anyio
-async def test_structured_generate_retry_pairs_invalid_answer_call() -> None:
-    """First attempt: answer() called with bad args (validation error).
-    Second attempt: answer() called with good args.
-    The second generate must receive a conversation where the first
-    tool_use is paired with a tool_result.
-    """
-    gen = RecordingGenerate(
-        [
-            _assistant_tool_call("c1", "answer", {"explanation": "x"}),
-            _assistant_tool_call("c2", "answer", {"explanation": "x", "score": 5}),
-        ]
-    )
+
+async def _run(
+    outputs: list[ModelOutput],
+) -> tuple[dict[str, Any] | None, list[ChatMessage], RecordingGenerate]:
+    gen = RecordingGenerate(outputs)
     with patch(
         "inspect_scout._llm_scanner.structured.generate_retry_refusals", new=gen
     ):
         value, messages, _ = await structured_generate(
             input="rate this", schema=SCHEMA, model="mockllm/model"
         )
-
-    assert len(gen.inputs) == 2
-    _assert_tool_calls_paired(gen.inputs[1])
+    # every conversation handed to generate, plus the final one, must be paired
+    for inp in gen.inputs:
+        _assert_tool_calls_paired(inp)
     _assert_tool_calls_paired(messages)
-    assert value == {"explanation": "x", "score": 5}
+    return value, messages, gen
 
 
 @pytest.mark.anyio
-async def test_structured_generate_retry_pairs_non_answer_call() -> None:
-    """First attempt: model ignores tool_choice and calls some other tool.
-    The retry loop must still pair that tool_use with a tool_result before
-    re-generating, otherwise the next API call is rejected.
-    """
-    gen = RecordingGenerate(
+async def test_valid_answer_first_try() -> None:
+    value, messages, gen = await _run(
+        [_assistant_with_calls(_tc("c1", "answer", VALID))]
+    )
+    assert len(gen.inputs) == 1
+    assert value == VALID
+    assert _tool_result(messages, "c1").error is None
+
+
+@pytest.mark.anyio
+async def test_invalid_answer_args_then_retry() -> None:
+    """answer() called with bad args → parsing error fed back, retry succeeds."""
+    value, messages, gen = await _run(
         [
-            _assistant_tool_call("c1", "lookup", {"q": "hello"}),
-            _assistant_tool_call("c2", "answer", {"explanation": "x", "score": 5}),
+            _assistant_with_calls(_tc("c1", "answer", {"explanation": "x"})),
+            _assistant_with_calls(_tc("c2", "answer", VALID)),
         ]
     )
-    with patch(
-        "inspect_scout._llm_scanner.structured.generate_retry_refusals", new=gen
-    ):
-        value, messages, _ = await structured_generate(
-            input="rate this", schema=SCHEMA, model="mockllm/model"
-        )
-
     assert len(gen.inputs) == 2
-    _assert_tool_calls_paired(gen.inputs[1])
-    _assert_tool_calls_paired(messages)
-    assert value == {"explanation": "x", "score": 5}
+    err = _tool_result(gen.inputs[1], "c1").error
+    assert err is not None and err.type == "parsing"
+    assert "score" in err.message
+    assert value == VALID
+
+
+@pytest.mark.anyio
+async def test_context_tool_call_then_retry() -> None:
+    """Model ignores tool_choice and calls a context tool → rejected, retry."""
+    value, messages, gen = await _run(
+        [
+            _assistant_with_calls(_tc("c1", "lookup", {"q": "hello"})),
+            _assistant_with_calls(_tc("c2", "answer", VALID)),
+        ]
+    )
+    assert len(gen.inputs) == 2
+    err = _tool_result(gen.inputs[1], "c1").error
+    assert err is not None and err.type == "unknown"
+    assert value == VALID
+
+
+@pytest.mark.anyio
+async def test_hallucinated_tool_then_retry() -> None:
+    """Model invents a tool name not in the tool list → same rejection path."""
+    value, _, gen = await _run(
+        [
+            _assistant_with_calls(_tc("c1", "made_up_tool", {})),
+            _assistant_with_calls(_tc("c2", "answer", VALID)),
+        ]
+    )
+    assert len(gen.inputs) == 2
+    err = _tool_result(gen.inputs[1], "c1").error
+    assert err is not None and err.type == "unknown"
+    assert "answer()" in err.message
+    assert value == VALID
+
+
+@pytest.mark.anyio
+async def test_answer_alongside_other_call_is_accepted() -> None:
+    """answer() + something else in one turn → accept the answer, stub the other."""
+    value, messages, gen = await _run(
+        [
+            _assistant_with_calls(
+                _tc("c1", "lookup", {"q": "hello"}),
+                _tc("c2", "answer", VALID),
+            )
+        ]
+    )
+    assert len(gen.inputs) == 1
+    assert value == VALID
+    assert _tool_result(messages, "c1").error is not None
+    assert _tool_result(messages, "c2").error is None
+
+
+@pytest.mark.anyio
+async def test_no_tool_call_then_retry() -> None:
+    """Model returns plain text → nudge with a user message, retry."""
+    value, _, gen = await _run(
+        [
+            _assistant_with_calls(),
+            _assistant_with_calls(_tc("c1", "answer", VALID)),
+        ]
+    )
+    assert len(gen.inputs) == 2
+    assert gen.inputs[1][-1].role == "user"
+    assert value == VALID

--- a/tests/llm_scanner/test_structured_generate.py
+++ b/tests/llm_scanner/test_structured_generate.py
@@ -25,7 +25,7 @@ from inspect_ai.model import (
     ChatMessageTool,
     ModelOutput,
 )
-from inspect_ai.tool import ToolCall
+from inspect_ai.tool import ToolCall, ToolInfo, ToolParams
 from inspect_ai.util import JSONSchema
 from inspect_scout._llm_scanner.structured import structured_generate
 
@@ -107,13 +107,17 @@ VALID = {"explanation": "x", "score": 5}
 
 async def _run(
     outputs: list[ModelOutput],
+    context_tools: list[ToolInfo] | None = None,
 ) -> tuple[dict[str, Any] | None, list[ChatMessage], RecordingGenerate]:
     gen = RecordingGenerate(outputs)
     with patch(
         "inspect_scout._llm_scanner.structured.generate_retry_refusals", new=gen
     ):
         value, messages, _ = await structured_generate(
-            input="rate this", schema=SCHEMA, model="mockllm/model"
+            input="rate this",
+            schema=SCHEMA,
+            context_tools=context_tools or [],
+            model="mockllm/model",
         )
     # every conversation handed to generate, plus the final one, must be paired
     for inp in gen.inputs:
@@ -150,22 +154,25 @@ async def test_invalid_answer_args_then_retry() -> None:
 
 @pytest.mark.anyio
 async def test_context_tool_call_then_retry() -> None:
-    """Model ignores tool_choice and calls a context tool → rejected, retry."""
+    """Model ignores tool_choice and calls a context tool → stub redirects, retry."""
+    lookup = ToolInfo(name="lookup", description="lookup", parameters=ToolParams())
     value, messages, gen = await _run(
         [
-            _assistant_with_calls(_tc("c1", "lookup", {"q": "hello"})),
+            _assistant_with_calls(_tc("c1", "lookup", {})),
             _assistant_with_calls(_tc("c2", "answer", VALID)),
-        ]
+        ],
+        context_tools=[lookup],
     )
     assert len(gen.inputs) == 2
-    err = _tool_result(gen.inputs[1], "c1").error
-    assert err is not None and err.type == "unknown"
+    result = _tool_result(gen.inputs[1], "c1")
+    assert result.error is None
+    assert "not callable here" in result.text and "answer()" in result.text
     assert value == VALID
 
 
 @pytest.mark.anyio
 async def test_hallucinated_tool_then_retry() -> None:
-    """Model invents a tool name not in the tool list → same rejection path."""
+    """Model invents a tool name not in the tool list → execute_tools rejects it."""
     value, _, gen = await _run(
         [
             _assistant_with_calls(_tc("c1", "made_up_tool", {})),
@@ -174,25 +181,27 @@ async def test_hallucinated_tool_then_retry() -> None:
     )
     assert len(gen.inputs) == 2
     err = _tool_result(gen.inputs[1], "c1").error
-    assert err is not None and err.type == "unknown"
-    assert "answer()" in err.message
+    assert err is not None and err.type == "parsing"
+    assert "made_up_tool" in err.message
     assert value == VALID
 
 
 @pytest.mark.anyio
 async def test_answer_alongside_other_call_is_accepted() -> None:
-    """answer() + something else in one turn → accept the answer, stub the other."""
+    """answer() + a context tool in one turn → accept the answer, stub the other."""
+    lookup = ToolInfo(name="lookup", description="lookup", parameters=ToolParams())
     value, messages, gen = await _run(
         [
             _assistant_with_calls(
-                _tc("c1", "lookup", {"q": "hello"}),
+                _tc("c1", "lookup", {}),
                 _tc("c2", "answer", VALID),
             )
-        ]
+        ],
+        context_tools=[lookup],
     )
     assert len(gen.inputs) == 1
     assert value == VALID
-    assert _tool_result(messages, "c1").error is not None
+    assert "not callable here" in _tool_result(messages, "c1").text
     assert _tool_result(messages, "c2").error is None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,16 +10,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P1W"
-
-[options.exclude-newer-package]
-inspect-petri = false
-inspect-ai = false
-inspect-scout = false
-inspect-swe = false
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,16 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+inspect-petri = false
+inspect-ai = false
+inspect-scout = false
+inspect-swe = false
+
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"


### PR DESCRIPTION
## Problem

`structured_generate` only ran `execute_tools` when the model called the `answer` tool. If the model called a *context* tool (declared only so the input transcript's existing `tool_use` blocks are valid) or returned an invalid `answer()` call, the retry loop appended feedback but left the `tool_use` block unanswered → API rejects the next turn with `tool_use ids were found without tool_result blocks immediately after`.

## Fix

Wrap each `context_tool` in a stub `ToolDef` that preserves its `name`/`description`/`parameters` but whose body returns `"'<name>' is not callable here — please respond using the answer() tool."`. Pass `[*stubs, answer_tooldef]` to both `generate` and `execute_tools`, and run `execute_tools` **unconditionally** every iteration. This pairs every `tool_use` with a `tool_result`:

- `answer()` with valid args → schema-validated by `execute_tools`, loop breaks
- `answer()` with invalid args → `execute_tools` emits a `parsing` `ToolCallError`, loop continues
- context tool → stub returns the redirect string, loop continues
- hallucinated tool → `execute_tools` emits `Tool X not found`, loop continues

No new validation code; reuses `execute_tools`' existing schema check + error paths.

## Tests

`tests/llm_scanner/test_structured_generate.py` (new): covers valid answer, invalid-args retry, context-tool call → redirect, hallucinated tool, no-tool-call nudge. 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
