### PR TITLE
Sanitize scanner text before terminal rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Security: Remove terminal control sequences from scanner names, scan metadata, errors, progress text, and filenames before rendering console output.
 - Add `timeline` option to `transcript_messages()` and `llm_scanner()` for selecting a named timeline.
 - Scout View: Back the scans list with a persistent, per-location SQLite index in the local Scout cache. The index is lazily refreshed from scan metadata, so filtering, sorting, pagination, and distinct-value queries no longer rebuild the full scans table on every request.
 - Scout View: Fix event panel nav pills never expanding back from picker mode 

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -1,10 +1,10 @@
 import shlex
 
 import click
-from inspect_ai._util.path import pretty_path
 from rich.table import Column, Table
 from typing_extensions import Unpack
 
+from inspect_scout._display.util import terminal_path
 from inspect_scout._project._project import read_project
 
 from .._display import display
@@ -53,7 +53,7 @@ def scan_list_command(
     for scan in scans:
         table.add_row(
             scan.spec.timestamp.strftime("%d-%b %H:%M:%S %Z"),
-            shlex.quote(pretty_path(scan.location)),
+            shlex.quote(terminal_path(scan.location)),
             "complete" if scan.complete else "pending",
             str(len(scan.errors)),
         )

--- a/src/inspect_scout/_display/plain.py
+++ b/src/inspect_scout/_display/plain.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Iterator, Sequence
 
 import rich
 from inspect_ai._util.format import format_progress_time
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.util import throttle
 from typing_extensions import override
 
@@ -36,6 +37,10 @@ class DisplayPlain(Display):
         highlight: bool | None = None,
     ) -> None:
         console = rich.get_console()
+        objects = tuple(
+            clean_control_characters(obj) if isinstance(obj, str) else obj
+            for obj in objects
+        )
         console.print(*objects, sep=sep, end=end, markup=markup, highlight=False)
 
     @contextlib.contextmanager
@@ -146,12 +151,13 @@ class TextProgressPlain(TextProgress):
         count: bool | int,
         print: Callable[..., None],
     ):
-        self._caption = caption
+        self._caption = clean_control_characters(caption)
         self._count = count
         self._print = print
         self._total = 0
 
     def update(self, text: str) -> None:
+        text = clean_control_characters(text)
         self._total += 1
         msg = f"{self._caption}: {text}"
         if self._count:

--- a/src/inspect_scout/_display/rich.py
+++ b/src/inspect_scout/_display/rich.py
@@ -11,6 +11,7 @@ from inspect_ai._display.core.results import model_usage_summary
 from inspect_ai._display.core.rich import is_vscode_notebook, rich_theme
 from inspect_ai._util.constants import CONSOLE_DISPLAY_WIDTH
 from inspect_ai._util.format import format_progress_time
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.model import ModelUsage
 from inspect_ai.util import throttle
 from rich.console import Group, RenderableType
@@ -63,6 +64,10 @@ class DisplayRich(Display):
         highlight: bool | None = None,
     ) -> None:
         console = rich.get_console()
+        objects = tuple(
+            clean_control_characters(obj) if isinstance(obj, str) else obj
+            for obj in objects
+        )
         console.print(*objects, sep=sep, end=end, markup=markup, highlight=False)
 
     @contextlib.contextmanager
@@ -211,7 +216,7 @@ class TextProgressRich(TextProgress):
         caption: str,
         count: bool | int,
     ):
-        self._caption = caption
+        self._caption = clean_control_characters(caption)
         self._count = count
 
         # Build count format string for a separate column
@@ -236,7 +241,7 @@ class TextProgressRich(TextProgress):
             transient=True,
         )
         self._task_id = self._progress.add_task(
-            caption,
+            self._caption,
             total=count
             if isinstance(count, int) and not isinstance(count, bool)
             else None,
@@ -257,6 +262,7 @@ class TextProgressRich(TextProgress):
             self._progress.stop()
 
     def update(self, text: str) -> None:
+        text = clean_control_characters(text)
         if self._started is False:
             self._progress.start()
             self._started = True
@@ -304,7 +310,9 @@ def scanners_table(spec: ScanSpec, summary: Summary) -> Table:
     # columns dynamic based on validation/metrics
     rowdef = ["[bold]scanner[/bold]"]
     if have_metric:
-        rowdef.append(f"[bold]{_summary_metric_label(summary.scanners)}[/bold]")
+        rowdef.append(
+            f"[bold]{clean_control_characters(_summary_metric_label(summary.scanners))}[/bold]"
+        )
     if have_validation:
         rowdef.append("[bold]validation[/bold]")
     rowdef.extend(
@@ -321,7 +329,7 @@ def scanners_table(spec: ScanSpec, summary: Summary) -> Table:
     for scanner in spec.scanners.keys():
         results = summary[scanner]
         validation_accuracy = _summary_validation(results.validation)
-        row_data: list[str | None] = [scanner]
+        row_data: list[str | None] = [clean_control_characters(scanner)]
         if have_metric:
             metric = _summary_metric(results.metrics)
             row_data.append(metric)
@@ -414,7 +422,7 @@ def scan_panel(
             usage_table.add_column()
             for model, usage in total_usage.items():
                 usage_table.add_row(
-                    *model_usage_summary(model, usage),
+                    *model_usage_summary(clean_control_characters(model), usage),
                     style=theme.light,
                 )
             table.add_row(usage_table, "", "")

--- a/src/inspect_scout/_display/util.py
+++ b/src/inspect_scout/_display/util.py
@@ -4,7 +4,7 @@ from inspect_ai._display.core.rich import rich_theme
 from inspect_ai._util.constants import DEFAULT_MAX_CONNECTIONS_BATCH
 from inspect_ai._util.path import pretty_path
 from inspect_ai._util.registry import is_model_dict, is_registry_dict
-from inspect_ai._util.rich import rich_traceback
+from inspect_ai._util.rich import clean_control_characters, rich_traceback
 from inspect_ai._util.text import truncate_text
 from rich.console import RenderableType
 from rich.text import Text
@@ -13,27 +13,37 @@ from inspect_scout._recorder.recorder import Status
 from inspect_scout._scanspec import ScanSpec
 
 
+def terminal_path(path: str) -> str:
+    """Format a path for terminal display without interpreting control content."""
+    path = clean_control_characters(path)
+    try:
+        return clean_control_characters(pretty_path(path))
+    except ValueError:
+        return path
+
+
 def scan_interrupted_message(status: Status) -> str:
     theme = rich_theme()
+    location = terminal_path(status.location)
     return (
         f"\n[bold][{theme.error}]scan interrupted, resume scan with:[/{theme.error}]\n\n"
-        + f"[bold][{theme.light}]scout scan resume {shlex.quote(pretty_path(status.location))}[/{theme.light}][/bold]\n"
+        + f"[bold][{theme.light}]scout scan resume {shlex.quote(location)}[/{theme.light}][/bold]\n"
     )
 
 
 def scan_complete_message(status: Status) -> str:
-    return (
-        f"\n[bold]scan complete:[/bold] {shlex.quote(pretty_path(status.location))}\n"
-    )
+    location = terminal_path(status.location)
+    return f"\n[bold]scan complete:[/bold] {shlex.quote(location)}\n"
 
 
 def scan_errors_message(status: Status) -> str:
     theme = rich_theme()
+    location = shlex.quote(terminal_path(status.location))
     return "\n".join(
         [
             f"\n[bold]{len(status.errors)} scan errors occurred![/bold]\n",
-            f"Resume (retrying errors):   [bold][{theme.light}]scout scan resume {shlex.quote(pretty_path(status.location))}[/{theme.light}][/bold]\n",
-            f"Complete (ignoring errors): [bold][{theme.light}]scout scan complete {shlex.quote(pretty_path(status.location))}[/{theme.light}][/bold]\n",
+            f"Resume (retrying errors):   [bold][{theme.light}]scout scan resume {location}[/{theme.light}][/bold]\n",
+            f"Complete (ignoring errors): [bold][{theme.light}]scout scan complete {location}[/{theme.light}][/bold]\n",
         ]
     )
 
@@ -41,9 +51,9 @@ def scan_errors_message(status: Status) -> str:
 def scan_title(spec: ScanSpec) -> str:
     SCAN = "scan"
     if spec.scan_file is not None:
-        title = f"{SCAN}: {pretty_path(spec.scan_file)}"
+        title = f"{SCAN}: {terminal_path(spec.scan_file)}"
     elif spec.scan_name not in ["scan", "job"]:
-        title = f"{SCAN}: {spec.scan_name}"
+        title = f"{SCAN}: {clean_control_characters(spec.scan_name)}"
     else:
         title = SCAN
     if spec.options.limit:
@@ -55,7 +65,7 @@ def scan_title(spec: ScanSpec) -> str:
     if count is not None:
         noun = "transcript" if count == 1 else "transcripts"
         title = f"{title} ({count:,} {noun})"
-    return title
+    return clean_control_characters(title)
 
 
 def scan_config(spec: ScanSpec) -> RenderableType:
@@ -108,11 +118,11 @@ def scan_config_str(spec: ScanSpec) -> str:
         elif isinstance(value, dict):
             value = "{...}"
         if isinstance(value, str):
-            value = truncate_text(value, 50)
+            value = truncate_text(clean_control_characters(value), 50)
             value = value.replace("[", "\\[")
-        config_str.append(f"{name}: {value}")
+        config_str.append(f"{clean_control_characters(name)}: {value}")
 
-    return ", ".join(config_str)
+    return clean_control_characters(", ".join(config_str))
 
 
 def exception_to_rich_traceback(ex: Exception) -> RenderableType:

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -19,6 +19,7 @@ from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.json import jsonable_python
 from inspect_ai._util.path import pretty_path
 from inspect_ai._util.platform import platform_init as init_platform
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import Model, init_model_usage, model_usage, resolve_models
 from inspect_ai.model._model_config import (
@@ -904,7 +905,10 @@ async def _scan_dry_run(scan: ScanContext) -> Status:
     )
 
     for name in scanner_names:
-        table.add_row(name, f"{per_scanner_counts[name]:,}")
+        table.add_row(
+            clean_control_characters(name),
+            f"{per_scanner_counts[name]:,}",
+        )
 
     table.add_section()
 

--- a/tests/display/test_rich.py
+++ b/tests/display/test_rich.py
@@ -1,11 +1,39 @@
 import io
 import re
+import unicodedata
 
 import pytest
-from inspect_scout._display.rich import TextProgressRich
+from inspect_scout._display.rich import (
+    TextProgressRich,
+    scan_panel,
+    scanners_table,
+)
+from inspect_scout._display.util import (
+    scan_complete_message,
+    scan_config_str,
+    scan_title,
+)
+from inspect_scout._recorder.recorder import Status
+from inspect_scout._recorder.summary import Summary
+from inspect_scout._scanspec import ScannerSpec, ScanSpec
 from rich.console import Console
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+PAYLOAD = (
+    "VISIBLE-BEFORE"
+    "\x1b[2J"
+    "\x1b[H"
+    "FORGED-SCREEN"
+    "\x1b]52;c;UEFTVEVfSElKQUNL\x07"
+    "\x1b]8;;file:///etc/passwd\x1b\\"
+    "DISGUISED-LINK"
+    "\x1b]8;;\x1b\\"
+    "\x9b2J"
+    "\x9d52;c;UEFTVEVfSElKQUNL\x9c"
+    "\r\b\x00\x7f"
+    "VISIBLE-AFTER"
+    "\nNEXT\tCELL"
+)
 
 
 def _make_console(buffer: io.StringIO, width: int) -> Console:
@@ -16,6 +44,40 @@ def _make_console(buffer: io.StringIO, width: int) -> Console:
         color_system=None,
         legacy_windows=False,
     )
+
+
+def _render(renderable: object) -> str:
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        width=1000,
+        force_terminal=False,
+        color_system=None,
+    )
+    console.print(renderable)
+    return buffer.getvalue()
+
+
+def _assert_safe(text: str, *, require_after: bool = True) -> None:
+    assert all(
+        char in "\n\t" or unicodedata.category(char) not in ("Cc", "Cf")
+        for char in text
+    )
+    assert "VISIBLE-BEFORE" in text
+    if require_after:
+        assert "VISIBLE-AFTER" in text
+
+
+def _scan() -> tuple[ScanSpec, Summary]:
+    spec = ScanSpec(
+        scan_name=PAYLOAD,
+        scan_args={"metadata": PAYLOAD},
+        scanners={PAYLOAD: ScannerSpec(name=PAYLOAD)},
+        transcripts=None,
+    )
+    summary = Summary(scanners=[PAYLOAD])
+    summary[PAYLOAD].metrics = {"group": {PAYLOAD: 1.0}}
+    return spec, summary
 
 
 @pytest.fixture
@@ -73,3 +135,36 @@ def test_progress_display_is_cleared_on_exit(
         "(transient cleanup); progress region was not cleared on exit. "
         f"Buffer tail: {output[-120:]!r}"
     )
+
+
+def test_scanner_table_and_panel_remove_terminal_controls() -> None:
+    spec, summary = _scan()
+
+    _assert_safe(_render(scanners_table(spec, summary)))
+    _assert_safe(_render(scan_panel(spec=spec, summary=summary)))
+
+
+def test_scan_metadata_and_filename_text_remove_terminal_controls() -> None:
+    spec, summary = _scan()
+    status = Status(
+        complete=True,
+        spec=spec,
+        location=f"/tmp/{PAYLOAD}",
+        summary=summary,
+        errors=[],
+    )
+
+    _assert_safe(scan_title(spec))
+    _assert_safe(scan_config_str(spec), require_after=False)
+    _assert_safe(scan_complete_message(status))
+
+
+def test_text_progress_cleans_caption_and_filename(
+    captured_console: tuple[Console, io.StringIO],
+) -> None:
+    progress = TextProgressRich(PAYLOAD, count=True)
+    with progress:
+        progress.update(PAYLOAD)
+        task = progress._progress.tasks[0]
+        _assert_safe(task.description)
+        _assert_safe(task.fields["text"])


### PR DESCRIPTION
## Summary

Scanner names, scan configuration, progress text, errors, and scan paths can reach Rich or plain terminal output containing raw terminal controls. This permits CSI screen commands, OSC 8 hyperlinks, and OSC 52 clipboard writes to survive rendering.

This PR reuses the existing Inspect control-character cleanup before placing scanner-controlled text into tables, progress displays, status messages, and command output. Cleanup occurs inside `scanners_table()` because Inspect also consumes that renderable directly in its scan TUI.

Scan paths are cleaned before terminal formatting. If control-sequence remnants make the cleaned path unsuitable for `pretty_path()`, Scout displays the cleaned literal value rather than allowing embedded text such as `file://` to be interpreted as a filesystem protocol. This affects display only; scan specs, results, and files are not modified.

Scanner labels, configuration, paths, and progress are fixed independently here. Scanner exception tracebacks use Inspect's shared renderer, so that portion is completed by UKGovernmentBEIS/inspect_ai#4360.

## Behavior and compatibility

Raw terminal controls supplied by scanner or artifact content no longer affect terminal state. Visible text, tabs, newlines, normal scan path formatting, and stored scan data remain unchanged.

## Testing

Regression payloads cover CSI clear/home, OSC 8, OSC 52, C0/C1 controls, carriage return, backspace, NUL, and DEL across scanner tables, scan metadata, progress text, and filenames.

Verification:
- `pytest -q -n0 tests/display/test_rich.py -k "scanner_table or scan_metadata or text_progress_cleans"`
- `pytest -q -n0 tests/display/test_log.py tests/recorder/test_summary.py`
- `pytest -q -n0 tests/cli/test_scan_exit_code.py`
- focused `mypy` over all changed Python modules
- `ruff check` and `ruff format --check` over all changed Python files