### PR TITLE
Fix npm publish workflow (Node 22 self-upgrade fails)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: src/inspect_scout/_view/ts-mono/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -48,8 +50,10 @@ jobs:
 
       - name: Upgrade npm (for Trusted Publishing)
         run: |
-          npm i -g npm@^11.5.1
-          npm --version
+          # Install via prefix to avoid npm self-upgrade rebuild bug on Node 22.
+          npm install --prefix "$RUNNER_TEMP/npm-upgrade" --no-audit --no-fund npm@^11.5.1
+          echo "$RUNNER_TEMP/npm-upgrade/node_modules/.bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/npm-upgrade/node_modules/.bin/npm" --version
 
       - name: Install dependencies
         working-directory: src/inspect_scout/_view/ts-mono

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,7 +63,9 @@ jobs:
         run: |
           npm pkg set name="@meridianlabs/inspect-scout-viewer"
           npm pkg delete private
-          npm version from-git --no-git-tag-version
+          # Version tags live on the parent repo; the submodule has none.
+          VERSION=$(git -C ${{ github.workspace }} describe --tags --abbrev=0 --match='[0-9]*.[0-9]*.[0-9]*')
+          npm version "$VERSION" --no-git-tag-version
 
       - name: Bump to prerelease version
         if: ${{ inputs.prerelease }}


### PR DESCRIPTION
## Summary
- `pnpm/action-setup@v4` couldn't resolve the pnpm version because the workspace `package.json` lives in the submodule; pass `package_json_file` so it picks up the right file.
- `npm i -g npm@^11.5.1` (added so the publish step can use Trusted Publishing) crashes on Node 22 with `Cannot find module 'promise-retry'` — the new npm tarball overwrites the live npm's `node_modules` before arborist's rebuild phase resolves its requires. Install npm@11 into a scratch prefix instead and prepend its bin to `$GITHUB_PATH`, so the global npm is never touched.

Mirrors the fix landed in [inspect_ai#3991](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3991).

## Test plan
- [x] Trigger this workflow via `workflow_dispatch` against this branch with `dry-run: true` and confirm `Upgrade npm (for Trusted Publishing)` and `Publish to NPM (dry-run)` both succeed.
- [ ] After merge, next tagged release publishes without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)