### PR TITLE
Fix scan listing dropping the file:// protocol from scan locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: Preserve the caller's protocol (e.g. `file://`) in scan locations returned by scan listing (regression in v0.4.36 that broke relative folder display in the VS Code scans panel).
+
 ## 0.4.39 (02 June 2026)
 
 - Transcript: Resolve `ModelEvent` input references from the consolidated `events_data` message and call pools.

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -624,17 +624,24 @@ class FileRecorder(ScanRecorder):
     @override
     @staticmethod
     async def list(scans_location: str) -> list[Status]:
+        base = UPath(scans_location)
         async with AsyncFilesystem() as fs:
-            # iter_dirs yields URIs with a trailing slash; normalize via
-            # UPath.as_posix() to match the no-slash form used everywhere
-            # else (e.g. sync(), location()) so Status.location compares
-            # equal across code paths.
-            scan_dirs = [
-                UPath(uri).as_posix()
-                async for uri in fs.iter_dirs(
-                    scans_location, "scan_id=*", recursive=True
-                )
-            ]
+            # iter_dirs yields trailing-slash URIs for remote filesystems but
+            # plain paths for local ones (fsspec strips the file:// scheme).
+            # Normalize to the no-slash form AND rebase onto scans_location so
+            # Status.location keeps the caller's protocol — callers (e.g. the
+            # VS Code extension, and location()/sync() comparisons) relativize
+            # locations against the scans location they requested.
+            scan_dirs: list[str] = []
+            async for uri in fs.iter_dirs(scans_location, "scan_id=*", recursive=True):
+                entry = UPath(uri)
+                if base.protocol and not entry.protocol:
+                    plain = entry.as_posix()
+                    base_plain = UPath(base.path).as_posix()
+                    if plain.startswith(base_plain):
+                        rel = plain[len(base_plain) :].strip("/")
+                        entry = base / rel if rel else base
+                scan_dirs.append(entry.as_posix())
 
         # Fetch in parallel; skip scans that no longer exist and propagate
         # any other error. return_exceptions=True keeps one failure from

--- a/tests/recorder/test_list.py
+++ b/tests/recorder/test_list.py
@@ -1,0 +1,61 @@
+"""Tests that FileRecorder.list returns locations in the caller's format."""
+
+from pathlib import Path
+
+import pytest
+from inspect_scout._recorder.file import FileRecorder
+from inspect_scout._scanspec import ScannerSpec, ScanSpec
+
+
+def _make_spec(scanners: list[str]) -> ScanSpec:
+    """Create a minimal ScanSpec for testing."""
+    return ScanSpec(
+        scan_name="test",
+        scanners={s: ScannerSpec(name=s) for s in scanners},
+    )
+
+
+@pytest.fixture
+def scout_buffer_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point SCOUT_SCANBUFFER_DIR at an isolated temp dir."""
+    buf_dir = tmp_path / "buffer"
+    monkeypatch.setenv("SCOUT_SCANBUFFER_DIR", str(buf_dir))
+    return buf_dir
+
+
+@pytest.mark.asyncio
+async def test_list_preserves_file_uri_locations(
+    tmp_path: Path, scout_buffer_dir: Path
+) -> None:
+    """Listing a file:// location yields file:// scan locations.
+
+    Callers (e.g. the VS Code extension) relativize Status.location against
+    the scans location they requested, so the protocol must round-trip.
+    """
+    scans_dir = tmp_path / "scans"
+    spec = _make_spec(["s"])
+    rec = FileRecorder()
+    await rec.init(spec, scans_dir.as_posix())
+
+    statuses = await FileRecorder.list(scans_dir.as_uri())
+
+    assert [s.location for s in statuses] == [
+        f"{scans_dir.as_uri()}/scan_id={spec.scan_id}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_plain_path_locations_unchanged(
+    tmp_path: Path, scout_buffer_dir: Path
+) -> None:
+    """Listing a plain path location yields plain path scan locations."""
+    scans_dir = tmp_path / "scans"
+    spec = _make_spec(["s"])
+    rec = FileRecorder()
+    await rec.init(spec, scans_dir.as_posix())
+
+    statuses = await FileRecorder.list(scans_dir.as_posix())
+
+    assert [s.location for s in statuses] == [
+        (scans_dir / f"scan_id={spec.scan_id}").as_posix()
+    ]


### PR DESCRIPTION
## Summary

Since #437, `FileRecorder.list()` enumerates scan dirs via `AsyncFilesystem.iter_dirs`, which yields plain paths for local filesystems (fsspec strips the `file://` scheme). Listing a `file://` scans location therefore returned plain-path `Status.location`s.

Callers relativize locations against the scans location they requested, so the protocol must round-trip. The visible symptom: the VS Code extension's scans activity panel showed the full absolute folder hierarchy (`Users/…`) instead of paths relative to the local `./scans` dir.

## Fix

Rebase entries yielded by `iter_dirs` onto the requested `scans_location` when the base has a protocol and the entry doesn't. `s3://` requests (where `iter_dirs` already yields URIs) and plain-path requests are unchanged.

## Tests

- New `tests/recorder/test_list.py`: `file://` round-trip (failed before the fix with `/private/var/...` vs `file:///private/var/...`), plus a plain-path test pinning existing behavior.
- `tests/recorder` (60), `tests/view` (140), `tests/scanjobs` (12) all pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)