### PR TITLE
feat: add task_id and task_repeat metadata to validation cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Resolve nested schema references for `AnswerStructured`.
 - Bugfix: `llm_scanner` now reserves tokens for the rendered scanner template when sizing segments, so long templates no longer push the prompt past `context_window`.
 - Bugfix: Serialize metadata flds with pydantic_core.to_json
+- Include task_id and task_repeat in validations data files (as optional informational fields)
 - Scout View: Refine scanner result header and All Scores dialog
 - Scout View: Don't allow malformed metadata to blow up entire scan (#245)
 - Scout View: Refine scanner result header and All Scores dialog (#243)

--- a/design/validation-case-metadata.md
+++ b/design/validation-case-metadata.md
@@ -1,0 +1,70 @@
+# Validation Case Metadata: `task_id` and `task_repeat`
+
+## Problem
+
+Validation case files (CSV/JSON/YAML/JSONL) contain an opaque `id` (the transcript ID) that isn't meaningful to humans reviewing the file externally. When a user opens a validation CSV in a spreadsheet or text editor, they can't tell which sample or epoch a case corresponds to without cross-referencing the database.
+
+## Solution
+
+Add two optional, informational fields to validation cases:
+
+- **`task_id`** (`str | None`) — The sample identifier from the eval log (e.g., dataset sample id).
+- **`task_repeat`** (`int | None`) — The epoch/repeat number for the sample.
+
+These fields are **write-through metadata only**: they are stored in the file and returned by the API, but do not participate in validation logic, matching, or predicate evaluation. The frontend provides them when creating/upserting cases from a transcript context.
+
+## Changes
+
+### Python — `ValidationCase` model (`_validation/types.py`)
+
+Add two optional fields with `Field(default=None)`. They serialize into the file when present (via `exclude_none=True` in `model_dump`) and are ignored when absent.
+
+### Python — `ValidationCaseRequest` dataclass (`_view/_api_v2_types.py`)
+
+Add matching optional fields so the API accepts them from the frontend.
+
+### Python — API endpoints (`_view/_api_v2_validations.py`)
+
+Thread the new fields through `create_validation` and `upsert_validation_case` when constructing `ValidationCase` objects.
+
+### File I/O — No changes
+
+The writer uses `model_dump(exclude_none=True)` and writes raw dicts, so new fields flow through naturally. The reader loads raw dicts and passes them to Pydantic, which accepts (and ignores during validation logic) the extra fields. CSV files get `task_id`/`task_repeat` columns; structured formats get inline fields.
+
+### OpenAPI + generated TypeScript types
+
+Regenerate `openapi.json` and `generated.ts` after the Python model changes.
+
+### Frontend — Pass metadata when creating/upserting cases
+
+Where the frontend constructs upsert requests from a transcript context, include `task_id` and `task_repeat` from the transcript metadata if available.
+
+## What doesn't change
+
+- Validation logic, matching, predicates
+- File scanning / discovery
+- Split handling
+- Read path (extra fields in existing files are already tolerated)
+
+## File format examples
+
+**CSV:**
+```csv
+id,target,task_id,task_repeat
+abc123,true,sample_42,1
+def456,false,sample_42,2
+```
+
+**JSON/YAML:**
+```json
+[
+  {"id": "abc123", "target": true, "task_id": "sample_42", "task_repeat": 1},
+  {"id": "def456", "target": false, "task_id": "sample_42", "task_repeat": 2}
+]
+```
+
+## Branching
+
+Requires coordinated branches in both repos:
+- **inspect_scout** (base repo) — Python model, API, and schema changes
+- **ts-mono** (submodule) — Frontend changes to pass metadata through

--- a/docs/superpowers/plans/2026-05-22-validation-case-metadata.md
+++ b/docs/superpowers/plans/2026-05-22-validation-case-metadata.md
@@ -1,0 +1,526 @@
+# Validation Case Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional `task_id` and `task_repeat` fields to validation case files so they're human-readable outside the app.
+
+**Architecture:** Add the fields to the Pydantic model, API request dataclass, and API endpoints. Regenerate the OpenAPI schema and TypeScript types. Thread the values from the frontend's transcript context into upsert requests.
+
+**Tech Stack:** Python (Pydantic, FastAPI, dataclasses), TypeScript (React, React Query), OpenAPI codegen
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/inspect_scout/_validation/types.py` | Add `task_id` and `task_repeat` to `ValidationCase` |
+| Modify | `src/inspect_scout/_view/_api_v2_types.py` | Add fields to `ValidationCaseRequest` dataclass |
+| Modify | `src/inspect_scout/_view/_api_v2_validations.py` | Thread fields through `create_validation` and `upsert_validation_case` |
+| Modify | `src/inspect_scout/openapi.json` | Regenerated (not hand-edited) |
+| Modify | `src/inspect_scout/_view/ts-mono/apps/scout/src/types/generated.ts` | Regenerated (not hand-edited) |
+| Modify | `src/inspect_scout/_view/ts-mono/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx` | Pass `task_id` / `task_repeat` in upsert requests |
+| Test | `tests/view/test_validation_api.py` | Add tests for metadata round-trip |
+
+## Branching
+
+This feature requires coordinated branches in two repos:
+
+1. **inspect_scout** (base repo): branch `feat/validation-case-metadata`
+2. **ts-mono** (submodule): branch `feat/validation-case-metadata`
+
+Create the ts-mono branch first (Tasks 1-2), then the base repo branch (remaining tasks). The submodule pointer update happens when committing the base repo.
+
+---
+
+### Task 1: Create branches
+
+**Files:** None (git operations only)
+
+- [ ] **Step 1: Create the ts-mono feature branch**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+git checkout -b feat/validation-case-metadata
+cd -
+```
+
+- [ ] **Step 2: Create the base repo feature branch**
+
+```bash
+git checkout -b feat/validation-case-metadata
+```
+
+---
+
+### Task 2: Add fields to `ValidationCase` model
+
+**Files:**
+- Modify: `src/inspect_scout/_validation/types.py:10-61`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/view/test_validation_api.py`, add a test that creates a case with `task_id` and `task_repeat`, then reads it back and verifies the fields are present.
+
+```python
+def test_upsert_case_with_metadata(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat are stored and returned when provided."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_meta")
+
+    resp = client.post(
+        f"/api/v2/validations/{encoded_uri}/{case_id}",
+        json={
+            "target": True,
+            "task_id": "sample_42",
+            "task_repeat": 3,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["task_id"] == "sample_42"
+    assert data["task_repeat"] == 3
+
+    # Read back
+    get_resp = client.get(f"/api/v2/validations/{encoded_uri}/{case_id}")
+    assert get_resp.status_code == 200
+    get_data = get_resp.json()
+    assert get_data["task_id"] == "sample_42"
+    assert get_data["task_repeat"] == 3
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py::test_upsert_case_with_metadata -v`
+Expected: FAIL — `task_id` not in response (fields don't exist yet on the model).
+
+- [ ] **Step 3: Add fields to `ValidationCase`**
+
+In `src/inspect_scout/_validation/types.py`, add after the `split` field (line 44):
+
+```python
+    task_id: str | None = Field(default=None)
+    """Optional sample identifier from the source eval log (informational only)."""
+
+    task_repeat: int | None = Field(default=None)
+    """Optional epoch/repeat number from the source eval log (informational only)."""
+```
+
+- [ ] **Step 4: Add fields to `ValidationCaseRequest`**
+
+In `src/inspect_scout/_view/_api_v2_types.py`, add after the `predicate` field (line 204) in the `ValidationCaseRequest` dataclass:
+
+```python
+    task_id: str | None = None
+    """Optional sample identifier (informational, written to file but not used in validation)."""
+
+    task_repeat: int | None = None
+    """Optional epoch/repeat number (informational, written to file but not used in validation)."""
+```
+
+- [ ] **Step 5: Thread fields through `create_validation` endpoint**
+
+In `src/inspect_scout/_view/_api_v2_validations.py`, in `create_validation()` (around line 92), update the `ValidationCase` constructor to include the new fields:
+
+```python
+            cases.append(
+                ValidationCase(
+                    id=case_req.id,
+                    target=case_req.target,
+                    labels=case_req.labels,
+                    split=case_req.split,
+                    predicate=cast(PredicateType | None, case_req.predicate),
+                    task_id=case_req.task_id,
+                    task_repeat=case_req.task_repeat,
+                )
+            )
+```
+
+- [ ] **Step 6: Thread fields through `upsert_validation_case` endpoint**
+
+In `src/inspect_scout/_view/_api_v2_validations.py`, in `upsert_validation_case()` (around line 286), update the `ValidationCase` constructor:
+
+```python
+            case = ValidationCase(
+                id=decoded_case_id,
+                target=body.target,
+                labels=body.labels,
+                split=body.split,
+                predicate=cast(PredicateType | None, body.predicate),
+                task_id=body.task_id,
+                task_repeat=body.task_repeat,
+            )
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py::test_upsert_case_with_metadata -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/inspect_scout/_validation/types.py src/inspect_scout/_view/_api_v2_types.py src/inspect_scout/_view/_api_v2_validations.py tests/view/test_validation_api.py
+git commit -m "feat: add task_id and task_repeat metadata to validation cases"
+```
+
+---
+
+### Task 3: Add test for metadata omission (optional fields)
+
+**Files:**
+- Test: `tests/view/test_validation_api.py`
+
+- [ ] **Step 1: Write test that metadata fields are absent when not provided**
+
+```python
+def test_upsert_case_without_metadata(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat are absent from response when not provided."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_no_meta")
+
+    resp = client.post(
+        f"/api/v2/validations/{encoded_uri}/{case_id}",
+        json={"target": True},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "task_id" not in data
+    assert "task_repeat" not in data
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py::test_upsert_case_without_metadata -v`
+Expected: PASS (fields use `exclude_none=True` via `model_dump`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/view/test_validation_api.py
+git commit -m "test: verify metadata fields omitted when not provided"
+```
+
+---
+
+### Task 4: Add test for CSV round-trip with metadata
+
+**Files:**
+- Test: `tests/view/test_validation_api.py`
+
+- [ ] **Step 1: Write test that metadata persists in CSV file**
+
+```python
+def test_metadata_persists_in_csv(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat appear as columns in the CSV file."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_csv_meta")
+
+    client.post(
+        f"/api/v2/validations/{encoded_uri}/{case_id}",
+        json={"target": True, "task_id": "sample_7", "task_repeat": 2},
+    )
+
+    # Read the raw CSV and verify columns exist
+    csv_content = validation_csv.read_text()
+    assert "task_id" in csv_content
+    assert "task_repeat" in csv_content
+    assert "sample_7" in csv_content
+
+    # Read back via API — list all cases
+    all_resp = client.get(f"/api/v2/validations/{encoded_uri}")
+    assert all_resp.status_code == 200
+    cases = all_resp.json()
+    meta_case = next(c for c in cases if c["id"] == "t_csv_meta")
+    assert meta_case["task_id"] == "sample_7"
+    assert meta_case["task_repeat"] == 2
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py::test_metadata_persists_in_csv -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/view/test_validation_api.py
+git commit -m "test: verify metadata round-trips through CSV files"
+```
+
+---
+
+### Task 5: Run full validation test suite
+
+- [ ] **Step 1: Run all validation-related tests**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py tests/scanner/test_validation.py tests/validation/ -v`
+Expected: All PASS
+
+- [ ] **Step 2: Run type checker**
+
+Run: `.venv/bin/mypy src/inspect_scout/_validation/types.py src/inspect_scout/_view/_api_v2_types.py src/inspect_scout/_view/_api_v2_validations.py`
+Expected: No errors
+
+---
+
+### Task 6: Regenerate OpenAPI schema and TypeScript types
+
+**Files:**
+- Modify: `src/inspect_scout/openapi.json` (generated)
+- Modify: `src/inspect_scout/_view/ts-mono/apps/scout/src/types/generated.ts` (generated)
+
+- [ ] **Step 1: Regenerate OpenAPI schema**
+
+Run: `.venv/bin/python scripts/export_openapi_schema.py`
+
+- [ ] **Step 2: Verify the schema includes the new fields**
+
+Check that `openapi.json` now contains `task_id` and `task_repeat` in both the `ValidationCase` and `ValidationCaseRequest` schemas.
+
+Run: `grep -A2 task_id src/inspect_scout/openapi.json | head -20`
+
+- [ ] **Step 3: Build ts-mono to regenerate TypeScript types**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+pnpm install
+pnpm build
+cd -
+```
+
+- [ ] **Step 4: Verify generated types include new fields**
+
+Check that `generated.ts` now has `task_id` and `task_repeat` on both `ValidationCase` and `ValidationCaseRequest`.
+
+Run: `grep -A2 task_id src/inspect_scout/_view/ts-mono/apps/scout/src/types/generated.ts | head -20`
+
+- [ ] **Step 5: Commit generated files**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+git add apps/scout/src/types/generated.ts
+git commit -m "chore: regenerate types with task_id and task_repeat"
+cd -
+git add src/inspect_scout/openapi.json
+git commit -m "chore: regenerate openapi schema with task_id and task_repeat"
+```
+
+---
+
+### Task 7: Thread metadata through frontend upsert
+
+**Files:**
+- Modify: `src/inspect_scout/_view/ts-mono/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx:59-62,171-177,256-266,291-297`
+
+The `ValidationCaseEditor` component receives `transcriptId` but doesn't have access to `task_id` / `task_repeat`. The parent components (`TranscriptBody` and `ScannerResultPanel`) have this data. We need to:
+
+1. Add optional `taskId` and `taskRepeat` props to `ValidationCaseEditor`
+2. Pass them from both parent call sites
+3. Include them in the `ValidationCaseRequest` when upserting
+
+- [ ] **Step 1: Add props to `ValidationCaseEditor`**
+
+In `ValidationCaseEditor.tsx`, update the `ValidationCaseEditorProps` interface (line 59):
+
+```typescript
+interface ValidationCaseEditorProps {
+  transcriptId: string;
+  taskId?: string | null;
+  taskRepeat?: number | null;
+  className?: string | string[];
+}
+```
+
+Update the component to destructure the new props (line 64):
+
+```typescript
+export const ValidationCaseEditor: FC<ValidationCaseEditorProps> = ({
+  transcriptId,
+  taskId,
+  taskRepeat,
+  className,
+}) => {
+```
+
+Update `ValidationCaseEditorComponentProps` (line 171):
+
+```typescript
+interface ValidationCaseEditorComponentProps {
+  transcriptId: string;
+  taskId?: string | null;
+  taskRepeat?: number | null;
+  validationSets: string[];
+  editorValidationSetUri?: string;
+  validationCase?: ValidationCase | null;
+  validationCases?: ValidationCase[];
+  className?: string | string[];
+}
+```
+
+Pass the props through to `ValidationCaseEditorComponent` (around line 153):
+
+```typescript
+            <ValidationCaseEditorComponent
+              key={validatedSetUri}
+              transcriptId={transcriptId}
+              taskId={taskId}
+              taskRepeat={taskRepeat}
+              validationSets={setsData}
+              editorValidationSetUri={validatedSetUri}
+              validationCase={caseData}
+              validationCases={casesData}
+              className={className}
+            />
+```
+
+Update the inner component destructuring (line 180):
+
+```typescript
+const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
+  transcriptId,
+  taskId,
+  taskRepeat,
+  validationSets,
+  editorValidationSetUri,
+  validationCase: caseData,
+  validationCases,
+  className,
+}) => {
+```
+
+- [ ] **Step 2: Include metadata in the upsert request**
+
+In `handleFieldChange` (around line 291), add `task_id` and `task_repeat` to the request object:
+
+```typescript
+      const request: ValidationCaseRequest = {
+        id: updatedCase.id,
+        target: updatedCase.target,
+        labels: updatedCase.labels,
+        predicate: updatedCase.predicate,
+        split: updatedCase.split,
+        task_id: updatedCase.task_id ?? (taskId !== null ? taskId : undefined),
+        task_repeat:
+          updatedCase.task_repeat ??
+          (taskRepeat !== null ? taskRepeat : undefined),
+      };
+```
+
+This logic: use the value already on the case if it exists (e.g., when editing an existing case that already has metadata), otherwise use the prop values from the parent transcript context. This ensures metadata is set on first save but preserved on subsequent edits.
+
+Also add `taskId` and `taskRepeat` to the `handleFieldChange` `useCallback` dependency array (around line 317):
+
+```typescript
+    [
+      editorValidationSetUri,
+      transcriptId,
+      caseData,
+      queryClient,
+      updateValidationCaseMutation,
+      taskId,
+      taskRepeat,
+    ]
+```
+
+- [ ] **Step 3: Pass props from `TranscriptBody`**
+
+In `src/inspect_scout/_view/ts-mono/apps/scout/src/app/transcript/TranscriptBody.tsx` (line 565), update the `ValidationCaseEditor` usage:
+
+```typescript
+            <ValidationCaseEditor
+              transcriptId={transcript.transcript_id}
+              taskId={transcript.task_id}
+              taskRepeat={transcript.task_repeat}
+            />
+```
+
+- [ ] **Step 4: Pass props from `ScannerResultPanel`**
+
+In `src/inspect_scout/_view/ts-mono/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx` (line 486), update the `ValidationCaseEditor` usage:
+
+```typescript
+                <ValidationCaseEditor
+                  transcriptId={selectedResult.transcriptId}
+                  taskId={selectedResult.transcriptTaskId != null ? String(selectedResult.transcriptTaskId) : undefined}
+                  taskRepeat={selectedResult.transcriptTaskRepeat}
+                />
+```
+
+Note: `selectedResult.transcriptTaskId` is typed as `string | number | undefined`, so we coerce to string to match the `task_id` field type.
+
+- [ ] **Step 5: Run TypeScript checks**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+pnpm check
+cd -
+```
+
+Expected: No errors
+
+- [ ] **Step 6: Build**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+pnpm build
+cd -
+```
+
+Expected: Build succeeds
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+git add apps/scout/src/app/validation/components/ValidationCaseEditor.tsx apps/scout/src/app/transcript/TranscriptBody.tsx apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+git commit -m "feat: pass task_id and task_repeat through validation case editor"
+cd -
+```
+
+---
+
+### Task 8: Commit built assets and update submodule
+
+- [ ] **Step 1: Build final dist assets**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+pnpm build
+cd -
+```
+
+- [ ] **Step 2: Commit built dist in base repo**
+
+```bash
+git add src/inspect_scout/_view/dist/
+git add src/inspect_scout/_view/ts-mono
+git commit -m "chore: update built assets and submodule pointer"
+```
+
+---
+
+### Task 9: Final verification
+
+- [ ] **Step 1: Run full Python test suite**
+
+Run: `.venv/bin/pytest tests/view/test_validation_api.py -v`
+Expected: All PASS
+
+- [ ] **Step 2: Run Python checks**
+
+Run: `make check` (from repo root)
+Expected: No errors
+
+- [ ] **Step 3: Run TypeScript checks and build**
+
+```bash
+cd src/inspect_scout/_view/ts-mono
+pnpm check && pnpm build
+cd -
+```
+
+Expected: No errors

--- a/src/inspect_scout/_validation/types.py
+++ b/src/inspect_scout/_validation/types.py
@@ -43,6 +43,12 @@ class ValidationCase(BaseModel):
     split: str | None = Field(default=None)
     """Optional split name for organizing cases (e.g., 'dev', 'test', 'train')."""
 
+    task_id: str | None = Field(default=None)
+    """Optional sample identifier from the source eval log (informational only)."""
+
+    task_repeat: int | None = Field(default=None)
+    """Optional epoch/repeat number from the source eval log (informational only)."""
+
     @field_validator("labels", mode="before")
     @classmethod
     def coerce_labels_to_bool(cls, v: Any) -> dict[str, bool] | None:

--- a/src/inspect_scout/_view/_api_v2_types.py
+++ b/src/inspect_scout/_view/_api_v2_types.py
@@ -204,6 +204,12 @@ class ValidationCaseRequest:
     predicate: str | None = None
     """Optional predicate for comparing scanner result to target."""
 
+    task_id: str | None = None
+    """Optional sample identifier (informational, written to file but not used in validation)."""
+
+    task_repeat: int | None = None
+    """Optional epoch/repeat number (informational, written to file but not used in validation)."""
+
 
 @dataclass
 class CreateValidationSetRequest:

--- a/src/inspect_scout/_view/_api_v2_validations.py
+++ b/src/inspect_scout/_view/_api_v2_validations.py
@@ -96,6 +96,8 @@ def create_validation_router(
                     labels=case_req.labels,
                     split=case_req.split,
                     predicate=cast(PredicateType | None, case_req.predicate),
+                    task_id=case_req.task_id,
+                    task_repeat=case_req.task_repeat,
                 )
             )
 
@@ -289,6 +291,8 @@ def create_validation_router(
                 labels=body.labels,
                 split=body.split,
                 predicate=cast(PredicateType | None, body.predicate),
+                task_id=body.task_id,
+                task_repeat=body.task_repeat,
             )
 
             writer.upsert_case(case)

--- a/src/inspect_scout/_view/dist/assets/index-BuG8uQRY.js
+++ b/src/inspect_scout/_view/dist/assets/index-BuG8uQRY.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6f698672969188f279b11ebcae3a6f932f298d14eee0e5e031248900ae10496
-size 3201172

--- a/src/inspect_scout/_view/dist/assets/index-BuG8uQRY.js
+++ b/src/inspect_scout/_view/dist/assets/index-BuG8uQRY.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f698672969188f279b11ebcae3a6f932f298d14eee0e5e031248900ae10496
+size 3201172

--- a/src/inspect_scout/_view/dist/assets/index-C3K7225e.css
+++ b/src/inspect_scout/_view/dist/assets/index-C3K7225e.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9b1dc2818bb1938f0695645814b5e695930bf82813ebd04a742d31926589a7c
+size 1115928

--- a/src/inspect_scout/_view/dist/assets/index-COigHL6k.js
+++ b/src/inspect_scout/_view/dist/assets/index-COigHL6k.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92d60e5faccd3a6eebb71684310b4ab206e960251ca08115dc5a714d7b2890db
-size 3200870

--- a/src/inspect_scout/_view/dist/assets/index-DLF47L7f.css
+++ b/src/inspect_scout/_view/dist/assets/index-DLF47L7f.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f0ab8bf101db3f28ef782870e79b663ac5ed8757e270ec5b34e501f972479b7
-size 1115928

--- a/src/inspect_scout/_view/dist/assets/index-DmtArsgT.js
+++ b/src/inspect_scout/_view/dist/assets/index-DmtArsgT.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f18bd4e3ab1b3c2e49f642eb43122c80ba607e1569a7ba07f3545be03e794d28
+size 3201173

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4de23d33b018a438b1bf7aab3d52d692083090b894e67c0d9dbb91e083b27c8
+oid sha256:447ec853cecd2238ba16d28e8bf4b62b6b32f8e690de3358d093b46c6b949ba9
 size 2055

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:447ec853cecd2238ba16d28e8bf4b62b6b32f8e690de3358d093b46c6b949ba9
+oid sha256:d987b63bc157980b456773792f235c0b7072ffaaf7a4926790df6ab52c71f709
 size 2055

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -800,7 +800,7 @@
         "type": "object"
       },
       "BudgetPercent": {
-        "description": "Fire on each ``percent``-percent slice of the active ``budget``.\n\n``percent`` is in 0..100. With ``percent=25``, the trigger fires\nat ~25% / 50% / 75% / 100% of the relevant limit's usage. Has no\neffect when no limit is set for the chosen budget.",
+        "description": "Fire at percentage milestones of a named budget. Not yet implemented (Phase 5).\n\nExample: ``BudgetPercent(budget=\"cost\", percent=10)`` fires at 10%, 20%, \u2026\nof the ``cost_limit`` configured on the task or sample.",
         "properties": {
           "budget": {
             "enum": [
@@ -993,8 +993,7 @@
               {
                 "enum": [
                   "input",
-                  "generate",
-                  "operator"
+                  "generate"
                 ],
                 "type": "string"
               },
@@ -1102,8 +1101,7 @@
               {
                 "enum": [
                   "input",
-                  "generate",
-                  "operator"
+                  "generate"
                 ],
                 "type": "string"
               },
@@ -1218,8 +1216,7 @@
               {
                 "enum": [
                   "input",
-                  "generate",
-                  "operator"
+                  "generate"
                 ],
                 "type": "string"
               },
@@ -1324,8 +1321,7 @@
               {
                 "enum": [
                   "input",
-                  "generate",
-                  "operator"
+                  "generate"
                 ],
                 "type": "string"
               },
@@ -1355,129 +1351,6 @@
           "role"
         ],
         "title": "ChatMessageUser",
-        "type": "object"
-      },
-      "CheckpointEvent": {
-        "additionalProperties": true,
-        "description": "A successful checkpoint commit.\n\nEmitted by the checkpointer immediately after the per-checkpoint\nsidecar JSON is written \u2014 see working.md \u00a78a. Carries the full\nsidecar payload flattened into top-level fields (via multiple\ninheritance from :class:`CheckpointDetails`), so a consumer of\n``transcript().events`` (or the ``.eval`` log) reads\n``event.checkpoint_id`` / ``event.trigger`` / ``event.host`` etc.\ndirectly \u2014 same data as someone reading\n``<sample>/ckpt-NNNNN.json`` from disk.",
-        "properties": {
-          "checkpoint_id": {
-            "title": "Checkpoint Id",
-            "type": "integer"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "duration_ms": {
-            "title": "Duration Ms",
-            "type": "integer"
-          },
-          "event": {
-            "const": "checkpoint",
-            "default": "checkpoint",
-            "title": "Event",
-            "type": "string"
-          },
-          "host": {
-            "$ref": "#/components/schemas/SnapshotDetails"
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metadata"
-          },
-          "pending": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pending"
-          },
-          "sandboxes": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/SnapshotDetails"
-            },
-            "title": "Sandboxes",
-            "type": "object"
-          },
-          "size_bytes": {
-            "title": "Size Bytes",
-            "type": "integer"
-          },
-          "span_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Span Id"
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string"
-          },
-          "trigger": {
-            "enum": [
-              "time",
-              "turn",
-              "manual",
-              "token",
-              "cost",
-              "budget"
-            ],
-            "title": "Trigger",
-            "type": "string"
-          },
-          "turn": {
-            "title": "Turn",
-            "type": "integer"
-          },
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uuid"
-          },
-          "working_start": {
-            "title": "Working Start",
-            "type": "number"
-          }
-        },
-        "required": [
-          "checkpoint_id",
-          "trigger",
-          "turn",
-          "created_at",
-          "duration_ms",
-          "size_bytes",
-          "host",
-          "sandboxes",
-          "timestamp",
-          "working_start",
-          "event"
-        ],
-        "title": "CheckpointEvent",
         "type": "object"
       },
       "CheckpointSampleConfig": {
@@ -1514,13 +1387,10 @@
           "trigger": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Manual"
+                "$ref": "#/components/schemas/TimeInterval"
               },
               {
                 "$ref": "#/components/schemas/TurnInterval"
-              },
-              {
-                "$ref": "#/components/schemas/TimeInterval"
               },
               {
                 "$ref": "#/components/schemas/TokenInterval"
@@ -1530,6 +1400,10 @@
               },
               {
                 "$ref": "#/components/schemas/BudgetPercent"
+              },
+              {
+                "const": "manual",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2292,7 +2166,7 @@
         "type": "object"
       },
       "CostInterval": {
-        "description": "Fire every ``every`` dollars of sample-level cost.\n\nSample total cost is read from\n:func:`inspect_ai.model.sample_total_cost`; the trigger fires\neach time the running total crosses another ``every``-dollar\nboundary since the last fire.",
+        "description": "Fire every $N spent. Not yet implemented (Phase 5).",
         "properties": {
           "every": {
             "title": "Every",
@@ -3941,119 +3815,6 @@
         "title": "InputEvent",
         "type": "object"
       },
-      "InterruptEvent": {
-        "description": "Records that an agent's turn or sample was cut short.\n\nEmitted in three cases:\n\n- ``source=\"user_cancel\"`` \u2014 an ACP client (e.g. an editor or TUI)\n  called ``session/cancel`` while a turn was in flight.\n- ``source=\"limit\"`` \u2014 a sample-level limit (tokens, time, cost,\n  messages) tripped during execution.\n- ``source=\"system\"`` \u2014 the eval is shutting down for an external\n  reason and is cancelling active samples.\n\nThe ``interrupted`` field records what was running at the moment\nthe cancel reached the cancel scope. ``interrupted_tool_call_id``\nand ``interrupted_model_event_id`` give cross-references when\napplicable so downstream consumers can correlate this event with\nthe in-flight ``ToolEvent`` or ``ModelEvent``.",
-        "properties": {
-          "event": {
-            "const": "interrupt",
-            "default": "interrupt",
-            "title": "Event",
-            "type": "string"
-          },
-          "interrupted": {
-            "enum": [
-              "generate",
-              "tool_call",
-              "between_turns"
-            ],
-            "title": "Interrupted",
-            "type": "string"
-          },
-          "interrupted_model_event_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Interrupted Model Event Id"
-          },
-          "interrupted_tool_call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Interrupted Tool Call Id"
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metadata"
-          },
-          "pending": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pending"
-          },
-          "source": {
-            "enum": [
-              "user_cancel",
-              "limit",
-              "system"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "span_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Span Id"
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string"
-          },
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uuid"
-          },
-          "working_start": {
-            "title": "Working Start",
-            "type": "number"
-          }
-        },
-        "required": [
-          "timestamp",
-          "working_start",
-          "event",
-          "source",
-          "interrupted"
-        ],
-        "title": "InterruptEvent",
-        "type": "object"
-      },
       "InvalidationTopic": {
         "enum": [
           "project-config",
@@ -4937,12 +4698,6 @@
         "title": "Logprobs",
         "type": "object"
       },
-      "Manual": {
-        "description": "No-op trigger spec.\n\nThe engine's ``tick()`` always returns ``None`` for this spec \u2014\nfires happen only through explicit ``cp.checkpoint()`` calls.",
-        "properties": {},
-        "title": "Manual",
-        "type": "object"
-      },
       "MessageFormatOptions": {
         "description": "Message formatting options for controlling message content display.\n\nThese options control which parts of messages are included when\nformatting messages to strings.",
         "properties": {
@@ -5022,16 +4777,10 @@
                   "$ref": "#/components/schemas/BranchEvent"
                 },
                 {
-                  "$ref": "#/components/schemas/CheckpointEvent"
-                },
-                {
                   "$ref": "#/components/schemas/CompactionEvent"
                 },
                 {
                   "$ref": "#/components/schemas/InputEvent"
-                },
-                {
-                  "$ref": "#/components/schemas/InterruptEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ScoreEvent"
@@ -8092,16 +7841,10 @@
                 "$ref": "#/components/schemas/BranchEvent"
               },
               {
-                "$ref": "#/components/schemas/CheckpointEvent"
-              },
-              {
                 "$ref": "#/components/schemas/CompactionEvent"
               },
               {
                 "$ref": "#/components/schemas/InputEvent"
-              },
-              {
-                "$ref": "#/components/schemas/InterruptEvent"
               },
               {
                 "$ref": "#/components/schemas/ScoreEvent"
@@ -8164,16 +7907,10 @@
                       "$ref": "#/components/schemas/BranchEvent"
                     },
                     {
-                      "$ref": "#/components/schemas/CheckpointEvent"
-                    },
-                    {
                       "$ref": "#/components/schemas/CompactionEvent"
                     },
                     {
                       "$ref": "#/components/schemas/InputEvent"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InterruptEvent"
                     },
                     {
                       "$ref": "#/components/schemas/ScoreEvent"
@@ -9015,31 +8752,6 @@
         "title": "SearchResponse",
         "type": "object"
       },
-      "SnapshotDetails": {
-        "additionalProperties": true,
-        "description": "Per-backup stats captured in the sidecar.\n\nOne per repo (host repo + one per active sandbox repo). Values come\nfrom restic's backup summary \u2014 see :class:`ResticBackupSummary`.",
-        "properties": {
-          "duration_ms": {
-            "title": "Duration Ms",
-            "type": "integer"
-          },
-          "size_bytes": {
-            "title": "Size Bytes",
-            "type": "integer"
-          },
-          "snapshot_id": {
-            "title": "Snapshot Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "snapshot_id",
-          "size_bytes",
-          "duration_ms"
-        ],
-        "title": "SnapshotDetails",
-        "type": "object"
-      },
       "SpanBeginEvent": {
         "description": "Mark the beginning of a transcript span.",
         "properties": {
@@ -9657,7 +9369,7 @@
         "type": "object"
       },
       "TimeInterval": {
-        "description": "Fire after a wall-clock interval.\n\nThe engine fires when at least ``every`` has elapsed since the\nlast fire (or since the session opened, for the first fire).",
+        "description": "Fire every N of wall-clock time.",
         "properties": {
           "every": {
             "format": "duration",
@@ -9831,7 +9543,7 @@
         "type": "object"
       },
       "TokenInterval": {
-        "description": "Fire every ``every`` tokens of sample-level usage.\n\nSample total tokens are read from\n:func:`inspect_ai.model.sample_total_tokens`; the trigger fires\neach time the running total crosses another ``every``-token\nboundary since the last fire.",
+        "description": "Fire every N tokens generated. Not yet implemented (Phase 5).",
         "properties": {
           "every": {
             "title": "Every",
@@ -9950,7 +9662,6 @@
               "is_a_directory",
               "limit",
               "approval",
-              "cancelled",
               "unknown",
               "output_limit"
             ],
@@ -10467,16 +10178,10 @@
                   "$ref": "#/components/schemas/BranchEvent"
                 },
                 {
-                  "$ref": "#/components/schemas/CheckpointEvent"
-                },
-                {
                   "$ref": "#/components/schemas/CompactionEvent"
                 },
                 {
                   "$ref": "#/components/schemas/InputEvent"
-                },
-                {
-                  "$ref": "#/components/schemas/InterruptEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ScoreEvent"
@@ -11032,7 +10737,7 @@
         "type": "object"
       },
       "TurnInterval": {
-        "description": "Fire after every ``every`` agent turns of work.\n\nThe very first ``tick()`` call marks the boundary *before* turn 1\nhas run \u2014 agents place ``cp.tick()`` at the top of their loop, so\nthe opening tick stands between \"no turn yet\" and \"turn 1.\" That\nboundary is informational and doesn't count toward the threshold;\notherwise ``every=1`` would fire an empty checkpoint on the\nopening tick.",
+        "description": "Fire every N agent turns.",
         "properties": {
           "every": {
             "title": "Every",
@@ -11185,6 +10890,28 @@
                 "type": "null"
               }
             ]
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "task_repeat": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Repeat"
           }
         },
         "required": [
@@ -11258,6 +10985,28 @@
                 "type": "null"
               }
             ]
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "task_repeat": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Repeat"
           }
         },
         "title": "ValidationCaseRequest",

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -800,7 +800,7 @@
         "type": "object"
       },
       "BudgetPercent": {
-        "description": "Fire at percentage milestones of a named budget. Not yet implemented (Phase 5).\n\nExample: ``BudgetPercent(budget=\"cost\", percent=10)`` fires at 10%, 20%, \u2026\nof the ``cost_limit`` configured on the task or sample.",
+        "description": "Fire on each ``percent``-percent slice of the active ``budget``.\n\n``percent`` is in 0..100. With ``percent=25``, the trigger fires\nat ~25% / 50% / 75% / 100% of the relevant limit's usage. Has no\neffect when no limit is set for the chosen budget.",
         "properties": {
           "budget": {
             "enum": [
@@ -993,7 +993,8 @@
               {
                 "enum": [
                   "input",
-                  "generate"
+                  "generate",
+                  "operator"
                 ],
                 "type": "string"
               },
@@ -1101,7 +1102,8 @@
               {
                 "enum": [
                   "input",
-                  "generate"
+                  "generate",
+                  "operator"
                 ],
                 "type": "string"
               },
@@ -1216,7 +1218,8 @@
               {
                 "enum": [
                   "input",
-                  "generate"
+                  "generate",
+                  "operator"
                 ],
                 "type": "string"
               },
@@ -1321,7 +1324,8 @@
               {
                 "enum": [
                   "input",
-                  "generate"
+                  "generate",
+                  "operator"
                 ],
                 "type": "string"
               },
@@ -1351,6 +1355,129 @@
           "role"
         ],
         "title": "ChatMessageUser",
+        "type": "object"
+      },
+      "CheckpointEvent": {
+        "additionalProperties": true,
+        "description": "A successful checkpoint commit.\n\nEmitted by the checkpointer immediately after the per-checkpoint\nsidecar JSON is written \u2014 see working.md \u00a78a. Carries the full\nsidecar payload flattened into top-level fields (via multiple\ninheritance from :class:`CheckpointDetails`), so a consumer of\n``transcript().events`` (or the ``.eval`` log) reads\n``event.checkpoint_id`` / ``event.trigger`` / ``event.host`` etc.\ndirectly \u2014 same data as someone reading\n``<sample>/ckpt-NNNNN.json`` from disk.",
+        "properties": {
+          "checkpoint_id": {
+            "title": "Checkpoint Id",
+            "type": "integer"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "duration_ms": {
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "event": {
+            "const": "checkpoint",
+            "default": "checkpoint",
+            "title": "Event",
+            "type": "string"
+          },
+          "host": {
+            "$ref": "#/components/schemas/SnapshotDetails"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "pending": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending"
+          },
+          "sandboxes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SnapshotDetails"
+            },
+            "title": "Sandboxes",
+            "type": "object"
+          },
+          "size_bytes": {
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "trigger": {
+            "enum": [
+              "time",
+              "turn",
+              "manual",
+              "token",
+              "cost",
+              "budget"
+            ],
+            "title": "Trigger",
+            "type": "string"
+          },
+          "turn": {
+            "title": "Turn",
+            "type": "integer"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "working_start": {
+            "title": "Working Start",
+            "type": "number"
+          }
+        },
+        "required": [
+          "checkpoint_id",
+          "trigger",
+          "turn",
+          "created_at",
+          "duration_ms",
+          "size_bytes",
+          "host",
+          "sandboxes",
+          "timestamp",
+          "working_start",
+          "event"
+        ],
+        "title": "CheckpointEvent",
         "type": "object"
       },
       "CheckpointSampleConfig": {
@@ -1387,10 +1514,13 @@
           "trigger": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/TimeInterval"
+                "$ref": "#/components/schemas/Manual"
               },
               {
                 "$ref": "#/components/schemas/TurnInterval"
+              },
+              {
+                "$ref": "#/components/schemas/TimeInterval"
               },
               {
                 "$ref": "#/components/schemas/TokenInterval"
@@ -1400,10 +1530,6 @@
               },
               {
                 "$ref": "#/components/schemas/BudgetPercent"
-              },
-              {
-                "const": "manual",
-                "type": "string"
               },
               {
                 "type": "null"
@@ -2166,7 +2292,7 @@
         "type": "object"
       },
       "CostInterval": {
-        "description": "Fire every $N spent. Not yet implemented (Phase 5).",
+        "description": "Fire every ``every`` dollars of sample-level cost.\n\nSample total cost is read from\n:func:`inspect_ai.model.sample_total_cost`; the trigger fires\neach time the running total crosses another ``every``-dollar\nboundary since the last fire.",
         "properties": {
           "every": {
             "title": "Every",
@@ -3815,6 +3941,119 @@
         "title": "InputEvent",
         "type": "object"
       },
+      "InterruptEvent": {
+        "description": "Records that an agent's turn or sample was cut short.\n\nEmitted in three cases:\n\n- ``source=\"user_cancel\"`` \u2014 an ACP client (e.g. an editor or TUI)\n  called ``session/cancel`` while a turn was in flight.\n- ``source=\"limit\"`` \u2014 a sample-level limit (tokens, time, cost,\n  messages) tripped during execution.\n- ``source=\"system\"`` \u2014 the eval is shutting down for an external\n  reason and is cancelling active samples.\n\nThe ``interrupted`` field records what was running at the moment\nthe cancel reached the cancel scope. ``interrupted_tool_call_id``\nand ``interrupted_model_event_id`` give cross-references when\napplicable so downstream consumers can correlate this event with\nthe in-flight ``ToolEvent`` or ``ModelEvent``.",
+        "properties": {
+          "event": {
+            "const": "interrupt",
+            "default": "interrupt",
+            "title": "Event",
+            "type": "string"
+          },
+          "interrupted": {
+            "enum": [
+              "generate",
+              "tool_call",
+              "between_turns"
+            ],
+            "title": "Interrupted",
+            "type": "string"
+          },
+          "interrupted_model_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interrupted Model Event Id"
+          },
+          "interrupted_tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interrupted Tool Call Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "pending": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending"
+          },
+          "source": {
+            "enum": [
+              "user_cancel",
+              "limit",
+              "system"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "working_start": {
+            "title": "Working Start",
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "working_start",
+          "event",
+          "source",
+          "interrupted"
+        ],
+        "title": "InterruptEvent",
+        "type": "object"
+      },
       "InvalidationTopic": {
         "enum": [
           "project-config",
@@ -4698,6 +4937,12 @@
         "title": "Logprobs",
         "type": "object"
       },
+      "Manual": {
+        "description": "No-op trigger spec.\n\nThe engine's ``tick()`` always returns ``None`` for this spec \u2014\nfires happen only through explicit ``cp.checkpoint()`` calls.",
+        "properties": {},
+        "title": "Manual",
+        "type": "object"
+      },
       "MessageFormatOptions": {
         "description": "Message formatting options for controlling message content display.\n\nThese options control which parts of messages are included when\nformatting messages to strings.",
         "properties": {
@@ -4777,10 +5022,16 @@
                   "$ref": "#/components/schemas/BranchEvent"
                 },
                 {
+                  "$ref": "#/components/schemas/CheckpointEvent"
+                },
+                {
                   "$ref": "#/components/schemas/CompactionEvent"
                 },
                 {
                   "$ref": "#/components/schemas/InputEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/InterruptEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ScoreEvent"
@@ -7841,10 +8092,16 @@
                 "$ref": "#/components/schemas/BranchEvent"
               },
               {
+                "$ref": "#/components/schemas/CheckpointEvent"
+              },
+              {
                 "$ref": "#/components/schemas/CompactionEvent"
               },
               {
                 "$ref": "#/components/schemas/InputEvent"
+              },
+              {
+                "$ref": "#/components/schemas/InterruptEvent"
               },
               {
                 "$ref": "#/components/schemas/ScoreEvent"
@@ -7907,10 +8164,16 @@
                       "$ref": "#/components/schemas/BranchEvent"
                     },
                     {
+                      "$ref": "#/components/schemas/CheckpointEvent"
+                    },
+                    {
                       "$ref": "#/components/schemas/CompactionEvent"
                     },
                     {
                       "$ref": "#/components/schemas/InputEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InterruptEvent"
                     },
                     {
                       "$ref": "#/components/schemas/ScoreEvent"
@@ -8752,6 +9015,31 @@
         "title": "SearchResponse",
         "type": "object"
       },
+      "SnapshotDetails": {
+        "additionalProperties": true,
+        "description": "Per-backup stats captured in the sidecar.\n\nOne per repo (host repo + one per active sandbox repo). Values come\nfrom restic's backup summary \u2014 see :class:`ResticBackupSummary`.",
+        "properties": {
+          "duration_ms": {
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "size_bytes": {
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "snapshot_id": {
+            "title": "Snapshot Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "snapshot_id",
+          "size_bytes",
+          "duration_ms"
+        ],
+        "title": "SnapshotDetails",
+        "type": "object"
+      },
       "SpanBeginEvent": {
         "description": "Mark the beginning of a transcript span.",
         "properties": {
@@ -9369,7 +9657,7 @@
         "type": "object"
       },
       "TimeInterval": {
-        "description": "Fire every N of wall-clock time.",
+        "description": "Fire after a wall-clock interval.\n\nThe engine fires when at least ``every`` has elapsed since the\nlast fire (or since the session opened, for the first fire).",
         "properties": {
           "every": {
             "format": "duration",
@@ -9543,7 +9831,7 @@
         "type": "object"
       },
       "TokenInterval": {
-        "description": "Fire every N tokens generated. Not yet implemented (Phase 5).",
+        "description": "Fire every ``every`` tokens of sample-level usage.\n\nSample total tokens are read from\n:func:`inspect_ai.model.sample_total_tokens`; the trigger fires\neach time the running total crosses another ``every``-token\nboundary since the last fire.",
         "properties": {
           "every": {
             "title": "Every",
@@ -9662,6 +9950,7 @@
               "is_a_directory",
               "limit",
               "approval",
+              "cancelled",
               "unknown",
               "output_limit"
             ],
@@ -10178,10 +10467,16 @@
                   "$ref": "#/components/schemas/BranchEvent"
                 },
                 {
+                  "$ref": "#/components/schemas/CheckpointEvent"
+                },
+                {
                   "$ref": "#/components/schemas/CompactionEvent"
                 },
                 {
                   "$ref": "#/components/schemas/InputEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/InterruptEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ScoreEvent"
@@ -10737,7 +11032,7 @@
         "type": "object"
       },
       "TurnInterval": {
-        "description": "Fire every N agent turns.",
+        "description": "Fire after every ``every`` agent turns of work.\n\nThe very first ``tick()`` call marks the boundary *before* turn 1\nhas run \u2014 agents place ``cp.tick()`` at the top of their loop, so\nthe opening tick stands between \"no turn yet\" and \"turn 1.\" That\nboundary is informational and doesn't count toward the threshold;\notherwise ``every=1`` would fire an empty checkpoint on the\nopening tick.",
         "properties": {
           "every": {
             "title": "Every",

--- a/tests/view/test_validation_api.py
+++ b/tests/view/test_validation_api.py
@@ -829,6 +829,32 @@ def test_upsert_case_without_metadata(client: TestClient, validation_csv: Path) 
     assert "task_repeat" not in data
 
 
+def test_metadata_persists_in_csv(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat appear as columns in the CSV file."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_csv_meta")
+
+    client.post(
+        f"/validations/{encoded_uri}/{case_id}",
+        json={"target": True, "task_id": "sample_7", "task_repeat": 2},
+    )
+
+    # Read the raw CSV and verify columns exist
+    csv_content = validation_csv.read_text()
+    assert "task_id" in csv_content
+    assert "task_repeat" in csv_content
+    assert "sample_7" in csv_content
+
+    # Read back via API — list all cases
+    all_resp = client.get(f"/validations/{encoded_uri}")
+    assert all_resp.status_code == 200
+    cases = all_resp.json()
+    meta_case = next(c for c in cases if c["id"] == "t_csv_meta")
+    assert meta_case["task_id"] == "sample_7"
+    assert meta_case["task_repeat"] == 2
+
+
 def _git_init(path: Path) -> None:
     """Initialize a git repo at `path` with a deterministic identity."""
     import subprocess

--- a/tests/view/test_validation_api.py
+++ b/tests/view/test_validation_api.py
@@ -813,6 +813,22 @@ def test_upsert_case_with_metadata(client: TestClient, validation_csv: Path) -> 
     assert get_data["task_repeat"] == 3
 
 
+def test_upsert_case_without_metadata(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat are absent from response when not provided."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_no_meta")
+
+    resp = client.post(
+        f"/validations/{encoded_uri}/{case_id}",
+        json={"target": True},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "task_id" not in data
+    assert "task_repeat" not in data
+
+
 def _git_init(path: Path) -> None:
     """Initialize a git repo at `path` with a deterministic identity."""
     import subprocess

--- a/tests/view/test_validation_api.py
+++ b/tests/view/test_validation_api.py
@@ -786,6 +786,33 @@ class TestFileScannerFunctions:
         assert node_file.resolve() not in files
 
 
+def test_upsert_case_with_metadata(client: TestClient, validation_csv: Path) -> None:
+    """task_id and task_repeat are stored and returned when provided."""
+    uri = validation_csv.as_uri()
+    encoded_uri = _base64url(uri)
+    case_id = _base64url("t_meta")
+
+    resp = client.post(
+        f"/validations/{encoded_uri}/{case_id}",
+        json={
+            "target": True,
+            "task_id": "sample_42",
+            "task_repeat": 3,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["task_id"] == "sample_42"
+    assert data["task_repeat"] == 3
+
+    # Read back
+    get_resp = client.get(f"/validations/{encoded_uri}/{case_id}")
+    assert get_resp.status_code == 200
+    get_data = get_resp.json()
+    assert get_data["task_id"] == "sample_42"
+    assert get_data["task_repeat"] == 3
+
+
 def _git_init(path: Path) -> None:
     """Initialize a git repo at `path` with a deterministic identity."""
     import subprocess


### PR DESCRIPTION
## Summary
- Add optional `task_id` and `task_repeat` fields to `ValidationCase` and `ValidationCaseRequest` — informational metadata that makes validation files human-readable in external editors
- Thread the fields through both `create_validation` and `upsert_validation_case` API endpoints
- Regenerate OpenAPI schema and built frontend assets
- Frontend passes transcript metadata when creating/editing cases (via companion submodule PR)

## Companion PR
- meridianlabs-ai/ts-mono#247

## Test plan
- [x] `test_upsert_case_with_metadata` — metadata round-trips through upsert + read
- [x] `test_upsert_case_without_metadata` — fields absent when not provided
- [x] `test_metadata_persists_in_csv` — metadata appears as CSV columns and round-trips
- [x] Full validation test suite (174 tests pass)
- [x] `make check` — ruff, mypy clean
- [ ] Manual: create a validation case from a transcript, verify `task_id`/`task_repeat` in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)