### PR TITLE
Cap oversized tool/text output to prevent resize layerization stalls

### DIFF
--- a/src/inspect_scout/_view/dist/assets/index-Bd5cILag.css
+++ b/src/inspect_scout/_view/dist/assets/index-Bd5cILag.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:616c44f82b4082022299e2aa1b2fe665fff7565e5817657096270ccc6aac47be
-size 529594

--- a/src/inspect_scout/_view/dist/assets/index-Bd5cILag.css
+++ b/src/inspect_scout/_view/dist/assets/index-Bd5cILag.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:616c44f82b4082022299e2aa1b2fe665fff7565e5817657096270ccc6aac47be
+size 529594

--- a/src/inspect_scout/_view/dist/assets/index-CokTAQgb.css
+++ b/src/inspect_scout/_view/dist/assets/index-CokTAQgb.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85958d2a08304a3f3ff0aaca514500af22341ec4717d4980b801c8c20aaf988d
-size 529738

--- a/src/inspect_scout/_view/dist/assets/index-DNP7wM0L.css
+++ b/src/inspect_scout/_view/dist/assets/index-DNP7wM0L.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6af3e22edea1e1b78a744f00538a0c2ff8a19b1004956efaf33ff8cb95695b85
+size 529722

--- a/src/inspect_scout/_view/dist/assets/index-DfRX6E4M.js
+++ b/src/inspect_scout/_view/dist/assets/index-DfRX6E4M.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3410b9ddf321a58a26e979a66364b313cd06f77125df01d6d8977d67b96b5c00
+size 2726539

--- a/src/inspect_scout/_view/dist/assets/index-GBPUUcdq.js
+++ b/src/inspect_scout/_view/dist/assets/index-GBPUUcdq.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a0dc1a4977a88ff17256629d52c9a92a3623beebb2cdef6d7a08c93bc545947
-size 2719318

--- a/src/inspect_scout/_view/dist/assets/index-NtvEBXzq.js
+++ b/src/inspect_scout/_view/dist/assets/index-NtvEBXzq.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d78e4c9ca41dec3b72f78146e18f774c1fff63eb330d58462818957efcfb15d
-size 2725997

--- a/src/inspect_scout/_view/dist/assets/index-NtvEBXzq.js
+++ b/src/inspect_scout/_view/dist/assets/index-NtvEBXzq.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d78e4c9ca41dec3b72f78146e18f774c1fff63eb330d58462818957efcfb15d
+size 2725997

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f85a8f8a8e0b297cb7aee5a8e731287baa12c2a32638836d56e291ca36d4d19a
+oid sha256:932b26066eb30283077b8fe81773bef00521e2c8d658f3768d806b28692fb6e9
 size 3721

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba15620b52080f83d20d9f187232c1140c9d63d69976459ed7f99f2e75fe0269
+oid sha256:f85a8f8a8e0b297cb7aee5a8e731287baa12c2a32638836d56e291ca36d4d19a
 size 3721

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -1455,6 +1455,20 @@
             "title": "Trigger",
             "type": "string"
           },
+          "trigger_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Metadata"
+          },
           "turn": {
             "title": "Turn",
             "type": "integer"
@@ -7077,6 +7091,7 @@
               "time",
               "working",
               "token",
+              "turn",
               "cost",
               "operator",
               "custom"


### PR DESCRIPTION
## Problem

Viewing a transcript with a very large tool result (a single ~15 MB command output) made the scout viewer laggy on resize in Chrome and **spinlock in Safari**.

A Chrome performance trace of one resize showed the cost was **~14s in `Layerize`** (49 calls, up to 1.4s each) plus ~2.7s Layout / ~1.6s Paint. The output renders as one **~1,000,000px-tall DOM node**; the compositor re-layerizes that entire node on every resize. It's a compositor cost (invisible to JS profiling), and a fixed-height scroller does **not** help — the off-screen content is still layerized.

## Fix

Frontend changes land in meridianlabs-ai/ts-mono#341; this PR bumps the submodule pointer and rebuilds the shipped viewer bundle.

- Cap rendered text at **250k chars** (`cappedText` helper) in both `ToolTextOutput` and `RenderedText`, with a static "Output truncated — N hidden" notice. No expand affordance — revealing the full content would reintroduce the cliff.
- `contain: layout paint` on the collapsed `ExpandablePanel` wrapper as defense-in-depth.

## Verification

On the reproducing transcript, the largest rendered node dropped from **~1,045,498px → ~55,478px** tall. `pnpm check` and `pnpm test` pass.

> Note: `Layerize` cannot be measured headlessly, so the final smoothness check is a manual resize in Chrome/Safari on the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)