### PR TITLE
Prevent DuckDB SQL injection in Scout queries and artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Security: Build DuckDB queries from bound Parquet sources and quoted, schema-validated identifiers so malicious transcript/scan filenames and sort or distinct columns cannot inject SQL.
 - Add `timeline` option to `transcript_messages()` and `llm_scanner()` for selecting a named timeline.
 - Scout View: Back the scans list with a persistent, per-location SQLite index in the local Scout cache. The index is lazily refreshed from scan metadata, so filtering, sorting, pagination, and distinct-value queries no longer rebuild the full scans table on every request.
 - Scout View: Fix event panel nav pills never expanding back from picker mode 

--- a/src/inspect_scout/_query/__init__.py
+++ b/src/inspect_scout/_query/__init__.py
@@ -11,7 +11,7 @@ from .condition_sql import (
 )
 from .order_by import OrderBy
 from .query import Query
-from .sql import SQLDialect
+from .sql import SQLDialect, UnknownColumnError
 
 __all__ = [
     "Column",
@@ -25,6 +25,7 @@ __all__ = [
     "ScalarValue",
     "Query",
     "SQLDialect",
+    "UnknownColumnError",
     "condition_as_sql",
     "condition_from_sql",
 ]

--- a/src/inspect_scout/_query/condition_sql.py
+++ b/src/inspect_scout/_query/condition_sql.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 from typing import Any, Literal, overload
 
 from .condition import Condition, LogicalOperator, Operator
-from .sql import SQLDialect, format_sql_value
+from .sql import (
+    SQLDialect,
+    escape_identifier,
+    format_sql_value,
+    quote_identifier,
+)
 
 
 class ConditionSQLError(ValueError):
@@ -340,10 +345,6 @@ def _build_condition_sql(
             )
 
 
-def _esc_double(s: str) -> str:
-    return s.replace('"', '""')
-
-
 def _esc_single(s: str) -> str:
     return s.replace("'", "''")
 
@@ -455,7 +456,7 @@ def _format_condition_column(column_name: str, dialect: SQLDialect) -> str:
         if not path_parts:
             # No JSON path, just a column name that might contain a dot
             # in table.column format (not supported in current implementation)
-            return f'"{_esc_double(column_name)}"'
+            return quote_identifier(column_name)
 
         if dialect == "sqlite":
             # Build JSONPath like $.key[0]."user.name"
@@ -470,7 +471,7 @@ def _format_condition_column(column_name: str, dialect: SQLDialect) -> str:
                 else:
                     json_path_parts.append(f".{segment}")
             json_path = "$" + "".join(json_path_parts)
-            return f"json_extract(\"{_esc_double(base)}\", '{_esc_single(json_path)}')"
+            return f"json_extract({quote_identifier(base)}, '{_esc_single(json_path)}')"
 
         elif dialect == "duckdb":
             # Use json_extract_string to extract as VARCHAR for direct comparison
@@ -484,10 +485,13 @@ def _format_condition_column(column_name: str, dialect: SQLDialect) -> str:
                 else:
                     json_path_parts.append(f".{segment}")
             json_path = "$" + "".join(json_path_parts)
-            return f"json_extract_string(\"{_esc_double(base)}\", '{_esc_single(json_path)}')"
+            return (
+                f"json_extract_string({quote_identifier(base)}, "
+                f"'{_esc_single(json_path)}')"
+            )
 
         elif dialect == "postgres":
-            result = f'"{_esc_double(base)}"'
+            result = quote_identifier(base)
             for i, (segment, is_index) in enumerate(path_parts):
                 op = "->>" if i == len(path_parts) - 1 else "->"
                 if is_index:
@@ -499,7 +503,7 @@ def _format_condition_column(column_name: str, dialect: SQLDialect) -> str:
             return result
 
     # Simple (non-JSON) column
-    return f'"{_esc_double(column_name)}"'
+    return quote_identifier(column_name)
 
 
 def _get_condition_placeholder(position: int, dialect: SQLDialect) -> str:
@@ -781,7 +785,7 @@ def _needs_quoting(identifier: str) -> bool:
 
 def _escape_identifier(identifier: str) -> str:
     """Escape an identifier for use in double quotes."""
-    return identifier.replace('"', '""')
+    return escape_identifier(identifier)
 
 
 # Placeholder for condition_from_sql - will be implemented next

--- a/src/inspect_scout/_query/query.py
+++ b/src/inspect_scout/_query/query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, Callable
@@ -8,7 +9,7 @@ from typing import Any, Callable
 from .condition import Condition
 from .condition_sql import condition_as_sql
 from .order_by import OrderBy
-from .sql import ExecutableSQLDialect
+from .sql import ExecutableSQLDialect, quote_identifier, validate_column
 
 
 @dataclass
@@ -36,12 +37,14 @@ class Query:
         self,
         dialect: ExecutableSQLDialect,
         shuffle_column: str | None = None,
+        available_columns: Collection[str] | None = None,
     ) -> tuple[str, list[Any], Callable[[Any], None] | None]:
         """Generate SQL suffix (WHERE + ORDER BY + LIMIT).
 
         Args:
             dialect: SQL dialect for placeholders.
             shuffle_column: Column for shuffle ORDER BY (required if self.shuffle is set).
+            available_columns: Active top-level schema used to validate order columns.
 
         Returns:
             (sql_suffix, params, register_shuffle)
@@ -76,11 +79,17 @@ class Query:
                 "order_by is not meaningful when shuffle is enabled"
             )
             seed = 0 if self.shuffle is True else self.shuffle
-            order_by_clauses.append(f"shuffle_hash({shuffle_column})")
+            order_by_clauses.append(f"shuffle_hash({quote_identifier(shuffle_column)})")
             register_shuffle = _make_shuffle_registrar(dialect, seed)
         else:
+            if self.order_by and available_columns is None:
+                raise ValueError("available_columns is required when ordering a query")
             for ob in self.order_by:
-                order_by_clauses.append(f'"{ob.column}" {ob.direction}')
+                assert available_columns is not None
+                column = validate_column(ob.column, available_columns)
+                if ob.direction not in ("ASC", "DESC"):
+                    raise ValueError(f"Unsupported order direction: {ob.direction!r}")
+                order_by_clauses.append(f"{quote_identifier(column)} {ob.direction}")
 
         if order_by_clauses:
             parts.append(" ORDER BY " + ", ".join(order_by_clauses))

--- a/src/inspect_scout/_query/sql.py
+++ b/src/inspect_scout/_query/sql.py
@@ -1,10 +1,43 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from datetime import date, datetime
 from typing import Any, Literal
 
 ExecutableSQLDialect = Literal["sqlite", "duckdb", "postgres"]
 SQLDialect = ExecutableSQLDialect | Literal["filter"]
+
+
+class UnknownColumnError(ValueError):
+    """A query selected a column that is not present in the active schema."""
+
+    def __init__(self, column: str) -> None:
+        self.column = column
+        super().__init__(f"Unknown column: {column!r}")
+
+
+def escape_identifier(identifier: str) -> str:
+    """Escape one SQL identifier without adding quotes."""
+    if "\x00" in identifier:
+        raise ValueError("SQL identifiers cannot contain NUL characters")
+    return identifier.replace('"', '""')
+
+
+def quote_identifier(identifier: str) -> str:
+    """Quote one SQL identifier."""
+    return f'"{escape_identifier(identifier)}"'
+
+
+def quote_qualified_identifier(*identifiers: str) -> str:
+    """Quote already-separated components of a qualified SQL identifier."""
+    return ".".join(quote_identifier(identifier) for identifier in identifiers)
+
+
+def validate_column(column: str, available_columns: Collection[str]) -> str:
+    """Require a caller-selected top-level column to exist in a schema."""
+    if column not in available_columns:
+        raise UnknownColumnError(column)
+    return column
 
 
 def format_sql_value(value: Any) -> str:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterator, Mapping
+from logging import getLogger
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, cast
 
 import duckdb
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
 from inspect_scout._recorder.summary import Summary
 
+from .._query.sql import quote_identifier
 from .._recorder.buffer import (
     SCAN_ERRORS,
     SCAN_SUMMARY,
@@ -36,6 +38,7 @@ from .._recorder.buffer import (
 from .._scanner.result import Error, ResultReport
 from .._scanspec import ScanSpec, ScanTranscripts
 from .._transcript.types import TranscriptInfo
+from .._util.duckdb import create_parquet_view, restrict_external_access
 from .recorder import (
     ScanRecorder,
     ScanResultsArrow,
@@ -45,6 +48,7 @@ from .recorder import (
 )
 
 SCAN_JSON = "_scan.json"
+logger = getLogger(__name__)
 
 
 class LazyScannerMapping(Mapping[str, pd.DataFrame]):
@@ -580,37 +584,69 @@ class FileRecorder(ScanRecorder):
         # Create in-memory DuckDB connection
         conn = duckdb.connect(":memory:")
 
-        # Create views for each parquet file
-        async with AsyncFilesystem() as fs:
-            parquet_uris = sorted(
-                [u async for u in fs.iter_files(scan_location, "*.parquet")]
-            )
-        for parquet_uri in parquet_uris:
-            parquet_file = UPath(parquet_uri)
-            scanner_name = parquet_file.stem
-            # Create a view that references the parquet file
-            # Use absolute path to ensure it works regardless of working directory
-            # iter_files already yields absolute URIs.
-            abs_path = parquet_file.as_posix()
-
-            # Check if we need to expand resultsets
-            if rows == "results" and _has_resultsets(conn, abs_path):
-                # Create expanded view with UNNEST for resultset rows
-                sql = _create_expanded_view_sql(conn, abs_path, scanner_name)
-                conn.execute(sql)
-            else:
-                # Use existing simple view logic (for transcripts mode or non-resultset scanners)
-                # Check if value_type is uniform and needs casting
-                uniform_type = _get_uniform_value_type(conn, abs_path)
-                if uniform_type in ("boolean", "number"):
-                    cast_expr = _cast_value_sql(uniform_type)
-                    select_clause = f"SELECT * REPLACE ({cast_expr} AS value)"
-                else:
-                    select_clause = "SELECT *"
-
-                conn.execute(
-                    f"CREATE VIEW {scanner_name} AS {select_clause} FROM read_parquet('{abs_path}')"
+        scanner_tables: dict[str, str] = {}
+        allowed_paths: list[str] = []
+        try:
+            # Match filesystem entries to scanners declared by the parsed spec.
+            async with AsyncFilesystem() as fs:
+                parquet_uris = sorted(
+                    [u async for u in fs.iter_files(scan_location, "*.parquet")]
                 )
+            declared_scanners = set(status.spec.scanners)
+            parquet_by_scanner: dict[str, str] = {}
+            unexpected_count = 0
+            for parquet_uri in parquet_uris:
+                parquet_file = UPath(parquet_uri)
+                scanner_name = parquet_file.stem
+                if scanner_name not in declared_scanners:
+                    unexpected_count += 1
+                    continue
+                if scanner_name in parquet_by_scanner:
+                    raise ValueError(
+                        f"Multiple Parquet files found for scanner {scanner_name!r}"
+                    )
+                parquet_by_scanner[scanner_name] = parquet_file.as_posix()
+
+            if unexpected_count:
+                logger.warning(
+                    "Ignoring %d undeclared Parquet file(s) in scan results",
+                    unexpected_count,
+                )
+
+            for scanner_name in status.spec.scanners:
+                abs_path = parquet_by_scanner.get(scanner_name)
+                if abs_path is None:
+                    continue
+
+                source_view = create_parquet_view(conn, abs_path)
+                allowed_paths.append(abs_path)
+
+                # Check if we need to expand resultsets
+                if rows == "results" and _has_resultsets(conn, source_view):
+                    # Create expanded view with UNNEST for resultset rows
+                    sql = _create_expanded_view_sql(conn, source_view, scanner_name)
+                    conn.execute(sql)
+                else:
+                    # Use existing simple view logic (for transcripts mode or
+                    # non-resultset scanners). Check if value_type is uniform
+                    # and needs casting.
+                    uniform_type = _get_uniform_value_type(conn, source_view)
+                    if uniform_type in ("boolean", "number"):
+                        cast_expr = _cast_value_sql(uniform_type)
+                        select_clause = f"SELECT * REPLACE ({cast_expr} AS value)"
+                    else:
+                        select_clause = "SELECT *"
+
+                    conn.execute(
+                        f"CREATE VIEW {quote_identifier(scanner_name)} AS "
+                        f"{select_clause} FROM {quote_identifier(source_view)}"
+                    )
+                scanner_tables[scanner_name] = scanner_name
+
+            restrict_external_access(conn, allowed_paths=allowed_paths)
+        except Exception:
+            conn.close()
+            raise
 
         return ScanResultsDB(
             status=status.complete,
@@ -619,6 +655,7 @@ class FileRecorder(ScanRecorder):
             summary=status.summary,
             errors=status.errors,
             conn=conn,
+            scanner_tables=scanner_tables,
         )
 
     @override
@@ -800,25 +837,26 @@ def _ensure_scans_dir(scans_dir: UPath) -> None:
     scans_dir.mkdir(parents=True, exist_ok=True)
 
 
-def _has_resultsets(conn: duckdb.DuckDBPyConnection, parquet_path: str) -> bool:
+def _has_resultsets(conn: duckdb.DuckDBPyConnection, source_view: str) -> bool:
     """
     Check if a parquet file contains any resultset rows.
 
     Args:
         conn: DuckDB connection
-        parquet_path: Path to the parquet file
+        source_view: Generated view over the parquet file
 
     Returns:
         True if any rows have value_type == 'resultset', False otherwise
     """
     result = conn.execute(
-        f"SELECT COUNT(*) FROM read_parquet('{parquet_path}') WHERE value_type = 'resultset' LIMIT 1"
+        f"SELECT COUNT(*) FROM {quote_identifier(source_view)} "
+        "WHERE value_type = 'resultset' LIMIT 1"
     ).fetchone()
     return result is not None and result[0] > 0
 
 
 def _create_expanded_view_sql(
-    conn: duckdb.DuckDBPyConnection, parquet_path: str, scanner_name: str
+    conn: duckdb.DuckDBPyConnection, source_view: str, scanner_name: str
 ) -> str:
     """
     Generate SQL to create an expanded view that unnests resultset rows.
@@ -832,7 +870,7 @@ def _create_expanded_view_sql(
 
     Args:
         conn: DuckDB connection to query schema
-        parquet_path: Path to the parquet file
+        source_view: Generated view over the parquet file
         scanner_name: Name for the view
 
     Returns:
@@ -841,7 +879,7 @@ def _create_expanded_view_sql(
     # Query the actual column names from the parquet file to avoid hardcoding
     # We use LIMIT 0 to get just the schema without reading data
     result = conn.execute(
-        f"SELECT * FROM read_parquet('{parquet_path}') LIMIT 0"
+        f"SELECT * FROM {quote_identifier(source_view)} LIMIT 0"
     ).description
     all_columns = [col[0] for col in result]
 
@@ -874,9 +912,9 @@ def _create_expanded_view_sql(
     }
 
     # Build the non-resultset rows query with explicit column selection
-    non_resultset_cols = ", ".join(all_columns)
+    non_resultset_cols = ", ".join(quote_identifier(column) for column in all_columns)
     non_resultset_query = f"""
-    SELECT {non_resultset_cols} FROM read_parquet('{parquet_path}')
+    SELECT {non_resultset_cols} FROM {quote_identifier(source_view)}
     WHERE value_type != 'resultset' OR value_type IS NULL
     """
 
@@ -898,15 +936,15 @@ def _create_expanded_view_sql(
     for col in all_columns:
         if col in base_columns:
             # Base columns from the parquet table
-            expanded_col_selects.append(f"base_row.{col}")
+            expanded_col_selects.append(f"base_row.{quote_identifier(col)}")
         elif col in scan_execution_fields:
             # NULL out scan execution fields to avoid incorrect aggregation
-            expanded_col_selects.append(f"NULL AS {col}")
+            expanded_col_selects.append(f"NULL AS {quote_identifier(col)}")
         elif col in validation_fields or col.startswith("validation_result_"):
             # NULL out validation fields in expanded rows because:
             # 1. Label-based validation can't create synthetic rows in SQL
             # 2. Without synthetic rows, validation results are incomplete/misleading
-            expanded_col_selects.append(f"NULL AS {col}")
+            expanded_col_selects.append(f"NULL AS {quote_identifier(col)}")
         elif col == "uuid":
             expanded_col_selects.append(
                 "json_extract_string(CAST(elem AS JSON), '$.uuid') AS uuid"
@@ -953,13 +991,13 @@ def _create_expanded_view_sql(
     expanded_resultset_query = f"""
     SELECT
         {", ".join(expanded_col_selects)}
-    FROM read_parquet('{parquet_path}') base_row,
-    UNNEST(CAST(json_extract(base_row.value, '$') AS JSON[])) AS t(elem)
-    WHERE base_row.value_type = 'resultset'
+    FROM {quote_identifier(source_view)} base_row,
+    UNNEST(CAST(json_extract(base_row.{quote_identifier("value")}, '$') AS JSON[])) AS t(elem)
+    WHERE base_row.{quote_identifier("value_type")} = 'resultset'
     """
 
     # Combine both queries with UNION ALL
-    return f"""CREATE VIEW {scanner_name} AS
+    return f"""CREATE VIEW {quote_identifier(scanner_name)} AS
     SELECT * FROM (
         {non_resultset_query}
         UNION ALL
@@ -968,20 +1006,21 @@ def _create_expanded_view_sql(
 
 
 def _get_uniform_value_type(
-    conn: duckdb.DuckDBPyConnection, parquet_path: str
+    conn: duckdb.DuckDBPyConnection, source_view: str
 ) -> str | None:
     """
     Check if value_type is uniform across all rows in a parquet file.
 
     Args:
         conn: DuckDB connection
-        parquet_path: Path to the parquet file
+        source_view: Generated view over the parquet file
 
     Returns:
         The uniform value_type if all rows have the same type, None otherwise
     """
     result = conn.execute(
-        f"SELECT DISTINCT value_type FROM read_parquet('{parquet_path}') WHERE value_type IS NOT NULL"
+        f"SELECT DISTINCT value_type FROM {quote_identifier(source_view)} "
+        "WHERE value_type IS NOT NULL"
     ).fetchall()
 
     if len(result) == 1:

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -10,9 +10,11 @@ import pyarrow as pa
 if TYPE_CHECKING:
     from pyarrow import Scalar
 
+from .._query.sql import quote_identifier
 from .._scanner.result import Error, ResultReport
 from .._scanspec import ScanSpec, ScanTranscripts
 from .._transcript.types import TranscriptInfo
+from .._util.duckdb import generated_identifier
 from .summary import Summary
 
 
@@ -121,6 +123,9 @@ class ScanResultsDB(Status):
     conn: duckdb.DuckDBPyConnection
     """Connection to DuckDB database."""
 
+    scanner_tables: Mapping[str, str]
+    """Logical scanner names mapped to their queryable DuckDB relations."""
+
     def __init__(
         self,
         status: bool,
@@ -129,9 +134,11 @@ class ScanResultsDB(Status):
         summary: Summary,
         errors: list[Error],
         conn: duckdb.DuckDBPyConnection,
+        scanner_tables: Mapping[str, str],
     ) -> None:
         super().__init__(status, spec, location, summary, errors)
         self.conn = conn
+        self.scanner_tables = scanner_tables
 
     def __enter__(self) -> "ScanResultsDB":
         """Enter the async context manager."""
@@ -183,18 +190,22 @@ class ScanResultsDB(Status):
         file_conn = duckdb.connect(file)
 
         try:
-            # Get all tables and views from the in-memory connection
-            tables_and_views = self.conn.execute("SHOW TABLES").fetchall()
-
-            # Materialize each table/view into the file database
-            for row in tables_and_views:
-                table_name = row[0]
-
+            # Materialize each logical scanner relation into the file database
+            for scanner_name, table_name in self.scanner_tables.items():
                 # Read the data from the in-memory connection into a DataFrame
-                df = self.conn.execute(f"SELECT * FROM {table_name}").fetchdf()  # noqa: F841
+                df = self.conn.execute(
+                    f"SELECT * FROM {quote_identifier(table_name)}"
+                ).fetchdf()
 
-                # Write the DataFrame as a table in the file connection
-                file_conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM df")
+                registered_name = generated_identifier("export")
+                file_conn.register(registered_name, df)
+                try:
+                    file_conn.execute(
+                        f"CREATE TABLE {quote_identifier(scanner_name)} AS "
+                        f"SELECT * FROM {quote_identifier(registered_name)}"
+                    )
+                finally:
+                    file_conn.unregister(registered_name)
 
         finally:
             # Close the file connection

--- a/src/inspect_scout/_scanjobs/store.py
+++ b/src/inspect_scout/_scanjobs/store.py
@@ -14,6 +14,7 @@ from typing import Any
 from .._query import Query, ScalarValue
 from .._query.condition import Condition
 from .._query.condition_sql import condition_as_sql
+from .._query.sql import quote_identifier, validate_column
 from .._view._api_v2_types import ScanRow
 
 SCAN_JOBS_TABLE = "scan_jobs"
@@ -68,9 +69,10 @@ class ScanIndexStore:
 
     def upsert(self, rows: list[tuple[ScanRow, str]]) -> None:
         placeholders = ", ".join(["?"] * len(_ALL_COLUMNS))
-        cols = ", ".join(_ALL_COLUMNS)
+        cols = ", ".join(quote_identifier(column) for column in _ALL_COLUMNS)
         sql = (
-            f"INSERT OR REPLACE INTO {SCAN_JOBS_TABLE} ({cols}) VALUES ({placeholders})"
+            f"INSERT OR REPLACE INTO {quote_identifier(SCAN_JOBS_TABLE)} "
+            f"({cols}) VALUES ({placeholders})"
         )
         self._conn.executemany(
             sql, [self._row_to_tuple(row, token) for row, token in rows]
@@ -81,23 +83,26 @@ class ScanIndexStore:
         if not scan_ids:
             return
         self._conn.executemany(
-            f"DELETE FROM {SCAN_JOBS_TABLE} WHERE scan_id = ?",
+            f"DELETE FROM {quote_identifier(SCAN_JOBS_TABLE)} WHERE scan_id = ?",
             [(sid,) for sid in scan_ids],
         )
         self._conn.commit()
 
     def stored_tokens(self) -> dict[str, str]:
         cursor = self._conn.execute(
-            f"SELECT scan_id, change_token FROM {SCAN_JOBS_TABLE}"
+            f"SELECT scan_id, change_token FROM {quote_identifier(SCAN_JOBS_TABLE)}"
         )
         return {scan_id: token for scan_id, token in cursor.fetchall()}
 
     def select(self, query: Query | None = None) -> list[ScanRow]:
         query = query or Query()
-        suffix, params, _ = query.to_sql_suffix("sqlite")
-        cols = ", ".join(_SCAN_ROW_COLUMNS)
+        suffix, params, _ = query.to_sql_suffix(
+            "sqlite", available_columns=_SCAN_ROW_COLUMNS
+        )
+        cols = ", ".join(quote_identifier(column) for column in _SCAN_ROW_COLUMNS)
         cursor = self._conn.execute(
-            f"SELECT {cols} FROM {SCAN_JOBS_TABLE}{suffix}", params
+            f"SELECT {cols} FROM {quote_identifier(SCAN_JOBS_TABLE)}{suffix}",
+            params,
         )
         return [self._tuple_to_row(row) for row in cursor.fetchall()]
 
@@ -106,24 +111,26 @@ class ScanIndexStore:
         count_query = Query(where=query.where)
         suffix, params, _ = count_query.to_sql_suffix("sqlite")
         result = self._conn.execute(
-            f"SELECT COUNT(*) FROM {SCAN_JOBS_TABLE}{suffix}", params
+            f"SELECT COUNT(*) FROM {quote_identifier(SCAN_JOBS_TABLE)}{suffix}",
+            params,
         ).fetchone()
         return int(result[0])
 
     def distinct(self, column: str, condition: Condition | None) -> list[ScalarValue]:
-        if column not in _SCAN_ROW_COLUMNS:
-            raise ValueError(f"Unknown column: {column!r}")
+        column = validate_column(column, _SCAN_ROW_COLUMNS)
+        quoted_column = quote_identifier(column)
+        quoted_table = quote_identifier(SCAN_JOBS_TABLE)
         if condition is not None:
             where_sql, params = condition_as_sql(condition, "sqlite")
             sql = (
-                f'SELECT DISTINCT "{column}" FROM {SCAN_JOBS_TABLE} '
-                f'WHERE {where_sql} ORDER BY "{column}" ASC'
+                f"SELECT DISTINCT {quoted_column} FROM {quoted_table} "
+                f"WHERE {where_sql} ORDER BY {quoted_column} ASC"
             )
         else:
             params = []
             sql = (
-                f'SELECT DISTINCT "{column}" FROM {SCAN_JOBS_TABLE} '
-                f'ORDER BY "{column}" ASC'
+                f"SELECT DISTINCT {quoted_column} FROM {quoted_table} "
+                f"ORDER BY {quoted_column} ASC"
             )
         return [row[0] for row in self._conn.execute(sql, params).fetchall()]
 

--- a/src/inspect_scout/_transcript/database/factory.py
+++ b/src/inspect_scout/_transcript/database/factory.py
@@ -28,7 +28,7 @@ def transcripts_view(location: str) -> TranscriptsView:
     init_environment()
     match _location_type(location):
         case "database":
-            return ParquetTranscriptsDB(location)
+            return ParquetTranscriptsDB(location, read_only=True)
         case "eval_log":
             return EvalLogTranscriptsView(location)
 

--- a/src/inspect_scout/_transcript/database/parquet/index.py
+++ b/src/inspect_scout/_transcript/database/parquet/index.py
@@ -32,6 +32,13 @@ from inspect_ai._util.file import filesystem
 from inspect_ai.util import trace_message
 from shortuuid import uuid
 
+from ...._query.sql import quote_identifier
+from ...._util.duckdb import (
+    create_parquet_view,
+    drop_view,
+    parquet_view,
+    relation_columns,
+)
 from ..schema import CONTENT_COLUMNS
 from .index_cache import get_index_cache_path, load_cached_index, save_index_cache
 from .migration import migrate_table
@@ -215,37 +222,36 @@ async def create_index(
         # Empty database - nothing to index
         return None
 
-    # Build file list for read_parquet
-    if len(data_files) == 1:
-        file_pattern = f"'{data_files[0]}'"
-    else:
-        file_pattern = "[" + ", ".join(f"'{p}'" for p in data_files) + "]"
+    with parquet_view(
+        conn,
+        data_files,
+        union_by_name=True,
+        filename=True,
+    ) as source_view:
+        all_columns = relation_columns(conn, source_view)
 
-    # Read all metadata from data files, excluding messages/events
-    # First, get the schema to know which columns exist
-    schema_result = conn.execute(
-        f"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet({file_pattern}, union_by_name=true))"
-    ).fetchall()
-    all_columns = {row[0] for row in schema_result}
-
-    # Build exclude clause for large content columns if they exist
-    exclude_columns = [c for c in CONTENT_COLUMNS if c in all_columns]
-    exclude_clause = (
-        f" EXCLUDE ({', '.join(exclude_columns)})" if exclude_columns else ""
-    )
-
-    # Read metadata into Arrow table with deduplication.
-    # If the same transcript_id exists in multiple data files (e.g., from
-    # retried inserts after partial failures), keep only one entry.
-    # We use ROW_NUMBER() to pick one arbitrarily per transcript_id.
-    result = conn.execute(f"""
-        SELECT * EXCLUDE (_rn) FROM (
-            SELECT *{exclude_clause},
-                   ROW_NUMBER() OVER (PARTITION BY transcript_id) as _rn
-            FROM read_parquet({file_pattern}, union_by_name=true, filename=true)
+        # Build exclude clause for large content columns if they exist
+        exclude_columns = [c for c in CONTENT_COLUMNS if c in all_columns]
+        exclude_clause = (
+            " EXCLUDE ("
+            + ", ".join(quote_identifier(column) for column in exclude_columns)
+            + ")"
+            if exclude_columns
+            else ""
         )
-        WHERE _rn = 1
-    """).fetch_arrow_table()
+
+        # Read metadata into Arrow table with deduplication.
+        # If the same transcript_id exists in multiple data files (e.g., from
+        # retried inserts after partial failures), keep only one entry.
+        # We use ROW_NUMBER() to pick one arbitrarily per transcript_id.
+        result = conn.execute(f"""
+            SELECT * EXCLUDE (_rn) FROM (
+                SELECT *{exclude_clause},
+                       ROW_NUMBER() OVER (PARTITION BY transcript_id) as _rn
+                FROM {quote_identifier(source_view)}
+            )
+            WHERE _rn = 1
+        """).fetch_arrow_table()
 
     # Convert absolute filenames to relative paths (relative to database location)
     result = _make_filenames_relative(result, storage.location)
@@ -300,7 +306,7 @@ async def init_index_table(
     if not idx_files:
         # No index files - create empty table
         conn.execute(f"""
-            CREATE TABLE {table_name} AS
+            CREATE TABLE {quote_identifier(table_name)} AS
             SELECT ''::VARCHAR AS transcript_id, ''::VARCHAR AS filename
             WHERE FALSE
         """)
@@ -321,19 +327,14 @@ async def init_index_table(
             migrate_table(conn, table_name)
             return cached_count
 
-    # Build file list for read_parquet
-    if len(idx_files) == 1:
-        file_pattern = f"'{idx_files[0]}'"
-    else:
-        file_pattern = "[" + ", ".join(f"'{p}'" for p in idx_files) + "]"
-
     # Create table from index files
     # Handle file-not-found errors from concurrent operations with retry
     try:
-        conn.execute(f"""
-            CREATE TABLE {table_name} AS
-            SELECT * FROM read_parquet({file_pattern}, union_by_name=true)
-        """)
+        with parquet_view(conn, idx_files, union_by_name=True) as source_view:
+            conn.execute(f"""
+                CREATE TABLE {quote_identifier(table_name)} AS
+                SELECT * FROM {quote_identifier(source_view)}
+            """)
     except duckdb.IOException as e:
         error_msg = str(e).lower()
         if (
@@ -347,7 +348,9 @@ async def init_index_table(
         raise
 
     # Return row count
-    result = conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
+    result = conn.execute(
+        f"SELECT COUNT(*) FROM {quote_identifier(table_name)}"
+    ).fetchone()
     row_count = result[0] if result else 0
 
     # For remote storage, save to cache
@@ -604,28 +607,38 @@ def _read_and_deduplicate_index_files(
     """
     if len(idx_files) == 1:
         # Single file - no deduplication needed
-        return conn.execute(
-            f"SELECT * FROM read_parquet('{idx_files[0]}')"
-        ).fetch_arrow_table()
+        with parquet_view(conn, idx_files[0]) as source_view:
+            return conn.execute(
+                f"SELECT * FROM {quote_identifier(source_view)}"
+            ).fetch_arrow_table()
 
     # Read each file with an order tag. Higher order = newer file.
     # The idx_files list is sorted with older files first, so we use
     # the list index as the order (newer files have higher indices).
-    subqueries = []
-    for i, f in enumerate(sorted(idx_files)):
-        subqueries.append(f"SELECT *, {i} as _file_order FROM read_parquet('{f}')")
+    source_views: list[str] = []
+    try:
+        subqueries = []
+        for i, path in enumerate(sorted(idx_files)):
+            source_view = create_parquet_view(conn, path)
+            source_views.append(source_view)
+            subqueries.append(
+                f"SELECT *, {i} AS _file_order FROM {quote_identifier(source_view)}"
+            )
 
-    union_query = " UNION ALL BY NAME ".join(subqueries)
+        union_query = " UNION ALL BY NAME ".join(subqueries)
 
-    # Deduplicate: keep entry from newest file (highest _file_order)
-    return conn.execute(f"""
-        SELECT * EXCLUDE (_file_order, _rn) FROM (
-            SELECT *,
-                   ROW_NUMBER() OVER (
-                       PARTITION BY transcript_id
-                       ORDER BY _file_order DESC
-                   ) as _rn
-            FROM ({union_query})
-        )
-        WHERE _rn = 1
-    """).fetch_arrow_table()
+        # Deduplicate: keep entry from newest file (highest _file_order)
+        return conn.execute(f"""
+            SELECT * EXCLUDE (_file_order, _rn) FROM (
+                SELECT *,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY transcript_id
+                           ORDER BY _file_order DESC
+                       ) as _rn
+                FROM ({union_query})
+            )
+            WHERE _rn = 1
+        """).fetch_arrow_table()
+    finally:
+        for source_view in source_views:
+            drop_view(conn, source_view)

--- a/src/inspect_scout/_transcript/database/parquet/index_cache.py
+++ b/src/inspect_scout/_transcript/database/parquet/index_cache.py
@@ -26,6 +26,8 @@ import duckdb
 
 from inspect_scout._util.appdirs import scout_cache_dir
 
+from ...._query.sql import quote_identifier
+from ...._util.duckdb import parquet_view
 from .types import IndexStorage
 
 # Cache version - bump this to invalidate all existing caches
@@ -106,11 +108,14 @@ def load_cached_index(
         return None
 
     try:
-        conn.execute(f"""
-            CREATE TABLE {table_name} AS
-            SELECT * FROM read_parquet('{cache_path}')
-        """)
-        result = conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
+        with parquet_view(conn, str(cache_path)) as source_view:
+            conn.execute(f"""
+                CREATE TABLE {quote_identifier(table_name)} AS
+                SELECT * FROM {quote_identifier(source_view)}
+            """)
+        result = conn.execute(
+            f"SELECT COUNT(*) FROM {quote_identifier(table_name)}"
+        ).fetchone()
         return result[0] if result else 0
     except Exception:
         # Cache is corrupted or incompatible - will rebuild
@@ -141,10 +146,13 @@ def save_index_cache(
     tmp_path = cache_path.with_suffix(".tmp")
 
     try:
-        conn.execute(f"""
-            COPY {table_name} TO '{tmp_path}'
+        conn.execute(
+            f"""
+            COPY (SELECT * FROM {quote_identifier(table_name)}) TO ?
             (FORMAT PARQUET, COMPRESSION 'zstd')
-        """)
+            """,
+            [str(tmp_path)],
+        )
 
         # Atomic rename - on POSIX this atomically replaces any existing file
         os.rename(tmp_path, cache_path)

--- a/src/inspect_scout/_transcript/database/parquet/migration.py
+++ b/src/inspect_scout/_transcript/database/parquet/migration.py
@@ -17,6 +17,9 @@ Note: Both approaches are read-only compatible. Writes must use the original col
 
 import duckdb
 
+from ...._query.sql import quote_identifier
+from ...._util.duckdb import generated_identifier
+
 EVAL_LOG_COLUMN_MAP = {
     "task_name": "task_set",
     "eval_created": "date",
@@ -39,72 +42,86 @@ def migrate_table(
 
     column_map: {old_name: new_name, ...}
     """
-    columns = conn.execute(f"""
+    columns = conn.execute(
+        """
         SELECT column_name
         FROM information_schema.columns
-        WHERE table_name = '{table_name}'
-    """).fetchall()
+        WHERE table_name = ?
+        """,
+        [table_name],
+    ).fetchall()
     column_names = {row[0] for row in columns}
 
     # Build list of aliases needed
     aliases = [
-        f"{old} AS {new}"
+        f"{quote_identifier(old)} AS {quote_identifier(new)}"
         for old, new in column_map.items()
         if old in column_names and new not in column_names
     ]
 
     if aliases:
         alias_clause = ", ".join(aliases)
-        temp_table = f"{table_name}_migration_temp"
+        temp_table = generated_identifier("migration_table")
 
         # Create new table with original columns plus aliases
         conn.execute(f"""
-            CREATE TABLE {temp_table} AS
-            SELECT *, {alias_clause} FROM {table_name}
+            CREATE TABLE {quote_identifier(temp_table)} AS
+            SELECT *, {alias_clause} FROM {quote_identifier(table_name)}
         """)
 
         # Replace original table
-        conn.execute(f"DROP TABLE {table_name}")
-        conn.execute(f"ALTER TABLE {temp_table} RENAME TO {table_name}")
+        conn.execute(f"DROP TABLE {quote_identifier(table_name)}")
+        conn.execute(
+            f"ALTER TABLE {quote_identifier(temp_table)} "
+            f"RENAME TO {quote_identifier(table_name)}"
+        )
 
 
 def migrate_view(
     conn: duckdb.DuckDBPyConnection,
     view_name: str,
     column_map: dict[str, str] = EVAL_LOG_COLUMN_MAP,
-) -> None:
+) -> str | None:
     """
     Modify a view in place to add column aliases for backward compatibility.
 
     column_map: {old_name: new_name, ...}
     """
-    columns = conn.execute(f"""
+    columns = conn.execute(
+        """
         SELECT column_name
         FROM information_schema.columns
-        WHERE table_name = '{view_name}'
-    """).fetchall()
+        WHERE table_name = ?
+        """,
+        [view_name],
+    ).fetchall()
     column_names = {row[0] for row in columns}
 
     aliases = [
-        f"{old} AS {new}"
+        f"{quote_identifier(old)} AS {quote_identifier(new)}"
         for old, new in column_map.items()
         if old in column_names and new not in column_names
     ]
 
     if aliases:
-        result = conn.execute(f"""
-            SELECT sql FROM duckdb_views() WHERE view_name = '{view_name}'
-        """).fetchone()
-        if result is None:
-            return
-        view_sql = result[0]
-
-        # Extract the SELECT part after "CREATE VIEW name AS "
-        # and strip trailing semicolon if present
-        select_part = view_sql.split(" AS ", 1)[1].rstrip(";").strip()
+        base_view = generated_identifier("migration_view")
         alias_clause = ", ".join(aliases)
 
-        conn.execute(f"""
-            CREATE OR REPLACE VIEW {view_name} AS
-            SELECT *, {alias_clause} FROM ({select_part}) AS _base
-        """)
+        conn.execute(
+            f"ALTER VIEW {quote_identifier(view_name)} "
+            f"RENAME TO {quote_identifier(base_view)}"
+        )
+        try:
+            conn.execute(f"""
+                CREATE VIEW {quote_identifier(view_name)} AS
+                SELECT *, {alias_clause} FROM {quote_identifier(base_view)}
+            """)
+        except Exception:
+            conn.execute(
+                f"ALTER VIEW {quote_identifier(base_view)} "
+                f"RENAME TO {quote_identifier(view_name)}"
+            )
+            raise
+        return base_view
+
+    return None

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -33,6 +33,16 @@ from inspect_scout._util.filesystem import ensure_filesystem_dependencies
 from ...._query import Query
 from ...._query.condition import Condition, ScalarValue
 from ...._query.condition_sql import condition_as_sql
+from ...._query.sql import quote_identifier, validate_column
+from ...._util.duckdb import (
+    create_parquet_view,
+    drop_view,
+    escape_duckdb_glob,
+    generated_identifier,
+    parquet_view,
+    relation_columns,
+    restrict_external_access,
+)
 from ...json.load_filtered import load_filtered_transcript
 from ...transcripts import (
     Transcripts,
@@ -85,6 +95,8 @@ class _ParquetStreamContextManager:
     async def __aenter__(self) -> "_ParquetStreamContextManager":
         # Create fresh connection for streaming
         self._conn = duckdb.connect(":memory:")
+        if not self._parquet_path.startswith(("s3://", "hf://")):
+            restrict_external_access(self._conn, allowed_paths=[self._parquet_path])
         return self
 
     async def __aexit__(self, *_: object) -> None:
@@ -122,7 +134,8 @@ class _ParquetStreamContextManager:
                 " WHERE transcript_id = ?"
             )
             result = self._conn.execute(
-                sql, [self._parquet_path, self._transcript_id]
+                sql,
+                [escape_duckdb_glob(self._parquet_path), self._transcript_id],
             ).fetchone()
         except duckdb.BinderException:
             # Old file missing events_data/timelines columns — retry without
@@ -133,7 +146,8 @@ class _ParquetStreamContextManager:
                     " WHERE transcript_id = ?"
                 )
                 result = self._conn.execute(
-                    sql, [self._parquet_path, self._transcript_id]
+                    sql,
+                    [escape_duckdb_glob(self._parquet_path), self._transcript_id],
                 ).fetchone()
             except duckdb.BinderException:
                 try:
@@ -143,7 +157,11 @@ class _ParquetStreamContextManager:
                         " WHERE transcript_id = ?"
                     )
                     result = self._conn.execute(
-                        sql, [self._parquet_path, self._transcript_id]
+                        sql,
+                        [
+                            escape_duckdb_glob(self._parquet_path),
+                            self._transcript_id,
+                        ],
                     ).fetchone()
                 except duckdb.BinderException:
                     result = None
@@ -218,6 +236,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
         query: Query | None = None,
         snapshot: ScanTranscripts | None = None,
         pool_dedup: bool = True,
+        read_only: bool = False,
     ) -> None:
         """Initialize Parquet transcript database.
 
@@ -236,6 +255,8 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 which we can use to avoid crawling.
             pool_dedup: Condense repeated messages/calls into pools on write.
                 Exposed for testing; production callers should leave as True.
+            read_only: Restrict DuckDB external access after intended sources
+                are registered.
         """
         self._location = location
         self._target_file_size_mb = target_file_size_mb
@@ -243,6 +264,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
         self._query = query
         self._snapshot = snapshot
         self._pool_dedup = pool_dedup
+        self._read_only = read_only
 
         # could be called in a spawed worker where there are no fs deps yet
         ensure_filesystem_dependencies(location)
@@ -258,9 +280,13 @@ class ParquetTranscriptsDB(TranscriptsDB):
         self._index_storage: IndexStorage | None = None
         self._transcript_ids: set[str] = set()
         self._file_columns_cache: dict[str, set[str]] = {}
-        self._parquet_pattern: str | None = None
+        self._parquet_source_view: str | None = None
+        self._migration_source_view: str | None = None
         self._exclude_clause: str = ""
         self._parquet_columns: set[str] = set()
+        self._transcript_columns: set[str] = set()
+        self._index_columns: set[str] = set()
+        self._allowed_parquet_paths: set[str] = set()
 
     @override
     async def connect(self) -> None:
@@ -312,6 +338,13 @@ class ParquetTranscriptsDB(TranscriptsDB):
 
         # Discover and register Parquet files
         await self._create_transcripts_table()
+
+        if self._read_only:
+            self._allowed_parquet_paths = set(await self._discover_parquet_files())
+            restrict_external_access(
+                self._conn,
+                allowed_paths=sorted(self._allowed_parquet_paths),
+            )
 
     @override
     async def disconnect(self) -> None:
@@ -437,7 +470,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
 
         # Build SQL suffix using Query
         suffix, params, register_shuffle = effective_query.to_sql_suffix(
-            "duckdb", shuffle_column="transcript_id"
+            "duckdb",
+            shuffle_column="transcript_id",
+            available_columns=self._transcript_columns,
         )
         if register_shuffle:
             register_shuffle(self._conn)
@@ -543,13 +578,20 @@ class ParquetTranscriptsDB(TranscriptsDB):
         self, column: str, condition: Condition | None
     ) -> list[ScalarValue]:
         assert self._conn is not None
-        col_name = column
+        col_name = validate_column(column, self._transcript_columns)
+        quoted_column = quote_identifier(col_name)
         if condition is not None:
             where_sql, params = condition_as_sql(condition, "duckdb")
-            sql = f'SELECT DISTINCT "{col_name}" FROM transcripts WHERE {where_sql} ORDER BY "{col_name}" ASC'
+            sql = (
+                f"SELECT DISTINCT {quoted_column} FROM transcripts "
+                f"WHERE {where_sql} ORDER BY {quoted_column} ASC"
+            )
         else:
             params = []
-            sql = f'SELECT DISTINCT "{col_name}" FROM transcripts ORDER BY "{col_name}" ASC'
+            sql = (
+                f"SELECT DISTINCT {quoted_column} FROM transcripts "
+                f"ORDER BY {quoted_column} ASC"
+            )
         result = self._conn.execute(sql, params).fetchall()
         return [row[0] for row in result]
 
@@ -578,7 +620,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 order_by=query.order_by,
             )
             suffix, params, register_shuffle = index_query.to_sql_suffix(
-                "duckdb", shuffle_column="transcript_id"
+                "duckdb",
+                shuffle_column="transcript_id",
+                available_columns=self._index_columns,
             )
             if register_shuffle:
                 register_shuffle(self._conn)
@@ -605,7 +649,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                      + COALESCE(LENGTH(events_data), 0)
                 FROM read_parquet(?) WHERE transcript_id = ?
                 """,
-                [full_path, transcript_id],
+                [escape_duckdb_glob(full_path), transcript_id],
             ).fetchone()
         except duckdb.BinderException:
             result = self._conn.execute(
@@ -613,7 +657,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 SELECT COALESCE(LENGTH(messages), 0) + COALESCE(LENGTH(events), 0)
                 FROM read_parquet(?) WHERE transcript_id = ?
                 """,
-                [full_path, transcript_id],
+                [escape_duckdb_glob(full_path), transcript_id],
             ).fetchone()
         return result[0] if result else 0
 
@@ -710,9 +754,14 @@ class ParquetTranscriptsDB(TranscriptsDB):
 
             # Try optimistic read first (fast path for files with all columns)
             try:
-                sql = f"SELECT {', '.join(columns)} FROM read_parquet(?, union_by_name=true) WHERE transcript_id = ?"
+                sql = (
+                    "SELECT "
+                    + ", ".join(quote_identifier(column) for column in columns)
+                    + " FROM read_parquet(?, union_by_name=true) "
+                    "WHERE transcript_id = ?"
+                )
                 result = self._conn.execute(
-                    sql, [full_path, t.transcript_id]
+                    sql, [escape_duckdb_glob(full_path), t.transcript_id]
                 ).fetchone()
                 columns_read = columns  # All requested columns were available
             except duckdb.BinderException:
@@ -725,9 +774,14 @@ class ParquetTranscriptsDB(TranscriptsDB):
                     return transcript_no_content()
 
                 # Retry with only available columns
-                sql = f"SELECT {', '.join(columns_read)} FROM read_parquet(?, union_by_name=true) WHERE transcript_id = ?"
+                sql = (
+                    "SELECT "
+                    + ", ".join(quote_identifier(column) for column in columns_read)
+                    + " FROM read_parquet(?, union_by_name=true) "
+                    "WHERE transcript_id = ?"
+                )
                 result = self._conn.execute(
-                    sql, [full_path, t.transcript_id]
+                    sql, [escape_duckdb_glob(full_path), t.transcript_id]
                 ).fetchone()
 
             if not result:
@@ -1198,7 +1252,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
             assert self._conn is not None
             schema_result = self._conn.execute(
                 "SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet(?))",
-                [filename],
+                [escape_duckdb_glob(filename)],
             ).fetchall()
             self._file_columns_cache[filename] = {row[0] for row in schema_result}
         return self._file_columns_cache[filename]
@@ -1420,7 +1474,6 @@ class ParquetTranscriptsDB(TranscriptsDB):
             # Drop existing structures
             # DuckDB is type-strict: DROP TABLE IF EXISTS fails on VIEW and vice versa
             # Use try/except to handle both cases
-            self._conn.execute("DROP TABLE IF EXISTS transcript_index")
             try:
                 self._conn.execute("DROP TABLE IF EXISTS transcripts")
             except duckdb.CatalogException:
@@ -1429,6 +1482,14 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 self._conn.execute("DROP VIEW IF EXISTS transcripts")
             except duckdb.CatalogException:
                 pass
+            if self._migration_source_view is not None:
+                drop_view(self._conn, self._migration_source_view)
+                self._migration_source_view = None
+            if self._parquet_source_view is not None:
+                drop_view(self._conn, self._parquet_source_view)
+                self._parquet_source_view = None
+            self._conn.execute("DROP TABLE IF EXISTS transcript_index")
+            self._allowed_parquet_paths = set()
 
             # Decision point: use index files if available, otherwise scan parquet
             idx_files: list[str] = []
@@ -1447,6 +1508,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
             else:
                 # Initialize from parquet files (warning is issued inside if files exist)
                 await self._init_from_parquet(warn_missing_index=should_check)
+
+            self._index_columns = relation_columns(self._conn, "transcript_index")
+            self._transcript_columns = relation_columns(self._conn, "transcripts")
 
     async def _init_from_index(self, check_coverage: bool = False) -> None:
         """Initialize from index files (fast path).
@@ -1470,6 +1534,14 @@ class ParquetTranscriptsDB(TranscriptsDB):
         if row_count == 0:
             self._create_empty_structures()
             return
+
+        self._allowed_parquet_paths = {
+            self._full_parquet_path(str(row[0]))
+            for row in self._conn.execute(
+                "SELECT DISTINCT filename FROM transcript_index "
+                "WHERE filename IS NOT NULL"
+            ).fetchall()
+        }
 
         # Synthesize missing schema columns as NULL
         self._ensure_index_schema()
@@ -1520,7 +1592,11 @@ class ParquetTranscriptsDB(TranscriptsDB):
         if self._snapshot and self._snapshot.transcript_ids:
             # Fast path: extract filenames from snapshot (no crawl needed)
             file_paths = sorted(
-                {f for f in self._snapshot.transcript_ids.values() if f is not None}
+                {
+                    self._full_parquet_path(f)
+                    for f in self._snapshot.transcript_ids.values()
+                    if f is not None
+                }
             )
         else:
             # Standard path: discover parquet files
@@ -1539,9 +1615,13 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 f"Queries will be slower. Run `scout db index {pretty_path(self._location)}` to build an index."
             )
 
-        # Build pattern for read_parquet
-        pattern = self._build_parquet_pattern(file_paths)
-        self._parquet_pattern = pattern
+        self._allowed_parquet_paths = set(file_paths)
+        self._parquet_source_view = create_parquet_view(
+            self._conn,
+            file_paths,
+            union_by_name=True,
+            filename=True,
+        )
 
         # Infer exclude clause from first file
         self._exclude_clause, self._parquet_columns = self._infer_exclude_clause(
@@ -1554,7 +1634,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
             self._create_index_from_snapshot()
         else:
             # Standard path: query parquet files
-            self._create_index_from_parquet(pattern)
+            self._create_index_from_parquet(self._parquet_source_view)
 
         # Create index on transcript_id for fast lookups
         self._conn.execute(
@@ -1562,7 +1642,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
         )
 
         # Create transcripts VIEW for memory-efficient metadata queries
-        self._create_transcripts_view(pattern)
+        self._create_transcripts_view(self._parquet_source_view)
 
     def _apply_query_filter_to_tables(self) -> None:
         """Apply pre-filter query to in-memory tables (indexed path only).
@@ -1576,7 +1656,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
 
         # Build SQL suffix using Query
         suffix, params, register_shuffle = self._query.to_sql_suffix(
-            "duckdb", shuffle_column="transcript_id"
+            "duckdb",
+            shuffle_column="transcript_id",
+            available_columns=relation_columns(self._conn, "transcript_index"),
         )
         if register_shuffle:
             register_shuffle(self._conn)
@@ -1618,7 +1700,9 @@ class ParquetTranscriptsDB(TranscriptsDB):
         for field in TRANSCRIPT_SCHEMA_FIELDS:
             duckdb_type = _pyarrow_to_duckdb_type(field.pyarrow_type)
             default_value = _duckdb_default_value(field.pyarrow_type)
-            column_defs.append(f'{default_value}::{duckdb_type} AS "{field.name}"')
+            column_defs.append(
+                f"{default_value}::{duckdb_type} AS {quote_identifier(field.name)}"
+            )
         # Add filename column (internal)
         column_defs.append("''::VARCHAR AS filename")
 
@@ -1630,13 +1714,6 @@ class ParquetTranscriptsDB(TranscriptsDB):
             WHERE FALSE
         """)
 
-    def _build_parquet_pattern(self, file_paths: list[str]) -> str:
-        """Build DuckDB pattern string for read_parquet."""
-        if len(file_paths) == 1:
-            return f"'{file_paths[0]}'"
-        else:
-            return "[" + ", ".join(f"'{p}'" for p in file_paths) + "]"
-
     def _create_index_from_snapshot(self) -> None:
         """Create transcript_index table directly from snapshot data."""
         assert self._conn is not None
@@ -1645,27 +1722,32 @@ class ParquetTranscriptsDB(TranscriptsDB):
         ids = list(self._snapshot.transcript_ids.keys())
         filenames = [self._snapshot.transcript_ids[tid] for tid in ids]
         arrow_table = pa.table({"transcript_id": ids, "filename": filenames})
-        self._conn.register("snapshot_data", arrow_table)
-        self._conn.execute("""
-            CREATE TABLE transcript_index AS
-            SELECT * FROM snapshot_data
-        """)
-        self._conn.unregister("snapshot_data")
+        snapshot_data = generated_identifier("snapshot")
+        self._conn.register(snapshot_data, arrow_table)
+        try:
+            self._conn.execute(
+                "CREATE TABLE transcript_index AS "
+                f"SELECT * FROM {quote_identifier(snapshot_data)}"
+            )
+        finally:
+            self._conn.unregister(snapshot_data)
 
-    def _create_index_from_parquet(self, pattern: str) -> None:
+    def _create_index_from_parquet(self, source_view: str) -> None:
         """Create transcript_index table by querying parquet files."""
         assert self._conn is not None
 
         base_sql = f"""
             SELECT transcript_id, filename
-            FROM read_parquet({pattern}, union_by_name=true, filename=true)
+            FROM {quote_identifier(source_view)}
         """
 
         # Apply pre-filter query if provided
         params: list[Any] = []
         if self._query:
             suffix, params, register_shuffle = self._query.to_sql_suffix(
-                "duckdb", shuffle_column="transcript_id"
+                "duckdb",
+                shuffle_column="transcript_id",
+                available_columns=relation_columns(self._conn, source_view),
             )
             if register_shuffle:
                 register_shuffle(self._conn)
@@ -1689,35 +1771,45 @@ class ParquetTranscriptsDB(TranscriptsDB):
         assert self._conn is not None
 
         schema_result = self._conn.execute(
-            f"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet('{file_path}'))"
+            "SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet(?))",
+            [escape_duckdb_glob(file_path)],
         ).fetchall()
         existing_columns = {row[0] for row in schema_result}
         exclude_columns = [col for col in CONTENT_COLUMNS if col in existing_columns]
 
-        clause = f" EXCLUDE ({', '.join(exclude_columns)})" if exclude_columns else ""
+        clause = (
+            " EXCLUDE ("
+            + ", ".join(quote_identifier(column) for column in exclude_columns)
+            + ")"
+            if exclude_columns
+            else ""
+        )
         return clause, existing_columns
 
-    def _infer_exclude_clause_full(self, pattern: str) -> tuple[str, set[str]]:
+    def _infer_exclude_clause_full(self, source_view: str) -> tuple[str, set[str]]:
         """Infer EXCLUDE clause by scanning all files' schemas.
 
         Slower fallback that unions schemas from all files to handle
         cases where schema differs across files.
 
         Args:
-            pattern: DuckDB file pattern for read_parquet.
+            source_view: Generated view over the intended Parquet files.
 
         Returns:
             Tuple of (EXCLUDE clause string, set of existing column names).
         """
         assert self._conn is not None
 
-        schema_result = self._conn.execute(
-            f"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet({pattern}, union_by_name=true))"
-        ).fetchall()
-        existing_columns = {row[0] for row in schema_result}
+        existing_columns = relation_columns(self._conn, source_view)
         exclude_columns = [col for col in CONTENT_COLUMNS if col in existing_columns]
 
-        clause = f" EXCLUDE ({', '.join(exclude_columns)})" if exclude_columns else ""
+        clause = (
+            " EXCLUDE ("
+            + ", ".join(quote_identifier(column) for column in exclude_columns)
+            + ")"
+            if exclude_columns
+            else ""
+        )
         return clause, existing_columns
 
     def _missing_columns_clause(self) -> str:
@@ -1733,19 +1825,21 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 and field.name not in CONTENT_COLUMNS
             ):
                 duckdb_type = _pyarrow_to_duckdb_type(field.pyarrow_type)
-                missing_exprs.append(f'NULL::{duckdb_type} AS "{field.name}"')
+                missing_exprs.append(
+                    f"NULL::{duckdb_type} AS {quote_identifier(field.name)}"
+                )
         if missing_exprs:
             return ", " + ", ".join(missing_exprs)
         return ""
 
-    def _create_transcripts_view(self, pattern: str) -> None:
+    def _create_transcripts_view(self, source_view: str) -> None:
         """Create the transcripts VIEW with appropriate EXCLUDE clause.
 
         Tries with exclude clause inferred from first file. If that fails
         (schema differs across files), falls back to full schema scan.
 
         Args:
-            pattern: DuckDB file pattern for read_parquet.
+            source_view: Generated view over the intended Parquet files.
         """
         assert self._conn is not None
 
@@ -1759,7 +1853,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 return f"""
                     CREATE VIEW transcripts AS
                     SELECT p.*{exclude_clause}{missing_clause}
-                    FROM read_parquet({pattern}, union_by_name=true, filename=true) p
+                    FROM {quote_identifier(source_view)} p
                     INNER JOIN transcript_index i ON p.transcript_id = i.transcript_id
                 """
             else:
@@ -1767,7 +1861,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 return f"""
                     CREATE VIEW transcripts AS
                     SELECT *{exclude_clause}{missing_clause}
-                    FROM read_parquet({pattern}, union_by_name=true, filename=true)
+                    FROM {quote_identifier(source_view)}
                 """
 
         missing_clause = self._missing_columns_clause()
@@ -1779,13 +1873,13 @@ class ParquetTranscriptsDB(TranscriptsDB):
             # Schema differs across files - fall back to full scan
             self._conn.execute("DROP VIEW IF EXISTS transcripts")
             self._exclude_clause, self._parquet_columns = (
-                self._infer_exclude_clause_full(pattern)
+                self._infer_exclude_clause_full(source_view)
             )
             missing_clause = self._missing_columns_clause()
             self._conn.execute(build_view_sql(self._exclude_clause, missing_clause))
 
         # migrate view for databases imported from eval_log
-        migrate_view(self._conn, "transcripts")
+        self._migration_source_view = migrate_view(self._conn, "transcripts")
 
     async def _discover_parquet_files(self) -> list[str]:
         """Discover all Parquet files in location.
@@ -1954,12 +2048,12 @@ class ParquetTranscriptsDB(TranscriptsDB):
             f"Compacting {len(session_files)} files for session {session_id}",
         ):
             # 2. Read all session data via DuckDB
-            pattern = self._build_parquet_pattern(session_files)
-
-            # Query and get a RecordBatchReader for streaming
-            result = self._conn.execute(f"""
-                SELECT * FROM read_parquet({pattern}, union_by_name=true)
-            """)
+            with parquet_view(
+                self._conn, session_files, union_by_name=True
+            ) as source_view:
+                table = self._conn.execute(
+                    f"SELECT * FROM {quote_identifier(source_view)}"
+                ).fetch_arrow_table()
 
             # 3. Write to new file(s) WITHOUT session_id using existing logic
             # Fetch batches manually since we need to write in batches
@@ -1968,7 +2062,6 @@ class ParquetTranscriptsDB(TranscriptsDB):
             target_size_bytes = self._target_file_size_mb * 1024 * 1024
 
             # Fetch as Arrow table and convert to batches
-            table = result.fetch_arrow_table()
             for batch in table.to_batches():
                 batch_size = self._estimate_batch_size(batch)
 
@@ -2192,12 +2285,15 @@ class ParquetTranscriptsDB(TranscriptsDB):
         assert self._conn is not None
         hf_token = os.environ.get("HF_TOKEN", None)
         if hf_token:
-            self._conn.execute(f"""
+            self._conn.execute(
+                """
                 CREATE SECRET hf_token (
                     TYPE huggingface,
-                    TOKEN '{hf_token}'
+                    TOKEN ?
                 )
-            """)
+                """,
+                [hf_token],
+            )
         else:
             self._conn.execute("""
                 CREATE SECRET hf_token (
@@ -2240,7 +2336,12 @@ class ParquetTranscripts(Transcripts):
                 reader more efficient (e.g. by preventing a full scan to find
                 transcript_id => filename mappings)
         """
-        db = ParquetTranscriptsDB(self._location, query=self._query, snapshot=snapshot)
+        db = ParquetTranscriptsDB(
+            self._location,
+            query=self._query,
+            snapshot=snapshot,
+            read_only=True,
+        )
         return TranscriptsViewReader(db, self._location, self._query.where)
 
     @staticmethod
@@ -2285,7 +2386,8 @@ def _ensure_index_schema(conn: duckdb.DuckDBPyConnection) -> None:
         if field.name not in existing and field.name not in CONTENT_COLUMNS:
             duckdb_type = _pyarrow_to_duckdb_type(field.pyarrow_type)
             conn.execute(
-                f'ALTER TABLE transcript_index ADD COLUMN "{field.name}" {duckdb_type}'
+                f"ALTER TABLE transcript_index ADD COLUMN "
+                f"{quote_identifier(field.name)} {duckdb_type}"
             )
 
 

--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -55,6 +55,7 @@ from typing_extensions import override
 from .._query import Query
 from .._query.condition import Condition, ScalarValue
 from .._query.condition_sql import condition_as_sql, conditions_as_filter
+from .._query.sql import quote_identifier, validate_column
 from .._scanspec import ScanTranscripts
 from .._transcript.transcripts import Transcripts
 from .._util.caching_async_zip import CachingAsyncZipReader
@@ -257,6 +258,7 @@ class EvalLogTranscriptsView(TranscriptsView):
 
         # sqlite connection (starts out none)
         self._conn: sqlite3.Connection | None = None
+        self._columns: set[str] = set()
 
         # AsyncFilesystem (starts out none)
         self._fs: AsyncFilesystem | None = None
@@ -292,6 +294,13 @@ class EvalLogTranscriptsView(TranscriptsView):
 
             df.to_sql(TRANSCRIPTS, self._conn, index=False, if_exists="replace")
 
+        self._columns = {
+            str(row[0])
+            for row in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", [TRANSCRIPTS]
+            ).fetchall()
+        }
+
     @override
     async def select(self, query: Query | None = None) -> AsyncIterator[TranscriptInfo]:
         assert self._conn is not None
@@ -299,12 +308,14 @@ class EvalLogTranscriptsView(TranscriptsView):
 
         # Build SQL suffix using Query
         suffix, params, register_shuffle = query.to_sql_suffix(
-            "sqlite", shuffle_column="sample_id"
+            "sqlite",
+            shuffle_column="sample_id",
+            available_columns=self._columns,
         )
         if register_shuffle:
             register_shuffle(self._conn)
 
-        sql = f"SELECT * FROM {TRANSCRIPTS}{suffix}"
+        sql = f"SELECT * FROM {quote_identifier(TRANSCRIPTS)}{suffix}"
         cursor = self._conn.execute(sql, params)
 
         # get column names
@@ -398,7 +409,7 @@ class EvalLogTranscriptsView(TranscriptsView):
         # For count, only WHERE matters (ignore limit/shuffle/order_by)
         count_query = Query(where=query.where)
         suffix, params, _ = count_query.to_sql_suffix("sqlite")
-        sql = f"SELECT COUNT(*) FROM {TRANSCRIPTS}{suffix}"
+        sql = f"SELECT COUNT(*) FROM {quote_identifier(TRANSCRIPTS)}{suffix}"
         result = self._conn.execute(sql, params).fetchone()
         assert result is not None
         return int(result[0])
@@ -408,13 +419,21 @@ class EvalLogTranscriptsView(TranscriptsView):
         self, column: str, condition: Condition | None
     ) -> list[ScalarValue]:
         assert self._conn is not None
-        col_name = column
+        col_name = validate_column(column, self._columns)
+        quoted_column = quote_identifier(col_name)
+        quoted_table = quote_identifier(TRANSCRIPTS)
         if condition is not None:
             where_sql, params = condition_as_sql(condition, "sqlite")
-            sql = f'SELECT DISTINCT "{col_name}" FROM {TRANSCRIPTS} WHERE {where_sql} ORDER BY "{col_name}" ASC'
+            sql = (
+                f"SELECT DISTINCT {quoted_column} FROM {quoted_table} "
+                f"WHERE {where_sql} ORDER BY {quoted_column} ASC"
+            )
         else:
             params = []
-            sql = f'SELECT DISTINCT "{col_name}" FROM {TRANSCRIPTS} ORDER BY "{col_name}" ASC'
+            sql = (
+                f"SELECT DISTINCT {quoted_column} FROM {quoted_table} "
+                f"ORDER BY {quoted_column} ASC"
+            )
         result = self._conn.execute(sql, params).fetchall()
         return [row[0] for row in result]
 
@@ -424,12 +443,14 @@ class EvalLogTranscriptsView(TranscriptsView):
         query = query or Query()
 
         suffix, params, register_shuffle = query.to_sql_suffix(
-            "sqlite", shuffle_column="sample_id"
+            "sqlite",
+            shuffle_column="sample_id",
+            available_columns=self._columns,
         )
         if register_shuffle:
             register_shuffle(self._conn)
 
-        sql = f"SELECT * FROM {TRANSCRIPTS}{suffix}"
+        sql = f"SELECT * FROM {quote_identifier(TRANSCRIPTS)}{suffix}"
         cursor = self._conn.execute(sql, params)
         column_names = [desc[0] for desc in cursor.description]
 
@@ -557,6 +578,7 @@ class EvalLogTranscriptsView(TranscriptsView):
         if self._conn is not None:
             self._conn.close()
             self._conn = None
+            self._columns = set()
 
         if self._fs is not None:
             await self._fs.close()
@@ -566,7 +588,8 @@ class EvalLogTranscriptsView(TranscriptsView):
         """Get sample id and epoch from database."""
         assert self._conn is not None
         cursor = self._conn.execute(
-            f"SELECT id, epoch FROM {TRANSCRIPTS} WHERE sample_id = ?",
+            f"SELECT id, epoch FROM {quote_identifier(TRANSCRIPTS)} "
+            "WHERE sample_id = ?",
             (t.transcript_id,),
         )
         row = cursor.fetchone()

--- a/src/inspect_scout/_util/duckdb.py
+++ b/src/inspect_scout/_util/duckdb.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import uuid4
+
+import duckdb
+
+from .._query.sql import quote_identifier
+
+
+def generated_identifier(prefix: str) -> str:
+    """Create an internal DuckDB identifier independent of artifact names."""
+    return f"_scout_{prefix}_{uuid4().hex}"
+
+
+def escape_duckdb_glob(path: str) -> str:
+    """Make a discovered path literal in DuckDB's glob-aware file readers."""
+    replacements = {
+        "*": "[*]",
+        "?": "[?]",
+        "[": "[[]",
+        "{": "[{]",
+    }
+    return "".join(replacements.get(char, char) for char in path)
+
+
+def parquet_paths(paths: str | Sequence[str]) -> str | list[str]:
+    """Normalize explicit Parquet paths for DuckDB's Python relation API."""
+    values = [paths] if isinstance(paths, str) else list(paths)
+    if not values:
+        raise ValueError("At least one Parquet path is required")
+    escaped = [escape_duckdb_glob(path) for path in values]
+    return escaped[0] if len(escaped) == 1 else escaped
+
+
+def create_parquet_view(
+    conn: duckdb.DuckDBPyConnection,
+    paths: str | Sequence[str],
+    *,
+    union_by_name: bool = False,
+    filename: bool = False,
+) -> str:
+    """Register explicit Parquet sources under an internal DuckDB view."""
+    name = generated_identifier("parquet")
+    paths_variable = f"{name}_paths"
+    conn.execute(
+        f"SET VARIABLE {quote_identifier(paths_variable)} = ?",
+        [parquet_paths(paths)],
+    )
+    options = []
+    if union_by_name:
+        options.append("union_by_name = true")
+    if filename:
+        options.append("filename = true")
+    option_sql = f", {', '.join(options)}" if options else ""
+    try:
+        conn.execute(
+            f"CREATE VIEW {quote_identifier(name)} AS "
+            f"SELECT * FROM read_parquet("
+            f"getvariable('{paths_variable}'){option_sql})"
+        )
+    except Exception:
+        conn.execute(f"RESET VARIABLE {quote_identifier(paths_variable)}")
+        raise
+    return name
+
+
+def drop_view(conn: duckdb.DuckDBPyConnection, view_name: str) -> None:
+    """Drop a generated DuckDB view."""
+    conn.execute(f"DROP VIEW IF EXISTS {quote_identifier(view_name)}")
+    if view_name.startswith("_scout_parquet_"):
+        conn.execute(f"RESET VARIABLE {quote_identifier(f'{view_name}_paths')}")
+
+
+@contextmanager
+def parquet_view(
+    conn: duckdb.DuckDBPyConnection,
+    paths: str | Sequence[str],
+    *,
+    union_by_name: bool = False,
+    filename: bool = False,
+) -> Iterator[str]:
+    """Temporarily register explicit Parquet sources as a generated view."""
+    view_name = create_parquet_view(
+        conn,
+        paths,
+        union_by_name=union_by_name,
+        filename=filename,
+    )
+    try:
+        yield view_name
+    finally:
+        drop_view(conn, view_name)
+
+
+def relation_columns(
+    conn: duckdb.DuckDBPyConnection,
+    relation_name: str,
+) -> set[str]:
+    """Read the top-level columns of a DuckDB table or view."""
+    rows = conn.execute(
+        f"SELECT column_name FROM (DESCRIBE {quote_identifier(relation_name)})"
+    ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def restrict_external_access(
+    conn: duckdb.DuckDBPyConnection,
+    *,
+    allowed_paths: Sequence[str] = (),
+    allowed_directories: Sequence[str] = (),
+) -> None:
+    """Lock a read-only DuckDB connection to explicitly intended sources."""
+    if allowed_paths:
+        path_variants: list[str] = []
+        for path in allowed_paths:
+            path_variants.append(path)
+            if path.startswith("file://"):
+                path_variants.append(path[len("file://") :])
+            elif "://" not in path:
+                absolute_path = Path(path).absolute()
+                path_variants.extend([str(absolute_path), absolute_path.as_uri()])
+        path_variants.extend(escape_duckdb_glob(path) for path in list(path_variants))
+        conn.execute(
+            "SET allowed_paths = ?",
+            [list(dict.fromkeys(path_variants))],
+        )
+    if allowed_directories:
+        conn.execute(
+            "SET allowed_directories = ?",
+            [list(dict.fromkeys(allowed_directories))],
+        )
+    conn.execute("SET autoinstall_known_extensions = false")
+    conn.execute("SET autoload_known_extensions = false")
+    conn.execute("SET enable_external_access = false")
+    conn.execute("SET lock_configuration = true")

--- a/src/inspect_scout/_view/_api_v2.py
+++ b/src/inspect_scout/_view/_api_v2.py
@@ -2,8 +2,10 @@
 
 from pathlib import Path as PathlibPath
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
+from .._query import UnknownColumnError
 from ._api_v2_config import create_config_router
 from ._api_v2_dist import create_dist_router
 from ._api_v2_scanners import create_scanners_router
@@ -33,6 +35,13 @@ def v2_api_app(
         title="Inspect Scout Viewer API",
         version=API_VERSION,
     )
+
+    @app.exception_handler(UnknownColumnError)
+    async def unknown_column_handler(
+        _request: Request, exc: UnknownColumnError
+    ) -> JSONResponse:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
     app.include_router(create_config_router(view_config=view_config))
     app.include_router(create_dist_router(dist_path=dist_path))
     app.include_router(create_topics_router())

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -1,0 +1,42 @@
+import pytest
+from inspect_scout._query import Query, UnknownColumnError
+from inspect_scout._query.order_by import OrderBy
+from inspect_scout._query.sql import quote_identifier
+
+
+def test_quote_identifier_escapes_embedded_quotes() -> None:
+    assert quote_identifier('column"; SELECT 1; --') == ('"column""; SELECT 1; --"')
+
+
+def test_order_by_requires_connected_schema() -> None:
+    query = Query(order_by=[OrderBy("model", "ASC")])
+
+    with pytest.raises(ValueError, match="available_columns"):
+        query.to_sql_suffix("duckdb")
+
+
+def test_order_by_rejects_unknown_column() -> None:
+    query = Query(order_by=[OrderBy('model"; SELECT 1; --', "ASC")])
+
+    with pytest.raises(UnknownColumnError):
+        query.to_sql_suffix("duckdb", available_columns={"model"})
+
+
+def test_order_by_quotes_valid_column() -> None:
+    query = Query(order_by=[OrderBy('model"name', "DESC")])
+
+    suffix, params, register_shuffle = query.to_sql_suffix(
+        "duckdb", available_columns={'model"name'}
+    )
+
+    assert suffix == ' ORDER BY "model""name" DESC'
+    assert params == []
+    assert register_shuffle is None
+
+
+def test_order_by_rejects_unknown_direction() -> None:
+    query = Query(order_by=[OrderBy("model", "ASC")])
+    query.order_by[0].direction = "ASC; SELECT 1"  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="Unsupported order direction"):
+        query.to_sql_suffix("duckdb", available_columns={"model"})

--- a/tests/recorder/test_duckdb_security.py
+++ b/tests/recorder/test_duckdb_security.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from inspect_scout._query.sql import quote_identifier
+from inspect_scout._recorder.summary import Summary
+from inspect_scout._scanresults import scan_results_db
+from inspect_scout._scanspec import ScannerSpec, ScanSpec
+
+
+def _write_status(scan: Path, scanners: list[str]) -> None:
+    spec = ScanSpec(
+        scan_id="security",
+        scan_name="security",
+        scanners={name: ScannerSpec(name=name) for name in scanners},
+    )
+    (scan / "_scan.json").write_text(spec.model_dump_json(), encoding="utf-8")
+    summary = Summary(scanners=scanners)
+    summary.complete = True
+    (scan / "_summary.json").write_text(summary.model_dump_json(), encoding="utf-8")
+
+
+def test_undeclared_malicious_scan_file_is_ignored(tmp_path: Path) -> None:
+    scan = tmp_path / "scan_id=security"
+    scan.mkdir()
+    _write_status(scan, ["safe"])
+    pq.write_table(
+        pa.table({"value_type": ["string"], "value": ["fixture"]}),
+        scan / "safe.parquet",
+    )
+
+    marker = tmp_path / "scan-marker.txt"
+    escaped_marker = str(marker).replace("\\", "\\\\").replace("/", "\\x2f")
+    malicious_name = (
+        "safe'); "
+        f"COPY (SELECT 'INJECTED') TO E'{escaped_marker}' "
+        "(HEADER false); --.parquet"
+    )
+    (scan / malicious_name).write_bytes(b"not parquet")
+
+    db = scan_results_db(str(scan))
+    try:
+        assert db.scanner_tables == {"safe": "safe"}
+        assert db.conn.execute("SELECT value FROM safe").fetchone() == ("fixture",)
+        with pytest.raises(duckdb.PermissionException):
+            db.conn.execute("COPY (SELECT 1) TO ?", [str(marker)])
+    finally:
+        db.conn.close()
+
+    assert not marker.exists()
+
+
+def test_declared_malicious_names_are_quoted(tmp_path: Path) -> None:
+    scan = tmp_path / "scan_id=security"
+    scan.mkdir()
+    marker = tmp_path / "declared-marker.txt"
+    escaped_marker = str(marker).replace("\\", "\\\\").replace("/", "\\x2f")
+    scanner_name = (
+        f"x'); COPY (SELECT 'INJECTED') TO E'{escaped_marker}' (HEADER false); --"
+    )
+    malicious_column = 'extra"; COPY (SELECT 1); --'
+    _write_status(scan, [scanner_name])
+    pq.write_table(
+        pa.table(
+            {
+                "transcript_id": ["t1"],
+                "value_type": ["resultset"],
+                "value": [
+                    '[{"uuid":"r1","label":"label","value":"ok","type":"string"}]'
+                ],
+                malicious_column: ["column-value"],
+            }
+        ),
+        scan / f"{scanner_name}.parquet",
+    )
+
+    db = scan_results_db(str(scan))
+    try:
+        table_name = db.scanner_tables[scanner_name]
+        row = db.conn.execute(
+            f"SELECT {quote_identifier(malicious_column)} "
+            f"FROM {quote_identifier(table_name)}"
+        ).fetchone()
+        assert row == ("column-value",)
+
+        output = tmp_path / "results'; --.duckdb"
+        db.to_file(str(output))
+        verify = duckdb.connect(str(output))
+        try:
+            assert scanner_name in {
+                row[0] for row in verify.execute("SHOW TABLES").fetchall()
+            }
+        finally:
+            verify.close()
+    finally:
+        db.conn.close()
+
+    assert not marker.exists()

--- a/tests/scanjobs/test_store.py
+++ b/tests/scanjobs/test_store.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from inspect_scout._query import Column, Query
+from inspect_scout._query import Column, Query, UnknownColumnError
 from inspect_scout._query.order_by import OrderBy
 from inspect_scout._scanjobs.store import ScanIndexStore
 from inspect_scout._view._api_v2_types import ScanRow
@@ -117,4 +117,13 @@ def test_distinct_rejects_unknown_column(tmp_path: Path) -> None:
     store.upsert([(make_row("a"), "t")])
     with pytest.raises(ValueError):
         store.distinct('x" FROM scan_jobs; --', None)
+    store.close()
+
+
+def test_order_by_rejects_unknown_column(tmp_path: Path) -> None:
+    store = ScanIndexStore(tmp_path / "scans.sqlite")
+    store.upsert([(make_row("a"), "t")])
+    with pytest.raises(UnknownColumnError):
+        store.select(Query(order_by=[OrderBy('x"; DELETE FROM scan_jobs; --', "ASC")]))
+    assert {row.scan_id for row in store.select()} == {"a"}
     store.close()

--- a/tests/transcript/database/test_duckdb_sql_security.py
+++ b/tests/transcript/database/test_duckdb_sql_security.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from inspect_ai.model import ChatMessageUser
+from inspect_scout._query import Query
+from inspect_scout._query.order_by import OrderBy
+from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
+from inspect_scout._transcript.types import Transcript
+
+
+def _minimal_transcript_table(transcript_id: str) -> pa.Table:
+    return pa.table(
+        {
+            "transcript_id": [transcript_id],
+            "messages": ["[]"],
+            "events": ["[]"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_malicious_transcript_filename_is_data(tmp_path: Path) -> None:
+    location = tmp_path / "transcripts"
+    location.mkdir()
+    marker = tmp_path / "transcript-marker.txt"
+
+    pq.write_table(_minimal_transcript_table("normal"), location / "a.parquet")
+    pq.write_table(_minimal_transcript_table("companion"), location / "z")
+
+    escaped_marker = str(marker).replace("\\", "\\\\").replace("/", "\\x2f")
+    malicious_name = (
+        "z']); "
+        f"COPY (SELECT 'INJECTED') TO E'{escaped_marker}' "
+        "(HEADER false); --.parquet"
+    )
+    pq.write_table(
+        _minimal_transcript_table("malicious-name"),
+        location / malicious_name,
+    )
+
+    db = ParquetTranscriptsDB(str(location), read_only=True)
+    await db.connect()
+    try:
+        assert await db.count(Query()) == 2
+        assert {item.transcript_id async for item in db.select()} == {
+            "normal",
+            "malicious-name",
+        }
+        assert len([item async for item in db.select(Query(shuffle=7))]) == 2
+        assert db._conn is not None
+        with pytest.raises(duckdb.PermissionException):
+            db._conn.execute("COPY (SELECT 1) TO ?", [str(marker)])
+    finally:
+        await db.disconnect()
+
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_metacharacter_database_path_and_index_round_trip(
+    tmp_path: Path,
+) -> None:
+    location = tmp_path / "db'; --"
+    db = ParquetTranscriptsDB(str(location))
+    await db.connect()
+    await db.insert(
+        [
+            Transcript(
+                transcript_id="indexed",
+                source_type="test",
+                source_id="source",
+                source_uri="test://source",
+                metadata={'custom"; column': "value"},
+                messages=[ChatMessageUser(content="fixture")],
+                events=[],
+            )
+        ]
+    )
+    await db.disconnect()
+
+    read_db = ParquetTranscriptsDB(str(location), read_only=True)
+    await read_db.connect()
+    try:
+        assert await read_db.count(Query()) == 1
+        assert await read_db.distinct('custom"; column', None) == ["value"]
+        assert (
+            len(
+                [
+                    item
+                    async for item in read_db.select(
+                        Query(order_by=[OrderBy('custom"; column', "ASC")])
+                    )
+                ]
+            )
+            == 1
+        )
+    finally:
+        await read_db.disconnect()

--- a/tests/transcript/database/test_index_cache.py
+++ b/tests/transcript/database/test_index_cache.py
@@ -8,6 +8,7 @@ import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from inspect_scout._query.sql import quote_identifier
 from inspect_scout._transcript.database.parquet.index import (
     init_index_table,
 )
@@ -227,6 +228,28 @@ class TestCacheSaveLoad:
         assert len(result) == 2
         assert result[0][0] == "id1"
         assert result[1][0] == "id2"
+
+    def test_cache_paths_and_table_names_are_not_sql(
+        self, conn: duckdb.DuckDBPyConnection, tmp_path: Path
+    ) -> None:
+        table_name = 'index"; COPY (SELECT 1); --'
+        loaded_name = 'loaded"; DROP TABLE x; --'
+        conn.execute(
+            f"CREATE TABLE {quote_identifier(table_name)} AS "
+            "SELECT 'id1' AS transcript_id, 'file.parquet' AS filename"
+        )
+
+        cache_path = tmp_path / "cache'; --.parquet"
+        save_index_cache(conn, cache_path, table_name)
+
+        conn2 = duckdb.connect(":memory:")
+        try:
+            assert load_cached_index(conn2, cache_path, loaded_name) == 1
+            assert conn2.execute(
+                f"SELECT transcript_id FROM {quote_identifier(loaded_name)}"
+            ).fetchone() == ("id1",)
+        finally:
+            conn2.close()
 
     def test_load_cached_index_returns_none_if_missing(
         self, conn: duckdb.DuckDBPyConnection, tmp_path: Path

--- a/tests/transcript/test_parquet_db.py
+++ b/tests/transcript/test_parquet_db.py
@@ -1117,13 +1117,19 @@ async def test_file_uri_discovery(test_location: Path) -> None:
 
     # Now create a new database using file: URI
     file_uri = test_location.as_uri()  # Converts to file:///path/to/dir
-    db_uri = ParquetTranscriptsDB(file_uri)
+    db_uri = ParquetTranscriptsDB(file_uri, read_only=True)
     await db_uri.connect()
 
     try:
         # Should discover and read all transcripts
         transcript_ids = await db_uri.transcript_ids(Query())
         assert len(transcript_ids) == 3
+        [info, *_] = [item async for item in db_uri.select(Query(limit=1))]
+        transcript = await db_uri.read(
+            info,
+            TranscriptContent(messages="all", events="all"),
+        )
+        assert transcript.messages
     finally:
         await db_uri.disconnect()
 

--- a/tests/util/test_duckdb.py
+++ b/tests/util/test_duckdb.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from inspect_scout._query.sql import quote_identifier
+from inspect_scout._util.duckdb import (
+    create_parquet_view,
+    restrict_external_access,
+)
+
+
+def test_discovered_parquet_paths_are_not_globs(tmp_path: Path) -> None:
+    literal = tmp_path / "literal*[x]?.parquet"
+    matching = tmp_path / "literal-otherx1.parquet"
+    pq.write_table(pa.table({"value": ["literal"]}), literal)
+    pq.write_table(pa.table({"value": ["other"]}), matching)
+
+    conn = duckdb.connect(":memory:")
+    try:
+        source_view = create_parquet_view(conn, str(literal))
+        restrict_external_access(conn, allowed_paths=[str(literal)])
+        assert conn.execute(
+            f"SELECT value FROM {quote_identifier(source_view)}"
+        ).fetchall() == [("literal",)]
+        with pytest.raises(duckdb.PermissionException):
+            conn.execute(
+                "SELECT value FROM read_parquet(?)",
+                [str(literal)],
+            ).fetchall()
+    finally:
+        conn.close()

--- a/tests/view/test_duckdb_sql_security.py
+++ b/tests/view/test_duckdb_sql_security.py
@@ -1,0 +1,109 @@
+import base64
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from inspect_ai.model import ChatMessageUser
+from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
+from inspect_scout._transcript.types import Transcript
+from inspect_scout._view._api_v2 import v2_api_app
+
+
+def _encode_dir(path: Path) -> str:
+    return base64.urlsafe_b64encode(str(path).encode()).decode().rstrip("=")
+
+
+@pytest_asyncio.fixture
+async def transcript_db(tmp_path: Path) -> AsyncIterator[Path]:
+    location = tmp_path / "transcripts"
+    db = ParquetTranscriptsDB(str(location))
+    await db.connect()
+    await db.insert(
+        [
+            Transcript(
+                transcript_id="security-test",
+                source_type="test",
+                source_id="source",
+                source_uri="test://source",
+                model="model",
+                messages=[ChatMessageUser(content="fixture")],
+                events=[],
+            )
+        ]
+    )
+    await db.disconnect()
+    yield location
+
+
+def test_order_by_sql_injection_is_rejected(
+    transcript_db: Path, tmp_path: Path
+) -> None:
+    marker = tmp_path / "order-by-marker.txt"
+    injected_column = (
+        f"transcript_id\"; COPY (SELECT 'INJECTED') TO '{marker}' (HEADER false); --"
+    )
+
+    with TestClient(v2_api_app(), raise_server_exceptions=False) as client:
+        response = client.post(
+            f"/transcripts/{_encode_dir(transcript_db)}",
+            json={
+                "order_by": {
+                    "column": injected_column,
+                    "direction": "ASC",
+                }
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Unknown column:")
+    assert not marker.exists()
+
+
+def test_distinct_sql_injection_is_rejected(
+    transcript_db: Path, tmp_path: Path
+) -> None:
+    marker = tmp_path / "distinct-marker.txt"
+    injected_column = (
+        f"model\"; COPY (SELECT 'INJECTED') TO E'{marker}' (HEADER false); --"
+    )
+
+    with TestClient(v2_api_app(), raise_server_exceptions=False) as client:
+        response = client.post(
+            f"/transcripts/{_encode_dir(transcript_db)}/distinct",
+            json={"column": injected_column},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Unknown column:")
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        '"',
+        "--",
+        "/* comment */",
+        "; SELECT 1",
+        "E''",
+        "\\x2f",
+        "model\\",
+    ],
+)
+def test_identifier_metacharacters_never_reach_sql(
+    transcript_db: Path, column: str
+) -> None:
+    with TestClient(v2_api_app(), raise_server_exceptions=False) as client:
+        order_response = client.post(
+            f"/transcripts/{_encode_dir(transcript_db)}",
+            json={"order_by": {"column": column, "direction": "ASC"}},
+        )
+        distinct_response = client.post(
+            f"/transcripts/{_encode_dir(transcript_db)}/distinct",
+            json={"column": column},
+        )
+
+    assert order_response.status_code == 400
+    assert distinct_response.status_code == 400


### PR DESCRIPTION
### Summary

Scout interpolated transcript query columns, Parquet paths, filename stems, and schema-derived names into DuckDB SQL. A crafted API request or portable scan/transcript artifact could append DuckDB statements and read or write host files.

This change:

- binds local and remote Parquet sources instead of constructing SQL literals;
- uses generated internal relations and centrally quoted identifiers;
- validates `order_by` and `distinct` columns against the connected schema;
- removes catalog SQL replay from view migration; and
- disables ambient external access on read-only artifact connections after their intended sources are registered.

Valid local, `file://`, S3, and Hugging Face database behavior is retained. Canonical scanner table names and explicit `ScanResultsDB.to_file()` exports remain available.

### Tests

- C6 transcript API `order_by` and `distinct` injection payloads
- C7 malicious scan filenames, scanner names, and Parquet column names
- C8 malicious transcript-database filenames
- quotes, comments, semicolons, backslashes, `E''`, and `\x2f`
- exact path handling for DuckDB glob metacharacters
- index/cache/migration and `file://` compatibility
- read-only external-access restrictions

Verification completed locally:

- 930 affected-subsystem tests passed, 1 skipped
- locked lazy remote-Parquet view verified with a local HTTP range fixture
- Ruff clean
- mypy clean across 425 source files