### PR TITLE
Regenerate types for anthropic fallback models

### DIFF
--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-CfMOhu2i.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-CfMOhu2i.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5f19df60d42d783dbb9d003111e3cefca205fbb717f2dfd1d736a3c051d39d9
-size 177046

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-Z6OFX-oS.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-Z6OFX-oS.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86825d47765a7898e6de543ced5209e073fd3e193820dc527f7c28736a669bb
+size 177046

--- a/src/inspect_scout/_view/dist/assets/index-C8y5ZXbm.css
+++ b/src/inspect_scout/_view/dist/assets/index-C8y5ZXbm.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f96717143a2cecf124ec8a3fe6ceb835b27f4f3974f5e3cbc69ead1ad18fbee0
+size 528340

--- a/src/inspect_scout/_view/dist/assets/index-CF8AoCSa.js
+++ b/src/inspect_scout/_view/dist/assets/index-CF8AoCSa.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c853622de2d5e7cb922db43121133f9af20c140089b42efbd02cbd08fbf89339
+size 2715442

--- a/src/inspect_scout/_view/dist/assets/index-DHVK8P2G.js
+++ b/src/inspect_scout/_view/dist/assets/index-DHVK8P2G.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60074df79cf5b4d7a673af4081dbf55df92f26bbe0ba1ef3bb920ec538111f73
-size 2712018

--- a/src/inspect_scout/_view/dist/assets/index-hPSoq3BW.css
+++ b/src/inspect_scout/_view/dist/assets/index-hPSoq3BW.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a310700d52fb2eace7079da6499b4dac7830fa2b654de48db176b97c77fd259d
-size 527767

--- a/src/inspect_scout/_view/dist/assets/jsx-runtime-29NaZBia.js
+++ b/src/inspect_scout/_view/dist/assets/jsx-runtime-29NaZBia.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8581964590485965f8579412e1c92ee1a1d068cdd9439d299909033ddb6508c7
-size 8974

--- a/src/inspect_scout/_view/dist/assets/jsx-runtime-Bt-cYkS5.js
+++ b/src/inspect_scout/_view/dist/assets/jsx-runtime-Bt-cYkS5.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cdf63b3db971db4dfd6b3505c1103161e510f7bd3f6902e8c18027b75cdeee
+size 8974

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP--eqBd8bg.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP--eqBd8bg.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:862ef49e13084a484e3ff33cb19033a87059856c00ced5e5969e579c736d0b25
-size 22573

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CD07wM5G.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CD07wM5G.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e896ceff16c1e3b28766be8840d0bd03dd402bda1e99d98c3adbb47cf8b0c6d0
+size 22573

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-D803FbTz.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-D803FbTz.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc55b476b24d7e0f23c03439bf7af16ae93cf4c887dc283dc3581715d24dc511
-size 2233922

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-S4QiO_Ju.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-S4QiO_Ju.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81809c2b70a170c24c818ed3a8e61314e0f44de6dade5d8422653624b56a6fa9
+size 2233922

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49ffba1df30e2ed0f27aa5bbfa2f9f03dbb7eda2fac6e5ca53774708e6533f16
+oid sha256:114bbf98f2384aa84bacde234cd582c9814d9026ff1b3f35b4fe42f8540bf96c
 size 3721

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -1492,7 +1492,7 @@
         "type": "object"
       },
       "CheckpointSampleConfig": {
-        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task).\n\nThe fields excluded from this base class \u2014 ``checkpoints_dir`` and\n``retention`` \u2014 are eval-wide concerns that the sample layer must\nnot influence. They live only on the derived :class:`CheckpointConfig`,\nwhich is the type used at the task and eval layers.\n\nSee ``design/plans/checkpointing-working.md`` \u00a72.",
+        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task).\n\nThe fields excluded from this base class \u2014 ``checkpoints_location``\nand ``retention`` \u2014 are eval-wide concerns that the sample layer must\nnot influence. They live only on the derived :class:`CheckpointConfig`,\nwhich is the type used at the task and eval layers.",
         "properties": {
           "max_consecutive_failures": {
             "anyOf": [
@@ -2779,6 +2779,20 @@
             ],
             "title": "Extra Headers"
           },
+          "fallback_models": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Models"
+          },
           "frequency_penalty": {
             "anyOf": [
               {
@@ -3253,6 +3267,20 @@
               }
             ],
             "title": "Extra Headers"
+          },
+          "fallback_models": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Models"
           },
           "frequency_penalty": {
             "anyOf": [
@@ -5626,6 +5654,43 @@
         "title": "ModelEvent",
         "type": "object"
       },
+      "ModelFallback": {
+        "description": "A model fallback (request served by a different model than requested).",
+        "properties": {
+          "count": {
+            "default": 1,
+            "title": "Count",
+            "type": "integer"
+          },
+          "fallback_model": {
+            "title": "Fallback Model",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "fallback_model",
+          "count"
+        ],
+        "title": "ModelFallback",
+        "type": "object"
+      },
       "ModelOutput": {
         "description": "Output from model generation.",
         "properties": {
@@ -5652,6 +5717,16 @@
               }
             ],
             "title": "Error"
+          },
+          "fallback": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModelFallback"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "metadata": {
             "anyOf": [


### PR DESCRIPTION
Regenerated OpenAPI schema, TS types, and built frontend assets.

Schema picks up upstream inspect_ai changes:
- New `ModelFallback` type and `ModelOutput.fallback` field
- New `fallback_models` field on generate config
- `CheckpointSampleConfig` docstring update (`checkpoints_dir` → `checkpoints_location`)

Also bumps ts-mono submodule and rebuilt `_view/dist` assets.