### PR TITLE
fix: serialize metadata flds with pydantic_core.to_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 - Structured generate: Warn model for orphan tool_use in structured_generate retry loop.
 - Enumerate all CSV, YAML, and JSON files when looking for validation sets (don't skip gitignored files).
 - Support custom role labels for transcript message rendering.
+- Scout View: Refine scanner result header and All Scores dialog
 - Bugfix: Stop doing blocking S3 file I/O on hot paths.
 - Bugfix: Resolve nested schema references for `AnswerStructured`.
 - Bugfix: `llm_scanner` now reserves tokens for the rendered scanner template when sizing segments, so long templates no longer push the prompt past `context_window`.
-- Scout View: Refine scanner result header and All Scores dialog
+- Bugfix: Serialize metadata flds with pydantic_core.to_json
 
 ## 0.4.35 (16 May 2026)
 

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 from dataclasses import dataclass
@@ -15,6 +14,7 @@ from inspect_ai._util.file import file
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai.scorer import value_to_float
 from pydantic import JsonValue
+from pydantic_core import to_json
 from upath import UPath
 
 from inspect_scout._recorder.summary import Summary
@@ -524,7 +524,7 @@ def _normalize_scalar(v: Any) -> Any:
         return v.to_json_string()
     # Decimal, lists, dicts, sets, tuples -> JSON text if possible
     try:
-        return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+        return to_json(v, fallback=str).decode("utf-8")
     except Exception:
         return str(v)
 

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -20,6 +20,7 @@ from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.path import pretty_path
 from inspect_ai.log import condense_events, expand_events
 from inspect_ai.util import trace_action, trace_message
+from pydantic_core import to_json
 from typing_extensions import override
 from upath import UPath
 
@@ -1039,8 +1040,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
             if value is None:
                 row[key] = None
             elif isinstance(value, (dict, list)):
-                # Complex types: serialize to JSON string
-                row[key] = json.dumps(value)
+                # to_json with str fallback so nested non-JSON-native values
+                # (e.g. pathlib.Path) stringify cleanly instead of raising.
+                row[key] = to_json(value, fallback=str).decode("utf-8")
             elif isinstance(value, (str, int, float, bool)):
                 # Scalar types: store directly
                 row[key] = value

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -1040,8 +1040,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
             if value is None:
                 row[key] = None
             elif isinstance(value, (dict, list)):
-                # to_json with str fallback so nested non-JSON-native values
-                # (e.g. pathlib.Path) stringify cleanly instead of raising.
+                # Complex types: serialize to JSON string
                 row[key] = to_json(value, fallback=str).decode("utf-8")
             elif isinstance(value, (str, int, float, bool)):
                 # Scalar types: store directly

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -334,14 +334,11 @@ async def test_record_serializes_path_in_metadata_as_json(
     recorder_buffer: RecorderBuffer,
     sample_results: list[ResultReport],
 ) -> None:
-    """transcript_metadata containing pathlib.Path must serialize as JSON.
+    """pathlib.Path in transcript metadata must serialize as JSON strings.
 
-    Regression for the online-scanner path where eval_sample.metadata
-    flows directly into TranscriptInfo.metadata without prior stringification.
-    Previously, a Path inside the dict would make json.dumps raise, and the
-    fallback `str(dict)` would store Python repr text (`{'k': PosixPath(...)}`)
-    in the parquet column — which the viewer can't parse, leaving the user
-    with "No scan results are available."
+    Previously, a Path inside the dict made json.dumps raise; the str(dict)
+    fallback then stored Python repr text (`{'k': PosixPath(...)}`) in the
+    parquet column, which the viewer can't parse.
     """
     scanner_name = "test_scanner"
     transcript = TranscriptInfo(
@@ -365,15 +362,15 @@ async def test_record_serializes_path_in_metadata_as_json(
     )
     table = pq.read_table(parquet_path.as_posix())
     values = table.column("transcript_metadata").to_pylist()
-    assert values, "expected at least one row"
+    assert len(values) == 1
 
     serialized = values[0]
     assert isinstance(serialized, str)
-    # Must be valid JSON (not Python repr from the str(dict) fallback)
-    assert "PosixPath" not in serialized, (
+    assert "PosixPath(" not in serialized, (
         f"Path leaked as Python repr into parquet column: {serialized!r}"
     )
-    parsed = json.loads(serialized)
-    assert parsed["eval_name"] == "refusal_classifier"
-    assert parsed["eval_file_path"] == "/home/foo/eval.yaml"
-    assert parsed["nested"] == {"inner_path": "/home/foo/inner.yaml"}
+    assert json.loads(serialized) == {
+        "eval_name": "refusal_classifier",
+        "eval_file_path": "/home/foo/eval.yaml",
+        "nested": {"inner_path": "/home/foo/inner.yaml"},
+    }

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -361,10 +361,7 @@ async def test_record_serializes_path_in_metadata_as_json(
         / "path-metadata-1.parquet"
     )
     table = pq.read_table(parquet_path.as_posix())
-    values = table.column("transcript_metadata").to_pylist()
-    assert len(values) == 1
-
-    serialized = values[0]
+    serialized = table.column("transcript_metadata")[0].as_py()
     assert isinstance(serialized, str)
     assert "PosixPath(" not in serialized, (
         f"Path leaked as Python repr into parquet column: {serialized!r}"

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import tempfile
 from pathlib import Path
 from typing import Generator
@@ -326,3 +327,53 @@ def test_buffer_dir_expands_tilde(
     monkeypatch.setenv("HOME", str(tmp_path))
     result = RecorderBuffer.buffer_dir("/some/scan/location")
     assert result.parent == tmp_path / "my_scout_buffer"
+
+
+@pytest.mark.asyncio
+async def test_record_serializes_path_in_metadata_as_json(
+    recorder_buffer: RecorderBuffer,
+    sample_results: list[ResultReport],
+) -> None:
+    """transcript_metadata containing pathlib.Path must serialize as JSON.
+
+    Regression for the online-scanner path where eval_sample.metadata
+    flows directly into TranscriptInfo.metadata without prior stringification.
+    Previously, a Path inside the dict would make json.dumps raise, and the
+    fallback `str(dict)` would store Python repr text (`{'k': PosixPath(...)}`)
+    in the parquet column — which the viewer can't parse, leaving the user
+    with "No scan results are available."
+    """
+    scanner_name = "test_scanner"
+    transcript = TranscriptInfo(
+        transcript_id="path-metadata-1",
+        source_type="test",
+        source_id="src-1",
+        source_uri="/path/to/src.log",
+        metadata={
+            "eval_name": "refusal_classifier",
+            "eval_file_path": Path("/home/foo/eval.yaml"),
+            "nested": {"inner_path": Path("/home/foo/inner.yaml")},
+        },
+    )
+
+    await recorder_buffer.record(transcript, scanner_name, sample_results, None)
+
+    parquet_path = (
+        recorder_buffer._buffer_dir
+        / f"scanner={scanner_name}"
+        / "path-metadata-1.parquet"
+    )
+    table = pq.read_table(parquet_path.as_posix())
+    values = table.column("transcript_metadata").to_pylist()
+    assert values, "expected at least one row"
+
+    serialized = values[0]
+    assert isinstance(serialized, str)
+    # Must be valid JSON (not Python repr from the str(dict) fallback)
+    assert "PosixPath" not in serialized, (
+        f"Path leaked as Python repr into parquet column: {serialized!r}"
+    )
+    parsed = json.loads(serialized)
+    assert parsed["eval_name"] == "refusal_classifier"
+    assert parsed["eval_file_path"] == "/home/foo/eval.yaml"
+    assert parsed["nested"] == {"inner_path": "/home/foo/inner.yaml"}

--- a/tests/transcript/test_parquet_db.py
+++ b/tests/transcript/test_parquet_db.py
@@ -830,6 +830,43 @@ async def test_nested_metadata_stored_as_json(parquet_db: ParquetTranscriptsDB) 
 
 
 @pytest.mark.asyncio
+async def test_path_in_nested_metadata_stringified(
+    parquet_db: ParquetTranscriptsDB,
+) -> None:
+    """pathlib.Path inside dict/list metadata round-trips as a path string.
+
+    Regression: ``_transcript_to_row`` used bare ``json.dumps(value)`` for
+    dict/list metadata values, which raises on a nested Path.
+    """
+    transcript = create_sample_transcript(
+        id="path-meta-1",
+        metadata={
+            "config": {
+                "eval_file_path": Path("/home/foo/eval.yaml"),
+                "nested": {"inner_path": Path("/home/foo/inner.yaml")},
+            },
+            "paths": [Path("/home/foo/a.yaml"), Path("/home/foo/b.yaml")],
+        },
+    )
+
+    await parquet_db.insert([transcript])
+
+    results = [
+        info
+        async for info in parquet_db.select(
+            Query(where=[c.transcript_id == "path-meta-1"])
+        )
+    ]
+    assert len(results) == 1
+    metadata = results[0].metadata
+    assert metadata["config"] == {
+        "eval_file_path": "/home/foo/eval.yaml",
+        "nested": {"inner_path": "/home/foo/inner.yaml"},
+    }
+    assert metadata["paths"] == ["/home/foo/a.yaml", "/home/foo/b.yaml"]
+
+
+@pytest.mark.asyncio
 async def test_reserved_column_validation(parquet_db: ParquetTranscriptsDB) -> None:
     """Test that reserved column names in metadata raise error."""
     from inspect_scout._transcript.database.parquet.transcripts import (


### PR DESCRIPTION
## Summary

- Replace `json.dumps` with `pydantic_core.to_json(v, fallback=str)` in the two parquet writers that touch user-supplied metadata, so a `pathlib.Path` (or any non-JSON-native object) in metadata produces a clean JSON string instead of Python repr text in the parquet column.
- Add tests.

## Original issue

When a scan runs through inspect_ai's `eval_set(scanner=...)` integration (the online path added in #424 ), `eval_sample.metadata` flows directly into `TranscriptInfo.metadata` without prior stringification. If an eval put a `Path` into sample metadata, the `_normalize_scalar` helper in `_recorder/buffer.py` hit:

```python
try:
    return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
except Exception:
    return str(v)
```

`json.dumps` raises `TypeError: Object of type PosixPath is not JSON serializable`, the `except` branch fires, and `str(dict)` yields:

```
"{'eval_name': 'foo', 'eval_file_path': PosixPath('/home/foo/eval.yaml')}"
```

That Python-repr text lands in the parquet `transcript_metadata` column, the viewer can't parse it, and the user sees **"No scan results are available."** in the browser & **"The editor could not be opened due to an unexpected error"** in VS Code.

## Fix
- `pydantic_core.to_json(v, fallback=str)`: natively handles `Path`, `UUID`, `Decimal`, `datetime`, `set`, pydantic models and falls back to `str()` per-value for unknowns — `str(Path)` returns the path string, not the `PosixPath(...)` constructor literal.
- Inspired by inspect_ai's `to_json_str_safe`, which is already used in `_scanner/result.py`.

Two call sites had the same shape of bug:

- `src/inspect_scout/_recorder/buffer.py` — `_normalize_scalar` (scan-results writer, the user-reported path).
- `src/inspect_scout/_transcript/database/parquet/transcripts.py` — `_transcript_to_row` (transcripts DB writer; analogous risk, would have crashed instead of producing repr text since there's no surrounding try/except there).

| Input | Old output | New output |
|---|---|---|
| `{"eval_file_path": Path("/home/foo/eval.yaml")}` | `"{'eval_file_path': PosixPath('/home/foo/eval.yaml')}"` | `'{"eval_file_path":"/home/foo/eval.yaml"}'` |


## Alternative FIx

`src/inspect_scout/_transcript/eval_log.py:748` could also fix at the entry-level here `metadata=dict(eval_sample.metadata),`, did not want to touch the in-memory metadata unless we want this kind of defense-in-depth

### Testing

- [x] New: `tests/scanner/test_recorder_buffer.py::test_record_serializes_path_in_metadata_as_json` — records a transcript with a top-level `Path` plus a nested dict-of-Path, reads the parquet back, asserts the JSON parses and contains no `PosixPath` literal.
- [x] New: `tests/transcript/test_parquet_db.py::test_path_in_nested_metadata_stringified` — round-trips a transcript with `Path` values nested in dicts and lists through `ParquetTranscriptsDB.insert` / `select`, asserts the values come back as path strings.
- [x] `pytest tests/recorder/ tests/scanner/test_recorder_buffer.py tests/transcript/test_parquet_db.py` 
- [x] `ruff check` + `ruff format`
- [x] `mypy src examples tests`
