### PR TITLE
Fix pool content-size test impacted by inspect_ai fallback-models fields (#4229)

### DIFF
--- a/tests/transcript/test_parquet_db.py
+++ b/tests/transcript/test_parquet_db.py
@@ -2111,40 +2111,27 @@ async def test_pool_dedup_content_size_includes_pools(
     test_location: Path,
 ) -> None:
     """Content size from pool-dedup file accounts for pool columns, not just shrunken events."""
-    original = _transcript_with_repeated_inputs()
-
-    # Insert without pools — baseline size
-    no_pool_dir = test_location / "no_pool"
-    no_pool_dir.mkdir()
-    db_no = ParquetTranscriptsDB(str(no_pool_dir), pool_dedup=False)
-    await db_no.connect()
+    db = ParquetTranscriptsDB(str(test_location))
+    await db.connect()
     try:
-        await db_no.insert([original])
-        infos = [info async for info in db_no.select(Query(limit=1))]
-        result_no = await db_no.read_messages_events(infos[0])
-        size_no_pool = result_no.uncompressed_size
-    finally:
-        await db_no.disconnect()
+        await db.insert([_transcript_with_repeated_inputs()])
+        infos = [info async for info in db.select(Query(limit=1))]
+        result = await db.read_messages_events(infos[0])
+        size = result.uncompressed_size
 
-    # Insert with pools — size should include pool data
-    pool_dir = test_location / "pool"
-    pool_dir.mkdir()
-    db_pool = ParquetTranscriptsDB(str(pool_dir))
-    await db_pool.connect()
-    try:
-        await db_pool.insert([original])
-        infos = [info async for info in db_pool.select(Query(limit=1))]
-        result_pool = await db_pool.read_messages_events(infos[0])
-        size_pool = result_pool.uncompressed_size
+        chunks: list[bytes] = []
+        async with result.data as stream:
+            async for chunk in stream:
+                chunks.append(chunk)
+        streamed_size = len(b"".join(chunks))
     finally:
-        await db_pool.disconnect()
+        await db.disconnect()
 
-    # Pool size should be in the same ballpark as non-pool — not drastically smaller.
-    # Without Phase 4 fix, events shrink to just refs and pools aren't counted,
-    # so size_pool would be much less than size_no_pool.
-    assert size_no_pool is not None
-    assert size_pool is not None
-    assert size_pool > 0
-    assert size_pool >= size_no_pool * 0.5, (
-        f"Pool content size {size_pool} is suspiciously small vs non-pool {size_no_pool}"
+    # Reported size must account for everything streamed — including the
+    # events_data pool column, not just the shrunken events. The stream adds
+    # a small amount of JSON framing on top of the raw column contents.
+    assert size is not None
+    assert size <= streamed_size
+    assert size >= streamed_size * 0.9, (
+        f"Content size {size} omits pool data (streamed {streamed_size} bytes)"
     )


### PR DESCRIPTION
## Source of the regression

CI on main started failing `test_pool_dedup_content_size_includes_pools` after upstream **inspect_ai commit [`4a7ac937`](https://github.com/UKGovernmentBEIS/inspect_ai/commit/4a7ac9370ef867a21b2c51f52243a6f07ca64154) — "fallback models" ([UKGovernmentBEIS/inspect_ai#4229](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4229))** landed on inspect_ai main (2026-06-11), which scout pins via `inspect-ai @ git+...@main`. Confirmed by bisecting inspect_ai with the test's size measurement: the parent commit passes (ratio 0.509), that commit fails (0.499).

The commit added `fallback_models` to `GenerateConfig` and `fallback`/`ModelFallback` to `ModelOutput`. The non-pool storage path serializes events with nulls included, so each ModelEvent grew by `"fallback_models": null` + `"fallback": null` (~129 bytes across the fixture's 3 events), while the pool path (`condense_events`) strips nulls/defaults and was unaffected. The test's `pool >= 0.5 × non-pool` heuristic had been sitting at a 1.8% margin ever since inspect_ai's input/call-message pooling landed (inspect_ai #3374), so this baseline growth tipped it under the threshold. The dedup itself is correct — round-trip and content-equality tests all pass.

(The same upstream commit also caused the `check-schema-and-types` drift in `openapi.json`, fixed separately in #467 and merged into this branch.)

## Fix

Replace the fragile pool-vs-non-pool ratio with a direct assertion of the test's actual intent (per its docstring: content size accounts for pool columns, not just shrunken events):

- Stream the pool-dedup result and measure the actual bytes transmitted
- Assert reported `uncompressed_size` is between 90% and 100% of the streamed bytes (the gap is JSON framing added by the stream)

This still catches the original regression the test guards against — if the `events_data` pool column weren't counted, the reported size would be 2709 vs 3300 streamed and fail — but no longer breaks whenever an upstream field addition grows the non-pool baseline.

https://claude.ai/code/session_01K85PTD6R9WQp4mh95YzDfB