### PR TITLE
Fix multi-process reader leak on scan shutdown

### DIFF
--- a/src/inspect_scout/_concurrency/_mp_common.py
+++ b/src/inspect_scout/_concurrency/_mp_common.py
@@ -28,12 +28,19 @@ from typing_extensions import TypeVarTuple, Unpack
 
 if TYPE_CHECKING:
     from .._scanner.result import ResultReport
+    from .._transcript.transcripts import TranscriptsReader
     from .._transcript.types import TranscriptInfo
     from ._mp_semaphore import PicklableMPSemaphore
 
     # TODO: This import from .common needs to be within a TYPE_CHECKING check since
     # it creates a circular dependency. We should fix this.
-    from .common import ParseFunctionResult, ParseJob, ScanMetrics, ScannerJob
+    from .common import (
+        ParseFunctionResult,
+        ParseJob,
+        ReaderCMFactory,
+        ScanMetrics,
+        ScannerJob,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -198,14 +205,16 @@ class IPCContext:
     from workers to the main process.
     """
 
-    parse_function: Callable[[ParseJob], Awaitable[ParseFunctionResult]]
+    parse_function: Callable[
+        [ParseJob, TranscriptsReader], Awaitable[ParseFunctionResult]
+    ]
     """Function that executes a parse job yielding scanner jobs."""
 
     scan_function: Callable[[ScannerJob], Awaitable[list[ResultReport]]]
     """Function that executes a scanner job and returns results."""
 
-    completed: Callable[[], Awaitable[None]]
-    """Function to indicate the stragegy is complete."""
+    reader_cm_factory: ReaderCMFactory
+    """Factory that yields a context-managed `TranscriptsReader` for this worker."""
 
     prefetch_multiple: float | None
     """Multiplier for scanner job queue size (base=task_count)."""

--- a/src/inspect_scout/_concurrency/_mp_subprocess.py
+++ b/src/inspect_scout/_concurrency/_mp_subprocess.py
@@ -136,7 +136,7 @@ def subprocess_main(
                             parse_function=ipc_ctx.parse_function,
                             scan_function=ipc_ctx.scan_function,
                             update_metrics=_update_worker_metrics,
-                            completed=ipc_ctx.completed,
+                            reader_cm_factory=ipc_ctx.reader_cm_factory,
                         )
                         print_diagnostics("Worker main", "All tasks completed normally")
                     except Exception as ex:

--- a/src/inspect_scout/_concurrency/common.py
+++ b/src/inspect_scout/_concurrency/common.py
@@ -3,6 +3,7 @@ from functools import reduce
 from typing import (
     AbstractSet,
     Any,
+    AsyncContextManager,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -14,6 +15,7 @@ from typing import (
 
 from .._scanner.result import ResultReport
 from .._scanner.scanner import Scanner
+from .._transcript.transcripts import TranscriptsReader
 from .._transcript.types import Transcript, TranscriptInfo
 
 
@@ -104,6 +106,16 @@ affected scanner — parse failure is recorded as an error per scanner.
 """
 
 
+ReaderCMFactory = Callable[[], AsyncContextManager[TranscriptsReader]]
+"""Factory that yields a context-managed `TranscriptsReader`.
+
+The strategy opens the CM once at startup and passes the resulting reader
+to each ``parse_function`` call. In single-process mode the factory yields
+an already-open reader (no-close wrapper); in multi-process mode each
+worker creates its own.
+"""
+
+
 class ConcurrencyStrategy(Protocol):
     """Callable strategy interface (Strategy Pattern) for executing scanner work.
 
@@ -118,11 +130,13 @@ class ConcurrencyStrategy(Protocol):
         self,
         *,
         parse_jobs: AsyncIterator[ParseJob],
-        parse_function: Callable[[ParseJob], Awaitable[ParseFunctionResult]],
+        parse_function: Callable[
+            [ParseJob, TranscriptsReader], Awaitable[ParseFunctionResult]
+        ],
         scan_function: Callable[[ScannerJob], Awaitable[list[ResultReport]]],
         record_results: Callable[
             [TranscriptInfo, str, list[ResultReport]], Awaitable[None]
         ],
         update_metrics: Callable[[ScanMetrics], None],
-        completed: Callable[[], Awaitable[None]],
+        reader_cm_factory: ReaderCMFactory,
     ) -> None: ...

--- a/src/inspect_scout/_concurrency/multi_process.py
+++ b/src/inspect_scout/_concurrency/multi_process.py
@@ -36,6 +36,7 @@ from inspect_ai.util._concurrency import init_concurrency
 from inspect_scout._display._display import display
 
 from .._scanner.result import ResultReport
+from .._transcript.transcripts import TranscriptsReader
 from .._transcript.types import TranscriptInfo
 from ._mp_common import (
     DillCallable,
@@ -58,6 +59,7 @@ from .common import (
     ConcurrencyStrategy,
     ParseFunctionResult,
     ParseJob,
+    ReaderCMFactory,
     ScanMetrics,
     ScannerJob,
     sum_metrics,
@@ -129,10 +131,12 @@ def multi_process_strategy(
             [TranscriptInfo, str, list[ResultReport]], Awaitable[None]
         ],
         parse_jobs: AsyncIterator[ParseJob],
-        parse_function: Callable[[ParseJob], Awaitable[ParseFunctionResult]],
+        parse_function: Callable[
+            [ParseJob, TranscriptsReader], Awaitable[ParseFunctionResult]
+        ],
         scan_function: Callable[[ScannerJob], Awaitable[list[ResultReport]]],
         update_metrics: Callable[[ScanMetrics], None] | None = None,
-        completed: Callable[[], Awaitable[None]],
+        reader_cm_factory: ReaderCMFactory,
     ) -> None:
         all_metrics: dict[int, ScanMetrics] = {}
 
@@ -167,7 +171,7 @@ def multi_process_strategy(
             ipc_ctx = IPCContext(
                 parse_function=DillCallable(parse_function),
                 scan_function=DillCallable(scan_function),
-                completed=DillCallable(completed),
+                reader_cm_factory=DillCallable(reader_cm_factory),
                 prefetch_multiple=prefetch_multiple,
                 diagnostics=diagnostics,
                 overall_start_time=time.time(),

--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -15,12 +15,14 @@ from inspect_ai.util._anyio import inner_exception
 
 from .._display import display
 from .._scanner.result import ResultReport
+from .._transcript.transcripts import TranscriptsReader
 from .._transcript.types import TranscriptInfo
 from ._iterator import SerializedAsyncIterator
 from .common import (
     ConcurrencyStrategy,
     ParseFunctionResult,
     ParseJob,
+    ReaderCMFactory,
     ScanMetrics,
     ScannerJob,
 )
@@ -84,10 +86,12 @@ def single_process_strategy(
             [TranscriptInfo, str, list[ResultReport]], Awaitable[None]
         ],
         parse_jobs: AsyncIterator[ParseJob],
-        parse_function: Callable[[ParseJob], Awaitable[ParseFunctionResult]],
+        parse_function: Callable[
+            [ParseJob, TranscriptsReader], Awaitable[ParseFunctionResult]
+        ],
         scan_function: Callable[[ScannerJob], Awaitable[list[ResultReport]]],
         update_metrics: Callable[[ScanMetrics], None] | None = None,
-        completed: Callable[[], Awaitable[None]],
+        reader_cm_factory: ReaderCMFactory,
     ) -> None:
         metrics = ScanMetrics(1)
         nonlocal overall_start_time
@@ -194,7 +198,7 @@ def single_process_strategy(
             metrics.tasks_idle -= 1
             return 1.0 if current_wait_duration == 0 else 1.0
 
-        async def _perform_parse(worker_id: int) -> bool:
+        async def _perform_parse(worker_id: int, reader: TranscriptsReader) -> bool:
             """Perform the parse action. Returns True if parse job was pulled from the queue, False if there was no parse job to perform."""
             # Pull from parse_jobs iterator and create scanner jobs
             try:
@@ -207,7 +211,7 @@ def single_process_strategy(
             _update_metrics()
 
             try:
-                result = await parse_function(parse_job)
+                result = await parse_function(parse_job, reader)
                 print_diagnostics(
                     f"Worker #{worker_id:02d}",
                     f"Parsed  ({(time.time() - exec_start_time):.3f}s) - ('{parse_job.transcript_info.transcript_id}')",
@@ -266,6 +270,7 @@ def single_process_strategy(
 
         async def _worker_task(
             worker_id: int,
+            reader: TranscriptsReader,
         ) -> None:
             """Worker that dynamically chooses between parsing and scanning."""
             nonlocal parse_jobs_exhausted
@@ -281,7 +286,7 @@ def single_process_strategy(
                         wait_duration = await _perform_wait(wait_duration)
                     elif action == "parse":
                         wait_duration = 0.0
-                        if await _perform_parse(worker_id):
+                        if await _perform_parse(worker_id, reader):
                             parses_completed += 1
                         else:
                             print_diagnostics(
@@ -317,18 +322,21 @@ def single_process_strategy(
                     _update_metrics()
 
         try:
-            async with create_task_group() as tg:
-                ticker_scope = anyio.CancelScope()
-                tg.start_soon(_metrics_ticker, ticker_scope)
+            async with reader_cm_factory() as reader:
+                async with create_task_group() as tg:
+                    ticker_scope = anyio.CancelScope()
+                    tg.start_soon(_metrics_ticker, ticker_scope)
 
-                # Spawn initial workers for faster ramp-up
-                global worker_id_counter
-                async with create_task_group() as worker_tg:
-                    for _ in range(task_count):
-                        worker_id_counter += 1
-                        metrics.task_count += 1
-                        worker_tg.start_soon(_worker_task, worker_id_counter)
-                ticker_scope.cancel()
+                    # Spawn initial workers for faster ramp-up
+                    global worker_id_counter
+                    async with create_task_group() as worker_tg:
+                        for _ in range(task_count):
+                            worker_id_counter += 1
+                            metrics.task_count += 1
+                            worker_tg.start_soon(
+                                _worker_task, worker_id_counter, reader
+                            )
+                    ticker_scope.cancel()
 
         except Exception as ex:
             raise inner_exception(ex) from None
@@ -339,6 +347,5 @@ def single_process_strategy(
             metrics.tasks_scanning = 0
             metrics.tasks_idle = 0
             _update_metrics()
-            await completed()
 
     return the_func

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -1,6 +1,7 @@
 import json
 import os
 import traceback
+from contextlib import asynccontextmanager
 from logging import getLogger
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping, Sequence, cast
@@ -577,23 +578,10 @@ async def _scan_async_inner(
                 # create metrics accumulator
                 metrics_accum = metrics_accumulators(scan.scanners)
 
-                async def _transcripts_reader() -> TranscriptsReader:
-                    global _process_transcripts_reader
-                    if _process_transcripts_reader is None:
-                        _process_transcripts_reader = await transcripts.reader(
-                            snapshot
-                        ).__aenter__()
-                    return _process_transcripts_reader
-
-                async def _strategy_completed() -> None:
-                    global _process_transcripts_reader
-                    if _process_transcripts_reader is not None:
-                        await _process_transcripts_reader.__aexit__(None, None, None)
-                        _process_transcripts_reader = None
-
-                async def _parse_function(job: ParseJob) -> ParseFunctionResult:
+                async def _parse_function(
+                    job: ParseJob, reader: TranscriptsReader
+                ) -> ParseFunctionResult:
                     try:
-                        reader = await _transcripts_reader()
                         union_transcript = await reader.read(
                             job.transcript_info, union_content
                         )
@@ -668,11 +656,21 @@ async def _scan_async_inner(
                     )
                 )
 
-                # if we are single process then re-use the tr we are holding
-                # (otherwise this will be initialized on demand in children)
+                # Build a reader CM factory that the strategy will open exactly
+                # once. In single-process mode, reuse the parent's already-open
+                # reader (no-close wrapper). In multi-process mode, each worker
+                # opens its own from the snapshot.
                 if single_process:
-                    global _process_transcripts_reader
-                    _process_transcripts_reader = tr
+
+                    @asynccontextmanager
+                    async def _reader_cm_factory() -> AsyncIterator[TranscriptsReader]:
+                        yield tr
+                else:
+
+                    @asynccontextmanager
+                    async def _reader_cm_factory() -> AsyncIterator[TranscriptsReader]:
+                        async with transcripts.reader(snapshot) as worker_reader:
+                            yield worker_reader
 
                 def accumulate_metrics(
                     scanner: str, results: Sequence[ResultReport]
@@ -714,7 +712,7 @@ async def _scan_async_inner(
                             scan_function=_scan_function,
                             record_results=record_results,
                             update_metrics=update_metrics,
-                            completed=_strategy_completed,
+                            reader_cm_factory=_reader_cm_factory,
                         )
 
                         # we've been throttle metrics calculation, now report it all
@@ -1211,7 +1209,3 @@ async def _validate_scan(
                 )
     else:
         return None
-
-
-# initialized on demand in child processes
-_process_transcripts_reader: TranscriptsReader | None = None


### PR DESCRIPTION
## Problem
In multi-process scans, the `TranscriptsReader` opened per worker (and its underlying aiobotocore client) was never closed on shutdown, leaking the client and its connections.

Root cause: the old design lazy-set a `_process_transcripts_reader` module global from inside the cloudpickled `parse_function`, and `_strategy_completed` read that same global to close the reader. But in workers each `cloudpickle.loads` produced a function with its own isolated `__globals__` snapshot — so `parse_function`'s writes to the global were never visible to `_strategy_completed`. The close path silently saw `None` and did nothing.

## Fix
Thread the reader through the strategy instead of via a module global:
- New `reader_cm_factory` strategy parameter. The strategy opens the CM exactly once and passes the resulting reader to each `parse_function` call.
- Single-process: factory is a no-close wrapper around the parent's already-open reader.
- Multi-process: each worker's factory opens its own `transcripts.reader(snapshot)`; `__aexit__` runs when the worker's task group finishes, closing the aiobotocore client per worker.
- Removes the now-unused `completed` strategy hook and the `_process_transcripts_reader` module global.

Reader lifecycle is now local to the strategy frame — no shared state crossing cloudpickle.