### PR TITLE
Chunk token counting in segment_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Chunk token counting in segment_messages so large transcripts don't flood the connection pool.
+
 ## 0.4.39 (02 June 2026)
 
 - Transcript: Resolve `ModelEvent` input references from the consolidated `events_data` message and call pools.

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, overload
 
+import anyio
 from inspect_ai._util._async import tg_collect
 from inspect_ai.event import (
     CompactionEvent,
@@ -30,6 +31,18 @@ if TYPE_CHECKING:
 
 DEFAULT_CONTEXT_WINDOW = 128_000
 _TOKENIZER_SAFETY_MARGIN = 0.05
+
+# ``count_tokens`` can be a network call (e.g. Anthropic's count_tokens
+# endpoint), so counting each message individually floods the connection
+# pool and rate limits on large transcripts. Messages are instead grouped
+# into chunks targeting a small fraction of the segment budget (sized via
+# a rough chars-per-token estimate), each chunk is counted with a single
+# call, and only a handful of calls are in flight at once. Segments are
+# then packed from whole chunks, trading a small amount of packing
+# headroom (at most one chunk's worth per segment) for far fewer calls.
+_COUNT_CHUNK_BUDGET_FRACTION = 0.05
+_COUNT_EST_CHARS_PER_TOKEN = 4
+_COUNT_MAX_CONCURRENCY = 8
 
 
 def _effective_segment_budget(
@@ -87,10 +100,11 @@ async def segment_messages(
 ) -> AsyncIterator[MessagesSegment]:
     """Render messages and split them into segments that fit within a token budget.
 
-    Renders each message individually via ``messages_as_str``, counts
-    tokens in parallel via ``tg_collect``, then accumulates segments that
-    fit within the effective budget (context window minus the portion
-    reserved by ``prompt_reserve``).
+    Renders each message individually via ``messages_as_str``, groups
+    the rendered messages into chunks and counts tokens per chunk (one
+    ``count_tokens`` call each, with bounded concurrency), then packs
+    chunks into segments that fit within the effective budget (context
+    window minus the portion reserved by ``prompt_reserve``).
 
     When given events or a ``TimelineSpan``, delegates to
     ``span_messages()`` to extract and merge messages (handling
@@ -155,18 +169,41 @@ async def segment_messages(
     if not rendered:
         return
 
-    # Pass 2: Count tokens in parallel
+    # Pass 2: Group messages into chunks and count tokens per chunk
+    # (see _COUNT_* constants above for why counting is chunked).
+    chunk_char_target = max(
+        1,
+        int(
+            effective_budget * _COUNT_CHUNK_BUDGET_FRACTION * _COUNT_EST_CHARS_PER_TOKEN
+        ),
+    )
+    chunks: list[list[tuple[ChatMessage, str]]] = [[]]
+    chunk_chars = 0
+    for msg, text in rendered:
+        if chunks[-1] and chunk_chars + len(text) > chunk_char_target:
+            chunks.append([])
+            chunk_chars = 0
+        chunks[-1].append((msg, text))
+        chunk_chars += len(text)
+
+    count_limiter = anyio.Semaphore(_COUNT_MAX_CONCURRENCY)
+
+    async def count_chunk(text: str) -> int:
+        async with count_limiter:
+            return await model.count_tokens(text)
+
+    chunk_texts = ["\n".join(text for _, text in chunk) for chunk in chunks]
     token_counts = await tg_collect(
-        [lambda t=text: model.count_tokens(t) for _, text in rendered]  # type: ignore[misc]
+        [lambda t=text: count_chunk(t) for text in chunk_texts]  # type: ignore[misc]
     )
 
-    # Pass 3: Segment based on accumulated token counts
+    # Pass 3: Segment based on accumulated chunk token counts
     segment_counter = 0
     current_messages: list[ChatMessage] = []
     current_texts: list[str] = []
     running_tokens = 0
 
-    for (msg, text), tokens in zip(rendered, token_counts, strict=False):
+    for chunk, tokens in zip(chunks, token_counts, strict=True):
         if current_messages and running_tokens + tokens > effective_budget:
             yield MessagesSegment(
                 messages=current_messages,
@@ -178,8 +215,8 @@ async def segment_messages(
             current_texts = []
             running_tokens = 0
 
-        current_messages.append(msg)
-        current_texts.append(text)
+        current_messages.extend(msg for msg, _ in chunk)
+        current_texts.extend(text for _, text in chunk)
         running_tokens += tokens
 
     # Yield remaining segment

--- a/tests/transcript/test_messages.py
+++ b/tests/transcript/test_messages.py
@@ -649,6 +649,44 @@ async def test_segment_messages_events_with_chunking() -> None:
 
 
 @pytest.mark.anyio
+async def test_segment_messages_counts_in_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token counting batches messages into chunks, not one call per message."""
+    model = get_model("mockllm/model")
+    count_calls: list[str] = []
+    original_count = model.count_tokens
+
+    async def spy_count_tokens(
+        input: str | list[ChatMessage],
+        config: GenerateConfig | None = None,
+    ) -> int:
+        assert isinstance(input, str)
+        count_calls.append(input)
+        return await original_count(input, config)
+
+    monkeypatch.setattr(model, "count_tokens", spy_count_tokens)
+
+    msgs: list[ChatMessage] = [
+        ChatMessageUser(content=f"Message number {i}", id=f"m-{i}") for i in range(50)
+    ]
+    msgs_as_str, _ = message_numbering()
+    results: list[MessagesSegment] = []
+    async for seg in segment_messages(
+        msgs,
+        messages_as_str=msgs_as_str,
+        model=model,
+        context_window=100_000,
+    ):
+        results.append(seg)
+
+    # All 50 messages fit in a single chunk → a single count_tokens call
+    assert len(count_calls) == 1
+    assert len(results) == 1
+    assert len(results[0].messages) == 50
+
+
+@pytest.mark.anyio
 async def test_segment_messages_empty_input() -> None:
     """Empty list yields nothing."""
     results = await _collect([], context_window=10_000)


### PR DESCRIPTION
## Problem

Scans of ~100M-token runs with Anthropic models stall for 10+ minutes ("trouble getting connections", workers stuck at scanning). No issues with OpenAI models or small runs.

Root cause: Pass 2 of `segment_messages()` counted tokens with one `model.count_tokens()` call **per message**, fanned out via `tg_collect` which has **no concurrency cap**. For Anthropic each count is an HTTP POST to `/v1/messages/count_tokens` (OpenAI counts locally with tiktoken — hence no symptom there). A 100M-token run fires tens of thousands of concurrent requests per transcript: connection-pool exhaustion plus count_tokens rate-limit retry backoff. Note inspect_ai's `Model.count_tokens` deliberately applies no concurrency cap, assuming callers are O(delta) — this call pattern violated that.

## Fix

Segmentation only needs boundaries against the budget, not per-message counts:

- Group contiguous rendered messages into chunks targeting ~5% of the segment budget (sized via a chars/4 estimate; actual counts still come from the API)
- One `count_tokens` call per chunk, on the same `"\n"`-joined text used for the final segment string
- Cap in-flight count calls at 8 (`anyio.Semaphore`) so counting can't starve scan `generate()` calls
- Pack segments greedily from whole chunks

Net effect on a 100M-token run with a 1M-context model: ~2,500 bounded calls instead of ~100K unbounded. Small spans collapse to a single call. The `timeline_messages()` path gets this for free since it delegates to `segment_messages()`.

Tradeoffs: segments fill to ≥~95% of budget instead of exactly (worst case ~5% more segments). A multi-message chunk can't exceed the budget (chunk target is 5% of it), so oversized-single-message behavior is unchanged.


@jjallaire, `inspect_ai`'s `Model.count_tokens` deliberately has no concurrency cap (the comment assumes callers are `O(delta)`). Scout was violating that assumption; this fix restores it, but the fragility might be worth flagging upstream.