### PR TITLE
Non-blocking S3 I/O on hot paths via `AsyncFilesystem`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fastapi>=0.128.1",
     "ijson>=3.2.0",
     "importlib-metadata",
-    "inspect-ai>=0.3.218",
+    "inspect-ai @ git+https://github.com/UKGovernmentBEIS/inspect_ai@main",
     "inspect-swe>=0.2.42",
     "jinja2>=3.0.0",
     "jsonlines>=3.0.0",

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -636,14 +636,20 @@ class FileRecorder(ScanRecorder):
                 )
             ]
 
-        async def _status(scan_dir: str) -> Status | None:
-            try:
-                return await FileRecorder.status(scan_dir)
-            except FileNotFoundError:
-                return None
-
-        results = await asyncio.gather(*(_status(d) for d in scan_dirs))
-        return [s for s in results if s is not None]
+        # Fetch in parallel; skip scans that no longer exist and propagate
+        # any other error. return_exceptions=True keeps one failure from
+        # cancelling its siblings.
+        results = await asyncio.gather(
+            *(FileRecorder.status(d) for d in scan_dirs), return_exceptions=True
+        )
+        scans: list[Status] = []
+        for r in results:
+            if isinstance(r, FileNotFoundError):
+                continue
+            if isinstance(r, BaseException):
+                raise r
+            scans.append(r)
+        return scans
 
 
 async def _compact_with_prior(

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -625,8 +625,12 @@ class FileRecorder(ScanRecorder):
     @staticmethod
     async def list(scans_location: str) -> list[Status]:
         async with AsyncFilesystem() as fs:
+            # iter_dirs yields URIs with a trailing slash; normalize via
+            # UPath.as_posix() to match the no-slash form used everywhere
+            # else (e.g. sync(), location()) so Status.location compares
+            # equal across code paths.
             scan_dirs = [
-                uri
+                UPath(uri).as_posix()
                 async for uri in fs.iter_dirs(
                     scans_location, "scan_id=*", recursive=True
                 )

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -1,4 +1,6 @@
+import asyncio
 import io
+import json
 import os
 import tempfile
 from collections.abc import Iterator, Mapping
@@ -104,11 +106,11 @@ class FileRecorder(ScanRecorder):
         scans_location: str,
     ) -> None:
         # create the scan dir
-        self._scan_dir = _ensure_scan_dir(UPath(scans_location), spec.scan_id)
+        self._scan_dir = await _ensure_scan_dir(UPath(scans_location), spec.scan_id)
         self._scanners_completed: list[str] = []
         # save the spec
         self._scan_spec = spec
-        self._write_scan_spec()
+        await self._write_scan_spec()
 
         # fresh start: clear any stale buffer state from a prior scan that
         # used the same scan_location (the buffer dir is deterministic per
@@ -123,7 +125,7 @@ class FileRecorder(ScanRecorder):
     async def snapshot_transcripts(self, snapshot: ScanTranscripts) -> None:
         assert self._scan_spec
         self._scan_spec.transcripts = snapshot
-        self._write_scan_spec()
+        await self._write_scan_spec()
 
     @override
     async def resume(
@@ -140,7 +142,7 @@ class FileRecorder(ScanRecorder):
         """
         self._scan_dir = UPath(scan_location)
         self._scan_fs = filesystem(self._scan_dir.as_posix())
-        self._scan_spec = _read_scan_spec(self._scan_dir)
+        self._scan_spec = await _read_scan_spec(self._scan_dir)
 
         self._seed_buffer_summary_from_scan_dir()
         # clear errors of transcripts that are about to be retried
@@ -166,7 +168,7 @@ class FileRecorder(ScanRecorder):
         """
         self._scan_dir = UPath(scan_location)
         self._scan_fs = filesystem(self._scan_dir.as_posix())
-        self._scan_spec = _read_scan_spec(self._scan_dir)
+        self._scan_spec = await _read_scan_spec(self._scan_dir)
 
         self._seed_buffer_summary_from_scan_dir()
         self._seed_buffer_errors_from_scan_dir()
@@ -260,16 +262,19 @@ class FileRecorder(ScanRecorder):
             )
         return self._scan_spec
 
-    def _write_scan_spec(self) -> None:
-        with file((self.scan_dir / SCAN_JSON).as_posix(), "w") as f:
-            f.write(to_json_str_safe(self._scan_spec))
+    async def _write_scan_spec(self) -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(
+                (self.scan_dir / SCAN_JSON).as_posix(),
+                to_json_str_safe(self._scan_spec).encode("utf-8"),
+            )
 
     @override
     @staticmethod
     async def sync(scan_location: str, complete: bool) -> Status:
         # get state
         scan_dir = UPath(scan_location)
-        scan_spec = _read_scan_spec(scan_dir)
+        scan_spec = await _read_scan_spec(scan_dir)
         scan_buffer_dir = RecorderBuffer.buffer_dir(scan_location)
 
         # write each scanner's compacted parquet. when a prior sync has
@@ -321,7 +326,10 @@ class FileRecorder(ScanRecorder):
     @staticmethod
     async def status(scan_location: str) -> Status:
         buffer_dir = RecorderBuffer.buffer_dir(scan_location)
-        spec = _read_scan_spec(UPath(scan_location))
+        spec = await _read_scan_spec(UPath(scan_location))
+
+        # Buffer dir is always local (see RecorderBuffer.buffer_dir); sync
+        # reads here are microseconds — acceptable on the loop.
         if buffer_dir.exists():
             return Status(
                 complete=False,
@@ -330,15 +338,20 @@ class FileRecorder(ScanRecorder):
                 summary=read_scan_summary(buffer_dir, spec),
                 errors=_read_scan_errors(buffer_dir),
             )
-        else:
-            summary = read_scan_summary(UPath(scan_location), spec)
-            return Status(
-                complete=summary.complete,
-                spec=spec,
-                location=scan_location,
-                summary=summary,
-                errors=_read_scan_errors(UPath(scan_location)),
-            )
+
+        # Scan dir may be remote; use async reads via AsyncFilesystem so
+        # the loop yields during S3 I/O.
+        scan_dir = UPath(scan_location)
+        async with AsyncFilesystem() as fs:
+            summary = await _async_read_scan_summary(fs, scan_dir, spec)
+            errors = await _async_read_scan_errors(fs, scan_dir)
+        return Status(
+            complete=summary.complete,
+            spec=spec,
+            location=scan_location,
+            summary=summary,
+            errors=errors,
+        )
 
     @override
     @staticmethod
@@ -502,12 +515,11 @@ class FileRecorder(ScanRecorder):
         status = await FileRecorder.status(scan_location)
 
         # enumerate the scanners
-        scanners = [
-            file.stem
-            for file in sorted(
-                UPath(scan_location, use_listings_cache=False).glob("*.parquet")
+        async with AsyncFilesystem() as fs:
+            parquet_uris = sorted(
+                [u async for u in fs.iter_files(scan_location, "*.parquet")]
             )
-        ]
+        scanners = [UPath(u).stem for u in parquet_uris]
 
         return _ScanResultsArrowFiles(
             status=status.complete,
@@ -533,7 +545,11 @@ class FileRecorder(ScanRecorder):
         if scanner is not None:
             scanner_names = [scanner]
         else:
-            scanner_names = [f.stem for f in sorted(scan_dir.glob("*.parquet"))]
+            async with AsyncFilesystem() as fs:
+                parquet_uris = sorted(
+                    [u async for u in fs.iter_files(scan_location, "*.parquet")]
+                )
+            scanner_names = [UPath(u).stem for u in parquet_uris]
 
         # Create lazy mapping with a loader that reads DataFrames on demand
         scanners = LazyScannerMapping(
@@ -559,18 +575,22 @@ class FileRecorder(ScanRecorder):
     ) -> ScanResultsDB:
         from upath import UPath
 
-        scan_dir = UPath(scan_location)
         status = await FileRecorder.status(scan_location)
 
         # Create in-memory DuckDB connection
         conn = duckdb.connect(":memory:")
 
         # Create views for each parquet file
-        for parquet_file in sorted(scan_dir.glob("*.parquet")):
+        async with AsyncFilesystem() as fs:
+            parquet_uris = sorted(
+                [u async for u in fs.iter_files(scan_location, "*.parquet")]
+            )
+        for parquet_uri in parquet_uris:
+            parquet_file = UPath(parquet_uri)
             scanner_name = parquet_file.stem
             # Create a view that references the parquet file
-            # Use absolute path to ensure it works regardless of working directory
-            abs_path = parquet_file.resolve().as_posix()
+            # iter_files already yields absolute URIs.
+            abs_path = parquet_file.as_posix()
 
             # Check if we need to expand resultsets
             if rows == "results" and _has_resultsets(conn, abs_path):
@@ -603,14 +623,22 @@ class FileRecorder(ScanRecorder):
     @override
     @staticmethod
     async def list(scans_location: str) -> list[Status]:
-        scans_dir = UPath(scans_location)
-        scans: list[Status] = []
-        for scan_dir in scans_dir.rglob("scan_id=*"):
+        async with AsyncFilesystem() as fs:
+            scan_dirs = [
+                uri
+                async for uri in fs.iter_dirs(
+                    scans_location, "scan_id=*", recursive=True
+                )
+            ]
+
+        async def _status(scan_dir: str) -> Status | None:
             try:
-                scans.append(await FileRecorder.status(scan_dir.as_posix()))
+                return await FileRecorder.status(scan_dir)
             except FileNotFoundError:
-                pass
-        return scans
+                return None
+
+        results = await asyncio.gather(*(_status(d) for d in scan_dirs))
+        return [s for s in results if s is not None]
 
 
 async def _compact_with_prior(
@@ -645,16 +673,34 @@ def _scanner_parquet_file(scan_dir: UPath, scanner: str) -> str:
     return (scan_dir / f"{scanner}.parquet").as_posix()
 
 
-def _read_scan_spec(scan_dir: UPath) -> ScanSpec:
+async def _read_scan_spec(scan_dir: UPath) -> ScanSpec:
     scan_json = scan_dir / SCAN_JSON
-    fs = filesystem(scan_dir.as_posix())
-    if not fs.exists(scan_json.as_posix()):
-        raise FileNotFoundError(
-            f"The specified directory '{scan_dir}' does not contain a scan."
-        )
+    async with AsyncFilesystem() as fs:
+        try:
+            data = await fs.read_file(scan_json.as_posix())
+        except Exception as e:
+            if _is_not_found(e):
+                raise FileNotFoundError(
+                    f"The specified directory '{scan_dir}' does not contain a scan."
+                ) from e
+            raise
+    return ScanSpec.model_validate_json(data)
 
-    with file(scan_json.as_posix(), "r") as f:
-        return ScanSpec.model_validate_json(f.read())
+
+def _is_not_found(e: BaseException) -> bool:
+    """True if the exception indicates a missing file (local or S3 404).
+
+    Duck-types ``botocore.exceptions.ClientError`` by inspecting the
+    ``.response`` attribute shape; avoids a hard dependency on the type.
+    """
+    if isinstance(e, FileNotFoundError):
+        return True
+    response = getattr(e, "response", None)
+    if isinstance(response, dict):
+        code = response.get("Error", {}).get("Code")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return True
+    return False
 
 
 def _read_scan_errors(scan_dir: UPath) -> list[Error]:
@@ -662,18 +708,49 @@ def _read_scan_errors(scan_dir: UPath) -> list[Error]:
     return read_scan_errors(str(scan_errors))
 
 
-def _find_scan_dir(scans_path: UPath, scan_id: str) -> UPath | None:
-    _ensure_scans_dir(scans_path)
-    for f in scans_path.glob(f"scan_id={scan_id}"):
-        if f.is_dir():
-            return f
+async def _async_read_scan_summary(
+    fs: AsyncFilesystem, scan_dir: UPath, spec: ScanSpec
+) -> Summary:
+    """Async counterpart to `read_scan_summary` for remote scan dirs."""
+    try:
+        data = await fs.read_file((scan_dir / SCAN_SUMMARY).as_posix())
+    except Exception as e:
+        if _is_not_found(e):
+            return Summary(complete=False, scanners=list(spec.scanners.keys()))
+        raise
+    text = data.decode().strip()
+    if text:
+        return Summary.model_validate_json(text)
+    return Summary(complete=False, scanners=list(spec.scanners.keys()))
 
+
+async def _async_read_scan_errors(fs: AsyncFilesystem, scan_dir: UPath) -> list[Error]:
+    """Async counterpart to `_read_scan_errors` for remote scan dirs."""
+    try:
+        data = await fs.read_file((scan_dir / SCAN_ERRORS).as_posix())
+    except Exception as e:
+        if _is_not_found(e):
+            return []
+        raise
+    errors: list[Error] = []
+    for line in data.decode().splitlines():
+        line = line.strip()
+        if line:
+            errors.append(Error(**json.loads(line)))
+    return errors
+
+
+async def _find_scan_dir(scans_path: UPath, scan_id: str) -> UPath | None:
+    _ensure_scans_dir(scans_path)
+    async with AsyncFilesystem() as fs:
+        async for uri in fs.iter_dirs(scans_path.as_posix(), f"scan_id={scan_id}"):
+            return UPath(uri)
     return None
 
 
-def _ensure_scan_dir(scans_path: UPath, scan_id: str) -> UPath:
+async def _ensure_scan_dir(scans_path: UPath, scan_id: str) -> UPath:
     # look for an existing scan dir
-    scan_dir = _find_scan_dir(scans_path, scan_id)
+    scan_dir = await _find_scan_dir(scans_path, scan_id)
 
     # if there is no scan_dir then create one
     if scan_dir is None:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -589,6 +589,7 @@ class FileRecorder(ScanRecorder):
             parquet_file = UPath(parquet_uri)
             scanner_name = parquet_file.stem
             # Create a view that references the parquet file
+            # Use absolute path to ensure it works regardless of working directory
             # iter_files already yields absolute URIs.
             abs_path = parquet_file.as_posix()
 
@@ -711,7 +712,18 @@ def _read_scan_errors(scan_dir: UPath) -> list[Error]:
 async def _async_read_scan_summary(
     fs: AsyncFilesystem, scan_dir: UPath, spec: ScanSpec
 ) -> Summary:
-    """Async counterpart to `read_scan_summary` for remote scan dirs."""
+    """Async counterpart to `read_scan_summary` for remote scan dirs.
+
+    The logic intentionally duplicates `read_scan_summary` rather than
+    delegating. We can't convert `read_scan_summary` itself to async
+    (it has sync callers — `RecorderBuffer.__init__`, `_sync_status_files`,
+    and the test suite), and we don't want to wrap it in
+    `anyio.to_thread.run_sync` because that puts sync fsspec calls inside
+    a thread, which interacts poorly with fsspec's internal loop-in-a-thread
+    + instance cache + adaptive retry behavior. So async callers that may be
+    reading from remote storage call this directly, and `AsyncFilesystem.read_file`
+    handles the async I/O natively.
+    """
     try:
         data = await fs.read_file((scan_dir / SCAN_SUMMARY).as_posix())
     except Exception as e:
@@ -725,7 +737,13 @@ async def _async_read_scan_summary(
 
 
 async def _async_read_scan_errors(fs: AsyncFilesystem, scan_dir: UPath) -> list[Error]:
-    """Async counterpart to `_read_scan_errors` for remote scan dirs."""
+    """Async counterpart to `_read_scan_errors` for remote scan dirs.
+
+    Duplicates the parsing logic intentionally — see
+    `_async_read_scan_summary` for the reasoning. In short: the sync
+    helpers must stay sync for their sync callers, and we don't put
+    sync fsspec inside `to_thread`.
+    """
     try:
         data = await fs.read_file((scan_dir / SCAN_ERRORS).as_posix())
     except Exception as e:

--- a/src/inspect_scout/_transcript/database/parquet/index.py
+++ b/src/inspect_scout/_transcript/database/parquet/index.py
@@ -16,7 +16,6 @@ The discovery priority ensures concurrent operations work correctly:
 3. If no manifest exists, use all `index_*.idx` files
 """
 
-import glob
 import os
 import re
 import tempfile
@@ -28,10 +27,10 @@ import duckdb
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
+from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import filesystem
 from inspect_ai.util import trace_message
 from shortuuid import uuid
-from upath import UPath
 
 from ..schema import CONTENT_COLUMNS
 from .index_cache import get_index_cache_path, load_cached_index, save_index_cache
@@ -381,21 +380,14 @@ async def _discover_index_files(storage: IndexStorage) -> list[str]:
     """
     index_dir = storage.index_dir_path()
 
-    if storage.is_remote():
-        # Remote storage: use filesystem listing
-        fs = filesystem(storage.location)
+    async with AsyncFilesystem() as fs:
         try:
-            all_files = fs.ls(index_dir, recursive=False)
+            all_idx_files = [
+                uri async for uri in fs.iter_files(index_dir, "*" + INDEX_EXTENSION)
+            ]
         except FileNotFoundError:
             # Index directory doesn't exist yet
             return []
-        all_idx_files = [f.name for f in all_files if _is_index_file(f.name)]
-    else:
-        # Local storage: use glob
-        index_path = UPath(index_dir)
-        if not index_path.exists():
-            return []
-        all_idx_files = [str(p) for p in index_path.glob("*" + INDEX_EXTENSION)]
 
     if not all_idx_files:
         return []
@@ -441,18 +433,13 @@ async def _list_all_index_files(storage: IndexStorage) -> list[str]:
     """
     index_dir = storage.index_dir_path()
 
-    if storage.is_remote():
-        fs = filesystem(storage.location)
+    async with AsyncFilesystem() as fs:
         try:
-            all_files = fs.ls(index_dir, recursive=False)
+            return [
+                uri async for uri in fs.iter_files(index_dir, "*" + INDEX_EXTENSION)
+            ]
         except FileNotFoundError:
             return []
-        return [f.name for f in all_files if _is_index_file(f.name)]
-    else:
-        index_path = UPath(index_dir)
-        if not index_path.exists():
-            return []
-        return [str(p) for p in index_path.glob("*" + INDEX_EXTENSION)]
 
 
 async def _discover_data_files(storage: IndexStorage) -> list[str]:
@@ -464,25 +451,17 @@ async def _discover_data_files(storage: IndexStorage) -> list[str]:
     Returns:
         List of data file paths.
     """
-    if storage.is_remote():
-        fs = filesystem(storage.location)
-        all_files = fs.ls(storage.location, recursive=True)
-        return [
-            f.name
-            for f in all_files
-            if f.name.endswith(".parquet") and f"/{INDEX_DIR}/" not in f.name
-        ]
-    else:
-        location_path = UPath(storage.location)
-        if not location_path.exists():
+    async with AsyncFilesystem() as fs:
+        try:
+            return [
+                uri
+                async for uri in fs.iter_files(
+                    storage.location, "*.parquet", recursive=True
+                )
+                if f"/{INDEX_DIR}/" not in uri and f"\\{INDEX_DIR}\\" not in uri
+            ]
+        except FileNotFoundError:
             return []
-
-        all_parquet = glob.glob(str(location_path / "**" / "*.parquet"), recursive=True)
-        return [
-            p
-            for p in all_parquet
-            if f"/{INDEX_DIR}/" not in p and f"\\{INDEX_DIR}\\" not in p
-        ]
 
 
 def _write_parquet_table(

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -1793,29 +1793,20 @@ class ParquetTranscriptsDB(TranscriptsDB):
             List of file paths (local or S3 URIs).
         """
         assert self._location is not None
-        if self._is_s3() or self._is_hf():
-            assert self._fs is not None
-
-            # List all files recursively (returns list of FileInfo objects)
-            fs = filesystem(self._location)
-            all_files = fs.ls(self._location, recursive=True)
-            # Filter for transcript parquet files
-            files = []
-            for f in all_files:
-                name = f.name
-                if name.endswith(".parquet"):
-                    files.append(name)
-            return files
-        else:
-            location_path = UPath(self._location)
-            if not location_path.exists():
-                location_path.mkdir(parents=True, exist_ok=True)
+        async with AsyncFilesystem() as fs:
+            try:
+                return [
+                    uri
+                    async for uri in fs.iter_files(
+                        self._location, PARQUET_TRANSCRIPTS_GLOB, recursive=True
+                    )
+                ]
+            except FileNotFoundError:
+                # On local fs only, create the directory so subsequent writes
+                # can proceed.
+                if not (self._is_s3() or self._is_hf()):
+                    UPath(self._location).mkdir(parents=True, exist_ok=True)
                 return []
-
-            # Recursively discover all transcript parquet files
-            return [
-                str(p) for p in location_path.glob(f"**/{PARQUET_TRANSCRIPTS_GLOB}")
-            ]
 
     def _have_transcript(self, transcript_id: str) -> bool:
         return transcript_id in (self._transcript_ids or set())
@@ -2013,27 +2004,18 @@ class ParquetTranscriptsDB(TranscriptsDB):
         assert self._location is not None
 
         # Pattern to match: transcripts_{session_id}_*.parquet
-        session_pattern = f"transcripts_{session_id}_"
+        pattern = f"transcripts_{session_id}_*.parquet"
 
-        if self._is_s3() or self._is_hf():
-            assert self._fs is not None
-            fs = filesystem(self._location)
-            all_files = fs.ls(self._location, recursive=True)
-            return [
-                f.name
-                for f in all_files
-                if f.name.endswith(".parquet")
-                and Path(f.name).name.startswith(session_pattern)
-            ]
-        else:
-            location_path = UPath(self._location)
-            if not location_path.exists():
+        async with AsyncFilesystem() as fs:
+            try:
+                return [
+                    uri
+                    async for uri in fs.iter_files(
+                        self._location, pattern, recursive=True
+                    )
+                ]
+            except FileNotFoundError:
                 return []
-
-            # Glob for session files
-            return [
-                str(p) for p in location_path.glob(f"**/{session_pattern}*.parquet")
-            ]
 
     def _as_async_iterator(
         self,

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -1793,20 +1793,24 @@ class ParquetTranscriptsDB(TranscriptsDB):
             List of file paths (local or S3 URIs).
         """
         assert self._location is not None
-        async with AsyncFilesystem() as fs:
-            try:
-                return [
-                    uri
-                    async for uri in fs.iter_files(
-                        self._location, PARQUET_TRANSCRIPTS_GLOB, recursive=True
-                    )
-                ]
-            except FileNotFoundError:
-                # On local fs only, create the directory so subsequent writes
-                # can proceed.
-                if not (self._is_s3() or self._is_hf()):
-                    UPath(self._location).mkdir(parents=True, exist_ok=True)
+
+        # For local backends, if the location doesn't yet exist, create
+        # it (so subsequent writes succeed) and short-circuit to an empty
+        # result. Remote backends (S3/HF) don't get this treatment: we
+        # don't pre-create remote dirs, and listing errors propagate.
+        if not (self._is_s3() or self._is_hf()):
+            location_path = UPath(self._location)
+            if not location_path.exists():
+                location_path.mkdir(parents=True, exist_ok=True)
                 return []
+
+        async with AsyncFilesystem() as fs:
+            return [
+                uri
+                async for uri in fs.iter_files(
+                    self._location, PARQUET_TRANSCRIPTS_GLOB, recursive=True
+                )
+            ]
 
     def _have_transcript(self, transcript_id: str) -> bool:
         return transcript_id in (self._transcript_ids or set())
@@ -2006,16 +2010,19 @@ class ParquetTranscriptsDB(TranscriptsDB):
         # Pattern to match: transcripts_{session_id}_*.parquet
         pattern = f"transcripts_{session_id}_*.parquet"
 
-        async with AsyncFilesystem() as fs:
-            try:
-                return [
-                    uri
-                    async for uri in fs.iter_files(
-                        self._location, pattern, recursive=True
-                    )
-                ]
-            except FileNotFoundError:
+        # For local backends, short-circuit when the location doesn't
+        # exist (matches origin/main's behavior — no mkdir here, just
+        # an empty result). Remote backends just list; listing errors
+        # propagate.
+        if not (self._is_s3() or self._is_hf()):
+            if not UPath(self._location).exists():
                 return []
+
+        async with AsyncFilesystem() as fs:
+            return [
+                uri
+                async for uri in fs.iter_files(self._location, pattern, recursive=True)
+            ]
 
     def _as_async_iterator(
         self,

--- a/src/inspect_scout/_transcript/local_files_cache.py
+++ b/src/inspect_scout/_transcript/local_files_cache.py
@@ -102,21 +102,7 @@ class LocalFilesCache:
 
 async def _download_file(fs: AsyncFilesystem, uri: str, dest_path: Path) -> None:
     """Download remote file to local path."""
-    # The streaming approach is leaking something that causes aiobotocore to raise
-    # errors on shutdown. Though harmless, it's disconcerting.
-    #
-    # TODO: We'll continue trying to get to the bottom of it, but we'll revert to
-    # fsspec.get_file for now.
-    use_streaming = False
-
-    if use_streaming:
-        file_size = await fs.get_size(uri)
-        async with await fs.read_file_bytes(uri, 0, file_size) as stream:
-            with open(dest_path, "wb") as f:
-                async for chunk in stream:
-                    f.write(chunk)
-    else:
-        filesystem(uri).get_file(uri, dest_path.as_posix())
+    await fs.get_file(uri, dest_path.as_posix())
 
 
 def _try_create_marker(marker_file: Path) -> bool:

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 from pathlib import Path
@@ -156,7 +157,13 @@ def view_server(
                 f"======== Running on {url} ========\n(Press CTRL+C to quit)"
             )
 
-        async with event_loop_monitor(), anyio.create_task_group() as tg:
+        monitor = (
+            event_loop_monitor()
+            if os.getenv("SCOUT_EVENT_LOOP_MONITOR", "false").lower()
+            in ("true", "1", "yes")
+            else contextlib.nullcontext()
+        )
+        async with monitor, anyio.create_task_group() as tg:
             tg.start_soon(announce_when_ready)
             await server.serve()
 

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import os
 from pathlib import Path

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -127,6 +127,25 @@ def view_server(
         v2_api.add_middleware(AuthorizationMiddleware, authorization=authorization)
 
     app = FastAPI(lifespan=notify_lifespan)
+
+    if os.getenv("SCOUT_VIEW_EVENT_LOOP_MONITOR", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    ):
+
+        async def log_and_monitor(
+            request: Request, call_next: RequestResponseEndpoint
+        ) -> Response:
+            method, path = request.method, request.url.path
+            print(f"-> {method} {path}", flush=True)
+            async with event_loop_monitor():
+                response = await call_next(request)
+            print(f"<- {method} {path} {response.status_code}", flush=True)
+            return response
+
+        app.middleware("http")(log_and_monitor)
+
     app.mount("/api/v2", v2_api)
 
     app.mount(
@@ -157,13 +176,7 @@ def view_server(
                 f"======== Running on {url} ========\n(Press CTRL+C to quit)"
             )
 
-        monitor = (
-            event_loop_monitor()
-            if os.getenv("SCOUT_VIEW_EVENT_LOOP_MONITOR", "false").lower()
-            in ("true", "1", "yes")
-            else contextlib.nullcontext()
-        )
-        async with monitor, anyio.create_task_group() as tg:
+        async with anyio.create_task_group() as tg:
             tg.start_soon(announce_when_ready)
             await server.serve()
 

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -159,7 +159,7 @@ def view_server(
 
         monitor = (
             event_loop_monitor()
-            if os.getenv("SCOUT_EVENT_LOOP_MONITOR", "false").lower()
+            if os.getenv("SCOUT_VIEW_EVENT_LOOP_MONITOR", "false").lower()
             in ("true", "1", "yes")
             else contextlib.nullcontext()
         )

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -9,6 +9,7 @@ import uvicorn
 from fastapi import FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 from inspect_ai._lfs import LFSError, resolve_lfs_directory
+from inspect_ai._util.event_loop_monitor import event_loop_monitor
 from inspect_ai._util.file import filesystem
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import HTMLResponse
@@ -155,7 +156,7 @@ def view_server(
                 f"======== Running on {url} ========\n(Press CTRL+C to quit)"
             )
 
-        async with anyio.create_task_group() as tg:
+        async with event_loop_monitor(), anyio.create_task_group() as tg:
             tg.start_soon(announce_when_ready)
             await server.serve()
 


### PR DESCRIPTION
## Summary

Removes sync fsspec / `UPath` I/O from the asyncio event loop in scout's hot paths. Symptoms addressed: UI thread starved during S3 transcript downloads, Ctrl-C ignored on the view server, ~2-minute scans-panel load for 48 scans (now ~11s).

Depends on companion API additions in inspect_ai: `AsyncFilesystem.get_file`, `iter_files`, `iter_dirs`. `pyproject.toml` is temporarily pinned to `inspect-ai @ git+main`

## Changes

**Recorder I/O via `AsyncFilesystem`:**
- `_read_scan_spec`, `_write_scan_spec`, `_find_scan_dir`, `_ensure_scan_dir` converted to async via `AsyncFilesystem.read_file` / `write_file` / `iter_dirs`.
- New `_async_read_scan_summary` / `_async_read_scan_errors` — async siblings of the existing sync helpers (the sync versions stay because they still have sync callers).
- `_is_not_found` helper translates botocore `ClientError` 404s alongside `FileNotFoundError`.
- `FileRecorder.list` parallelized via `asyncio.gather(return_exceptions=True)`; recursive scan-dir lookup via `iter_dirs(recursive=True)`. Missing scans are skipped, any other error propagates.
- `FileRecorder.status` uses async helpers for scan-dir reads (possibly remote); buffer-dir reads stay sync (buffer is always local).
- `results_arrow`, `results_df`, `results_db`: parquet enumeration via `iter_files`.

**Transcript cache:**
- `local_files_cache._download_file` reduced to a single `AsyncFilesystem.get_file` call.

**Parquet backends:**
- `parquet/index.py`: `_discover_index_files`, `_list_all_index_files`, `_discover_data_files` unified onto `iter_files`; drops remote-vs-local branching and the stdlib `glob.glob` walk.
- `parquet/transcripts.py`: `_discover_parquet_files`, `_list_session_files` unified onto `iter_files`. Local backends still short-circuit on missing path (with `mkdir` for `_discover_parquet_files`); remote backends list and propagate listing errors.

**View server diagnostic (opt-in):**
- `_view/server.py`: when `SCOUT_VIEW_EVENT_LOOP_MONITOR` is set, wraps each HTTP request in `event_loop_monitor()` and logs entry/exit. Off by default.