### PR TITLE
Fix unclosed S3 session leak in `read_messages_events`

### DIFF
--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -520,16 +520,24 @@ class EvalLogTranscriptsView(TranscriptsView):
 
         recorder_type = recorder_type_for_location(t.source_uri)
         if recorder_type is EvalRecorder:
-            # Create filesystem - ownership transfers to returned CM
+            # Create filesystem - ownership transfers to the returned CM only on
+            # success; close it here if anything fails before then so we don't
+            # leak its S3 client/session ("Unclosed client session").
             fs = AsyncFilesystem()
-            source_uri = (
-                await self._files_cache.resolve_remote_uri_to_local(fs, t.source_uri)
-                if self._files_cache
-                else t.source_uri
-            )
-            zip_reader = CachingAsyncZipReader(fs, source_uri)
-            entry = await zip_reader.get_member_entry(sample_filename)
-            inner_cm = await zip_reader.open_member_raw(entry)
+            try:
+                source_uri = (
+                    await self._files_cache.resolve_remote_uri_to_local(
+                        fs, t.source_uri
+                    )
+                    if self._files_cache
+                    else t.source_uri
+                )
+                zip_reader = CachingAsyncZipReader(fs, source_uri)
+                entry = await zip_reader.get_member_entry(sample_filename)
+                inner_cm = await zip_reader.open_member_raw(entry)
+            except BaseException:
+                await fs.close()
+                raise
             return TranscriptMessagesAndEvents(
                 data=_OwnedZipStreamContextManager(fs, inner_cm),
                 compression_method=entry.compression_method,

--- a/tests/transcript/test_eval_log_read_messages_events.py
+++ b/tests/transcript/test_eval_log_read_messages_events.py
@@ -5,8 +5,11 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_scout._transcript import eval_log as eval_log_mod
 from inspect_scout._transcript.eval_log import EvalLogTranscriptsView
 from inspect_scout._transcript.types import TranscriptInfo
+from inspect_scout._util.caching_async_zip import CachingAsyncZipReader
 
 TEST_EVAL_LOGS_DIR = Path(__file__).parent.parent / "recorder" / "logs"
 
@@ -169,4 +172,54 @@ async def test_read_messages_events_cleans_up_via_aclose() -> None:
     assert close_called, (
         "AsyncFilesystem.close() was not called. "
         "aclose() should clean up resources when context manager is never entered."
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_messages_events_closes_fs_on_internal_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed read must not leak the AsyncFilesystem (its S3 client/session).
+
+    read_messages_events() creates an AsyncFilesystem and only transfers
+    ownership to the returned _OwnedZipStreamContextManager on the final
+    return. If any step in between raises (a stalled/failed S3 read, exactly
+    the scenario in the bug report), fs is dropped without close() — leaking
+    the aiohttp ClientSession/connector ("Unclosed client session").
+    """
+    eval_path = (
+        TEST_EVAL_LOGS_DIR
+        / "2025-11-07T10-59-47-05-00_websearch-addition-problem_LqPDntDnkk4h2fSqQ8i6CE.eval"
+    )
+
+    created: list[AsyncFilesystem] = []
+    closed: list[AsyncFilesystem] = []
+
+    # Track every AsyncFilesystem constructed by eval_log and whether it's closed.
+    class _TrackingFS(AsyncFilesystem):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+        async def close(self) -> None:
+            closed.append(self)
+            await super().close()
+
+    monkeypatch.setattr(eval_log_mod, "AsyncFilesystem", _TrackingFS)
+
+    # Simulate a read failing after the filesystem has been created.
+    async def _raise(self: CachingAsyncZipReader, member: Any) -> Any:
+        raise RuntimeError("simulated stalled read")
+
+    monkeypatch.setattr(CachingAsyncZipReader, "open_member_raw", _raise)
+
+    async with EvalLogTranscriptsView(str(eval_path)) as view:
+        info = await _get_first_transcript_info(view)
+        with pytest.raises(RuntimeError, match="simulated stalled read"):
+            await view.read_messages_events(info)
+
+    assert len(created) == 1, "expected read_messages_events to create one filesystem"
+    assert closed == created, (
+        "read_messages_events leaked an AsyncFilesystem (S3 client/session) when it "
+        "raised before transferring ownership to the returned context manager."
     )


### PR DESCRIPTION
## Problem

A large S3 scan reported a burst of `Unclosed client session` / `Unclosed connector` (aiohttp/aioboto3) errors at the end.
```
ERROR    Unclosed client session                                                                                        base_events.py:1871
         client_session: <aiohttp.client.ClientSession object at 0x144ba1950>                                                              
```

## Root cause

`EvalLogTranscriptsView.read_messages_events()` creates an `AsyncFilesystem`, performs S3 I/O with it, and transfers ownership to the returned `_OwnedZipStreamContextManager` **only on the final `return`**. With no `try/except`, any failure in between — `resolve_remote_uri_to_local`, `get_member_entry`, or `open_member_raw`, including cancellation of a stalled read — dropped `fs` without `close()`, leaking its aiohttp `ClientSession`/connector.

## Fix

Wrap the fallible I/O in `try/except BaseException`, `await fs.close()` on failure, then re-raise. `BaseException` (not `Exception`) so a cancelled stalled read — the report's scenario — also cleans up.

## Test

`test_read_messages_events_closes_fs_on_internal_error` simulates a failed read, tracks every `AsyncFilesystem` constructed, and asserts all are closed. Fails before the fix (1 created, 0 closed); passes after. Full `tests/transcript/` suite green (567 passed, 1 skipped).

## Scope

Closes the one genuine create-without-close path in current code. The scan `read()` path uses a `self._fs` singleton closed in `disconnect()`; it only leaks on hard worker-process teardown — a separate concern, not addressed here.