### PR TITLE
llm_scanner: account for template tokens in segment budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support custom role labels for transcript message rendering.
 - Bugfix: Stop doing blocking S3 file I/O on hot paths.
 - Bugfix: Resolve nested schema references for `AnswerStructured`.
+- Bugfix: `llm_scanner` now reserves tokens for the rendered scanner template when sizing segments, so long templates no longer push the prompt past `context_window`.
 - Scout View: Refine scanner result header and All Scores dialog
 
 ## 0.4.35 (16 May 2026)

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -271,6 +271,19 @@ def llm_scanner(
                 value_to_float=value_to_float,
             )
 
+        # Measure template overhead by rendering with messages="" so the
+        # segmenter can subtract it from the per-segment budget. Without
+        # this, a long template can push the rendered prompt past the
+        # model's context window even when the messages alone fit.
+        reserved_tokens = await _template_overhead_tokens(
+            template=resolved_template,
+            template_variables=template_variables,
+            transcript=transcript,
+            question=question,
+            answer=resolved_answer,
+            model=resolved_model,
+        )
+
         segments = [
             seg
             async for seg in transcript_messages(
@@ -280,6 +293,7 @@ def llm_scanner(
                 context_window=context_window,
                 compaction=compaction,
                 depth=depth,
+                reserved_tokens=reserved_tokens,
             )
         ]
         segment_results: list[Result] = await tg_collect(
@@ -430,3 +444,40 @@ async def _render_split_prompt(
     )
     prefix, suffix = templates
     return _render_template(prefix, kwargs), _render_template(suffix, kwargs)
+
+
+async def _template_overhead_tokens(
+    *,
+    template: str | tuple[str, str],
+    template_variables: dict[str, Any] | Callable[[Transcript], dict[str, Any]] | None,
+    transcript: Transcript,
+    question: str | Callable[[Transcript], Awaitable[str]] | None,
+    answer: Answer,
+    model: Model,
+) -> int:
+    """Count tokens of the rendered prompt template with no messages.
+
+    Used by the segmenter to reserve budget for prompt scaffolding so
+    the rendered prompt (template + messages) fits in the context
+    window.
+    """
+    if isinstance(template, tuple):
+        prefix_str, suffix_str = await _render_split_prompt(
+            templates=template,
+            template_variables=template_variables,
+            transcript=transcript,
+            messages="",
+            question=question,
+            answer=answer,
+        )
+        rendered = prefix_str + suffix_str
+    else:
+        rendered = await render_scanner_prompt(
+            template=template,
+            template_variables=template_variables,
+            transcript=transcript,
+            messages="",
+            question=question,
+            answer=answer,
+        )
+    return await model.count_tokens(rendered)

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -24,7 +24,7 @@ from .._scanner.scanner import (
     Scanner,
     scanner,
 )
-from .._transcript.messages import transcript_messages
+from .._transcript.messages import _effective_segment_budget, transcript_messages
 from .._transcript.timeline import TimelineMessages
 from .._transcript.types import Transcript, TranscriptContent
 from ._reducer import aggregate_results
@@ -283,6 +283,18 @@ def llm_scanner(
             answer=resolved_answer,
             model=resolved_model,
         )
+        effective_budget = _effective_segment_budget(
+            model=resolved_model,
+            context_window=context_window,
+            reserved_tokens=reserved_tokens,
+        )
+        if effective_budget <= 0:
+            raise RuntimeError(
+                "Scanner template overhead exceeds the available context window "
+                f"budget: template overhead={reserved_tokens} tokens, available "
+                f"discounted budget={effective_budget + reserved_tokens} tokens. "
+                "Increase context_window or shorten the scanner template."
+            )
 
         segments = [
             seg

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -54,12 +54,14 @@ async def segment_messages(
     model: Model | str | None = None,
     context_window: int | None = None,
     compaction: Literal["all", "last"] | int = "all",
+    reserved_tokens: int = 0,
 ) -> AsyncIterator[MessagesSegment]:
     """Render messages and split them into segments that fit within a token budget.
 
     Renders each message individually via ``messages_as_str``, counts
     tokens in parallel via ``tg_collect``, then accumulates segments that
-    fit within the effective budget (context window * 80%).
+    fit within the effective budget (context window * 80% minus
+    ``reserved_tokens``).
 
     When given events or a ``TimelineSpan``, delegates to
     ``span_messages()`` to extract and merge messages (handling
@@ -76,6 +78,10 @@ async def segment_messages(
             looked up via ``get_model_info(model)``.
         compaction: How to handle compaction boundaries when source
             contains events. Passed through to ``span_messages()``.
+        reserved_tokens: Tokens to reserve for prompt overhead that
+            wraps the messages (e.g. a scanner template). Subtracted
+            from the effective budget so the rendered prompt fits in
+            the context window.
 
     Yields:
         MessagesSegment instances, each fitting within the token budget.
@@ -107,7 +113,7 @@ async def segment_messages(
             if model_info is not None and model_info.input_tokens is not None
             else DEFAULT_CONTEXT_WINDOW
         )
-    effective_budget = int(budget * _BUDGET_DISCOUNT)
+    effective_budget = max(1, int(budget * _BUDGET_DISCOUNT) - reserved_tokens)
 
     # Pass 1: Render each message sequentially (counter ordering matters)
     rendered: list[tuple[ChatMessage, str]] = []
@@ -164,6 +170,7 @@ async def transcript_messages(
     compaction: Literal["all", "last"] | int = "all",
     depth: int | None = None,
     include_scorers: bool = False,
+    reserved_tokens: int = 0,
 ) -> AsyncIterator[MessagesSegment]:
     """Yield pre-rendered message segments from a transcript.
 
@@ -199,6 +206,9 @@ async def transcript_messages(
             events-only or messages-only paths.
         include_scorers: Whether to include scorer events in message
             extraction. Defaults to ``False``.
+        reserved_tokens: Tokens to reserve for prompt overhead that
+            wraps the messages (e.g. a scanner template). Forwarded to
+            ``segment_messages()`` / ``timeline_messages()``.
 
     Yields:
         ``MessagesSegment`` (or ``TimelineMessages``) for each segment.
@@ -226,6 +236,7 @@ async def transcript_messages(
             context_window=context_window,
             compaction=compaction,
             depth=depth,
+            reserved_tokens=reserved_tokens,
         ):
             yield timeline_seg  # type: ignore[misc]
     else:
@@ -234,6 +245,7 @@ async def transcript_messages(
             messages_as_str=messages_as_str,
             model=model,
             context_window=context_window,
+            reserved_tokens=reserved_tokens,
         ):
             yield seg
 

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -32,6 +32,26 @@ DEFAULT_CONTEXT_WINDOW = 128_000
 _BUDGET_DISCOUNT = 0.8
 
 
+def _effective_segment_budget(
+    *,
+    model: Model,
+    context_window: int | None,
+    reserved_tokens: int = 0,
+) -> int:
+    """Compute the discounted token budget available for rendered messages."""
+    if context_window is not None:
+        budget = context_window
+    else:
+        model_info = get_model_info(model)
+        budget = (
+            model_info.input_tokens
+            if model_info is not None and model_info.input_tokens is not None
+            else DEFAULT_CONTEXT_WINDOW
+        )
+
+    return int(budget * _BUDGET_DISCOUNT) - reserved_tokens
+
+
 @dataclass(frozen=True)
 class MessagesSegment:
     """A segment of rendered messages that fits within a token budget.
@@ -104,16 +124,14 @@ async def segment_messages(
         return
 
     # Compute effective budget
-    if context_window is not None:
-        budget = context_window
-    else:
-        model_info = get_model_info(model)
-        budget = (
-            model_info.input_tokens
-            if model_info is not None and model_info.input_tokens is not None
-            else DEFAULT_CONTEXT_WINDOW
-        )
-    effective_budget = max(1, int(budget * _BUDGET_DISCOUNT) - reserved_tokens)
+    effective_budget = max(
+        1,
+        _effective_segment_budget(
+            model=model,
+            context_window=context_window,
+            reserved_tokens=reserved_tokens,
+        ),
+    )
 
     # Pass 1: Render each message sequentially (counter ordering matters)
     rendered: list[tuple[ChatMessage, str]] = []

--- a/src/inspect_scout/_transcript/timeline.py
+++ b/src/inspect_scout/_transcript/timeline.py
@@ -171,6 +171,7 @@ async def timeline_messages(
     context_window: int | None = None,
     compaction: Literal["all", "last"] | int = "all",
     depth: int | None = None,
+    reserved_tokens: int = 0,
 ) -> AsyncIterator[TimelineMessages]:
     """Yield pre-rendered message segments from timeline spans.
 
@@ -204,6 +205,9 @@ async def timeline_messages(
             each branch (typically top-level agents/solvers); ``N``
             allows up to N nested scannable layers. ``None`` (default)
             recurses without limit. ``0`` yields nothing.
+        reserved_tokens: Tokens to reserve for prompt overhead that
+            wraps the messages (e.g. a scanner template). Forwarded to
+            ``segment_messages()``.
 
     Yields:
         TimelineMessages for each segment. Empty spans are skipped.
@@ -220,6 +224,7 @@ async def timeline_messages(
             model=model,
             context_window=context_window,
             compaction=compaction,
+            reserved_tokens=reserved_tokens,
         ):
             yield TimelineMessages(
                 messages=seg.messages,

--- a/tests/llm_scanner/test_llm_scanner.py
+++ b/tests/llm_scanner/test_llm_scanner.py
@@ -2,9 +2,18 @@
 
 from unittest.mock import patch
 
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageUser,
+    ModelOutput,
+    get_model,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.tool import ToolChoice, ToolInfo
 from inspect_scout import llm_scanner
 from inspect_scout._scanner.scanner import SCANNER_CONTENT_ATTR
-from inspect_scout._transcript.types import TranscriptContent
+from inspect_scout._transcript.types import Transcript, TranscriptContent
 
 # ---------------------------------------------------------------------------
 # content parameter tests
@@ -64,3 +73,62 @@ class TestModelRoleParameter:
         # Should construct without error when model_role is omitted
         scan_fn = llm_scanner(question="test?", answer="boolean")
         assert scan_fn is not None
+
+
+# ---------------------------------------------------------------------------
+# template_overhead / context_window interaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_long_template_does_not_overflow_context_window() -> None:
+    """Template tokens must be counted against the segment budget.
+
+    With a very long template, the rendered prompt (template + messages)
+    must still fit inside ``context_window``. Previously, only message
+    tokens counted, so a long template could push the rendered prompt
+    past the model's context window.
+    """
+    msgs: list[ChatMessage] = [
+        ChatMessageUser(content="word " * 50, id=f"m{i}") for i in range(4)
+    ]
+    transcript = Transcript(transcript_id="t", messages=msgs)
+
+    captured_prompts: list[list[ChatMessage]] = []
+
+    def capture(
+        input_msgs: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        captured_prompts.append(list(input_msgs))
+        return ModelOutput.from_content(
+            model="mockllm",
+            content="Reason.\n\nANSWER: yes",
+            stop_reason="stop",
+        )
+
+    mock_model = get_model("mockllm/model", custom_outputs=capture, memoize=False)
+
+    # ~330 tokens of fixed template text — large enough that combined with
+    # messages it would overflow context_window=500 if not accounted for.
+    long_template = (
+        "filler " * 300
+    ) + "\n{{ messages }}\n{{ answer_prompt }}\n{{ question }}\n{{ answer_format }}"
+
+    scan_fn = llm_scanner(
+        question="Is this helpful?",
+        answer="boolean",
+        model=mock_model,
+        template=long_template,
+        context_window=500,
+    )
+    await scan_fn(transcript)
+
+    assert captured_prompts, "model should have been called at least once"
+    for prompt in captured_prompts:
+        token_count = await mock_model.count_tokens(prompt)
+        assert token_count <= 500, (
+            f"prompt overflowed context_window: {token_count} > 500"
+        )

--- a/tests/llm_scanner/test_llm_scanner.py
+++ b/tests/llm_scanner/test_llm_scanner.py
@@ -132,3 +132,74 @@ async def test_long_template_does_not_overflow_context_window() -> None:
         assert token_count <= 500, (
             f"prompt overflowed context_window: {token_count} > 500"
         )
+
+
+@pytest.mark.anyio
+async def test_default_template_does_not_overflow_context_window() -> None:
+    """Default split-template prompts must respect ``context_window``.
+
+    This exercises the default ``template=None`` path that most callers
+    use, ensuring the reserved template overhead is applied before
+    segmenting messages.
+    """
+    msgs: list[ChatMessage] = [
+        ChatMessageUser(content="word " * 10, id=f"m{i}") for i in range(4)
+    ]
+    transcript = Transcript(transcript_id="t", messages=msgs)
+
+    captured_prompts: list[list[ChatMessage]] = []
+
+    def capture(
+        input_msgs: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        captured_prompts.append(list(input_msgs))
+        return ModelOutput.from_content(
+            model="mockllm",
+            content="Reason.\n\nANSWER: yes",
+            stop_reason="stop",
+        )
+
+    mock_model = get_model("mockllm/model", custom_outputs=capture, memoize=False)
+
+    scan_fn = llm_scanner(
+        question="Is this helpful?",
+        answer="boolean",
+        model=mock_model,
+        context_window=200,
+    )
+    await scan_fn(transcript)
+
+    assert len(captured_prompts) > 1
+    for prompt in captured_prompts:
+        token_count = await mock_model.count_tokens(prompt)
+        assert token_count <= 200, (
+            f"prompt overflowed context_window: {token_count} > 200"
+        )
+
+
+@pytest.mark.anyio
+async def test_template_overhead_exceeding_budget_raises_runtime_error() -> None:
+    """Scanning should fail when template overhead alone exceeds budget."""
+    transcript = Transcript(
+        transcript_id="t",
+        messages=[ChatMessageUser(content="word " * 5, id="m1")],
+    )
+
+    mock_model = get_model("mockllm/model", memoize=False)
+    oversized_template = (
+        "filler " * 1000
+    ) + "\n{{ messages }}\n{{ answer_prompt }}\n{{ question }}\n{{ answer_format }}"
+
+    scan_fn = llm_scanner(
+        question="Is this helpful?",
+        answer="boolean",
+        model=mock_model,
+        template=oversized_template,
+        context_window=500,
+    )
+
+    with pytest.raises(RuntimeError, match="template|context window|budget"):
+        await scan_fn(transcript)

--- a/tests/llm_scanner/test_timeline_within_span_reduction.py
+++ b/tests/llm_scanner/test_timeline_within_span_reduction.py
@@ -89,6 +89,11 @@ def _yes_no_outputs(answers: list[str]) -> list[ModelOutput]:
     ]
 
 
+def _repeated_words(count: int) -> str:
+    """Create predictable text long enough to force chunking when needed."""
+    return " ".join(["word"] * count)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -102,14 +107,16 @@ async def test_single_span_multi_chunk_reduces_to_single_result() -> None:
         name="agent",
         events=[
             _model_event(
-                input_texts=["first user msg"], output_text="asst reply", uuid="m1"
+                input_texts=[_repeated_words(20)],
+                output_text=_repeated_words(20),
+                uuid="m1",
             ),
         ],
     )
     transcript = _transcript_with_spans([span])
 
-    # context_window=1 forces each rendered message into its own segment
-    # (2 messages -> 2 segments). Prime 2 distinct answers.
+    # The default scanner template consumes most of a small context window,
+    # so 20-word input/output messages are split into two segments here.
     mock_model = get_model(
         "mockllm/model",
         custom_outputs=_yes_no_outputs(["no", "yes"]),
@@ -119,7 +126,7 @@ async def test_single_span_multi_chunk_reduces_to_single_result() -> None:
         question="Is this helpful?",
         answer="boolean",
         model=mock_model,
-        context_window=1,
+        context_window=200,
     )
 
     out = await scan_fn(transcript)
@@ -139,7 +146,9 @@ async def test_multi_span_one_chunked_returns_resultset() -> None:
         name="agent-a",
         events=[
             _model_event(
-                input_texts=["user msg a"], output_text="asst reply a", uuid="ma"
+                input_texts=[_repeated_words(20)],
+                output_text=_repeated_words(20),
+                uuid="ma",
             ),
         ],
     )
@@ -164,7 +173,7 @@ async def test_multi_span_one_chunked_returns_resultset() -> None:
         question="Is this helpful?",
         answer="boolean",
         model=mock_model,
-        context_window=1,
+        context_window=200,
     )
 
     out = await scan_fn(transcript)
@@ -186,7 +195,9 @@ async def test_custom_reducer_invoked_on_timeline_scans() -> None:
         name="agent",
         events=[
             _model_event(
-                input_texts=["first user msg"], output_text="asst reply", uuid="m1"
+                input_texts=[_repeated_words(20)],
+                output_text=_repeated_words(20),
+                uuid="m1",
             ),
         ],
     )
@@ -209,7 +220,7 @@ async def test_custom_reducer_invoked_on_timeline_scans() -> None:
         question="Is this helpful?",
         answer="boolean",
         model=mock_model,
-        context_window=1,
+        context_window=200,
         reducer=recording_reducer,
     )
 


### PR DESCRIPTION
## Summary
- Long scanner templates pushed the rendered prompt past `context_window` because only message tokens were budgeted against it.
- Render the template with `messages=""`, count its tokens, and thread the result as a new `reserved_tokens` param through `segment_messages` / `transcript_messages` / `timeline_messages` so the segmenter shrinks per-segment messages to leave room for the template.
- Reported user case: hitting context length limits with a really long template; previously only mitigatable by manually lowering `context_window`.