### PR TITLE
Scout View: harden standalone network trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Security: Validate standalone Scout View Host and browser origins, prevent framing, and require authorization or explicit acknowledgement for non-loopback binds.
 - Security: Remove terminal control sequences from scanner names, scan metadata, errors, progress text, and filenames before rendering console output.
 - Security: Build DuckDB queries from bound Parquet sources and quoted, schema-validated identifiers so malicious transcript/scan filenames and sort or distinct columns cannot inject SQL.
 - Add `timeline` option to `transcript_messages()` and `llm_scanner()` for selecting a named timeline.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -96,6 +96,47 @@ scout scan list
 
 Scans will be listed from most to least recent. If you are running within VS Code you can click the scans in the list to view them in a VS Code editor. The VS Code Scout activity bar also includes a scans pane that lists recent scans.
 
+#### Remote Access
+
+By default, `scout view` binds to `127.0.0.1` on port 7576. For single-user access to a viewer on a remote machine, keep that loopback bind and use SSH port forwarding:
+
+``` bash
+ssh -L 7576:127.0.0.1:7576 user@remote
+```
+
+Run `scout view` normally on the remote machine, then open `http://127.0.0.1:7576` locally.
+
+If local DNS or a hosts file maps a custom name to loopback, declare that exact browser origin:
+
+``` bash
+scout view --trusted-origin http://my-scout:7576
+```
+
+Binding beyond loopback requires request authorization. For browser access, place Scout View behind an authenticating reverse proxy that injects the configured upstream authorization header:
+
+``` bash
+INSPECT_VIEW_AUTHORIZATION_TOKEN="$UPSTREAM_SECRET" \
+  scout view \
+  --host 0.0.0.0 \
+  --trusted-origin https://scout.example.org \
+  --root-path /scout
+```
+
+Load `UPSTREAM_SECRET` through your normal secret-management mechanism and set it to the complete expected `Authorization` header value (for example, `Bearer ...`). The proxy must authenticate the external user, preserve the configured public `Host`, set the public request scheme from a trusted proxy address, remove any client-supplied copy of the upstream authorization header, and inject the configured value.
+
+For compatibility, an absolute `--root-path` such as `https://scout.example.org/scout` supplies its origin when no explicit `--trusted-origin` is provided. An explicit trusted origin is preferred, and a path-only `root_path` does not grant host or origin trust.
+
+Unauthenticated network exposure remains available only through an explicit acknowledgement:
+
+``` bash
+scout view \
+  --host 0.0.0.0 \
+  --trusted-origin "http://$MACHINE_IP:7576" \
+  --unsafe-allow-unauthenticated
+```
+
+This permits any network client that can reach the address to call viewer APIs. Exact Host and browser-origin validation and framing protection remain active. `--trusted-host` may add an exact authority for a non-browser client or health check, but does not authorize a browser origin. Hosting the frontend and API on different origins is not supported.
+
 ### Projects
 
 In some cases you'll prefer to define your transcript source, scanning model, and other configuration once for a project rather than each time you run `scout scan`. You can do this with a `scout.yaml` project file. For example, if we have this project file in our working directory:

--- a/src/inspect_scout/_cli/common.py
+++ b/src/inspect_scout/_cli/common.py
@@ -102,7 +102,7 @@ def view_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     @click.option(
         "--host",
         default=DEFAULT_SERVER_HOST,
-        help="Tcp/Ip host for view server.",
+        help="TCP/IP bind host. Non-loopback binds require authorization or an explicit unsafe acknowledgement.",
     )
     @click.option(
         "--port",
@@ -122,6 +122,21 @@ def view_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         default="",
         envvar="UVICORN_ROOT_PATH",
         help="ASGI root_path for serving behind a reverse proxy.",
+    )
+    @click.option(
+        "--trusted-origin",
+        multiple=True,
+        help="Exact browser origin allowed to use the viewer. Repeat for multiple origins.",
+    )
+    @click.option(
+        "--trusted-host",
+        multiple=True,
+        help="Additional exact HTTP authority allowed for non-browser clients.",
+    )
+    @click.option(
+        "--unsafe-allow-unauthenticated",
+        is_flag=True,
+        help="Acknowledge unauthenticated access when binding beyond loopback.",
     )
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> click.Context:

--- a/src/inspect_scout/_cli/view.py
+++ b/src/inspect_scout/_cli/view.py
@@ -11,6 +11,7 @@ from inspect_scout._cli.common import (
     resolve_view_authorization,
     view_options,
 )
+from inspect_scout._view.network import ViewerNetworkPolicyError
 
 from .._view.view import view
 
@@ -49,20 +50,29 @@ def view_command(
     port: int,
     browser: bool | None,
     root_path: str,
+    trusted_origin: tuple[str, ...],
+    trusted_host: tuple[str, ...],
+    unsafe_allow_unauthenticated: bool,
     **common: Unpack[CommonOptions],
 ) -> None:
     """View scan results."""
     process_common_options(common)
 
-    view(
-        project_dir=project_dir,
-        transcripts=transcripts,
-        scans=scans,
-        host=host,
-        port=port,
-        browser=browser is True,
-        mode=mode,
-        authorization=resolve_view_authorization(),
-        log_level=common["log_level"],
-        root_path=root_path,
-    )
+    try:
+        view(
+            project_dir=project_dir,
+            transcripts=transcripts,
+            scans=scans,
+            host=host,
+            port=port,
+            browser=browser is True,
+            mode=mode,
+            authorization=resolve_view_authorization(),
+            log_level=common["log_level"],
+            root_path=root_path,
+            trusted_origins=trusted_origin,
+            trusted_hosts=trusted_host,
+            unsafe_allow_unauthenticated=unsafe_allow_unauthenticated,
+        )
+    except ViewerNetworkPolicyError as ex:
+        raise click.UsageError(str(ex)) from ex

--- a/src/inspect_scout/_view/network.py
+++ b/src/inspect_scout/_view/network.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from starlette.datastructures import MutableHeaders
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_VALIDATED_HOST_SCOPE_KEY = "inspect_scout.viewer_authority"
+_VIEW_DOCS_URL = "https://meridianlabs-ai.github.io/inspect_scout/"
+
+
+class ViewerNetworkPolicyError(ValueError):
+    """Invalid or unsafe standalone viewer network configuration."""
+
+
+@dataclass(frozen=True)
+class Authority:
+    host: str
+    port: int | None = None
+
+    def __str__(self) -> str:
+        host = f"[{self.host}]" if ":" in self.host else self.host
+        return f"{host}:{self.port}" if self.port is not None else host
+
+
+@dataclass(frozen=True)
+class Origin:
+    scheme: str
+    authority: Authority
+
+    def __str__(self) -> str:
+        return f"{self.scheme}://{self.authority}"
+
+
+@dataclass(frozen=True)
+class ViewerNetworkPolicy:
+    bind_host: str
+    port: int
+    trusted_hosts: frozenset[Authority]
+    trusted_origins: frozenset[Origin]
+    authorization: str | None = None
+    unsafe_allow_unauthenticated: bool = False
+
+
+def resolve_viewer_network_policy(
+    *,
+    bind_host: str,
+    port: int,
+    trusted_hosts: tuple[str, ...] = (),
+    trusted_origins: tuple[str, ...] = (),
+    authorization: str | None = None,
+    unsafe_allow_unauthenticated: bool = False,
+    root_path: str = "",
+) -> ViewerNetworkPolicy:
+    """Validate and resolve standalone viewer network trust configuration."""
+    if not 1 <= port <= 65535:
+        raise ViewerNetworkPolicyError(f"Invalid viewer port: {port}")
+
+    canonical_bind_host = _canonical_hostname(bind_host)
+    loopback = _is_loopback_host(canonical_bind_host)
+    wildcard = _is_wildcard_host(canonical_bind_host)
+
+    resolved_hosts: set[Authority] = set()
+    for value in trusted_hosts:
+        try:
+            resolved_hosts.add(_parse_authority(value))
+        except ValueError as ex:
+            raise ViewerNetworkPolicyError(
+                f"Invalid trusted host {value!r}: {ex}"
+            ) from ex
+
+    origin_values = trusted_origins
+    compatibility_origin = None
+    if not origin_values:
+        compatibility_origin = _absolute_root_path_origin(root_path)
+        if compatibility_origin is not None:
+            origin_values = (compatibility_origin,)
+
+    resolved_origins: set[Origin] = set()
+    for value in origin_values:
+        try:
+            resolved_origins.add(_parse_origin(value))
+        except ValueError as ex:
+            raise ViewerNetworkPolicyError(
+                f"Invalid trusted origin {value!r}: {ex}"
+            ) from ex
+    resolved_hosts.update(origin.authority for origin in resolved_origins)
+
+    if loopback:
+        for host in _loopback_default_hosts(canonical_bind_host):
+            origin = _http_origin(host, port)
+            resolved_hosts.add(origin.authority)
+            resolved_origins.add(origin)
+    elif not wildcard:
+        origin = _http_origin(canonical_bind_host, port)
+        resolved_hosts.add(origin.authority)
+        resolved_origins.add(origin)
+
+    authorization = authorization or None
+    if not loopback and authorization is None and not unsafe_allow_unauthenticated:
+        extra = (
+            " Wildcard binds also require --trusted-origin or --trusted-host."
+            if wildcard
+            else ""
+        )
+        raise ViewerNetworkPolicyError(
+            f"Refusing to expose Scout View on {bind_host} without request "
+            "authorization. Configure INSPECT_VIEW_AUTHORIZATION_TOKEN behind "
+            "an authenticated proxy, or pass --unsafe-allow-unauthenticated "
+            f"to acknowledge unauthenticated network access.{extra} "
+            f"See {_VIEW_DOCS_URL}."
+        )
+
+    explicit_trust = bool(trusted_hosts or trusted_origins or compatibility_origin)
+    if wildcard and not explicit_trust:
+        raise ViewerNetworkPolicyError(
+            f"Refusing wildcard bind {bind_host} without an explicit trusted "
+            "origin or host. Configure --trusted-origin or --trusted-host. "
+            f"See {_VIEW_DOCS_URL}."
+        )
+
+    return ViewerNetworkPolicy(
+        bind_host=canonical_bind_host,
+        port=port,
+        trusted_hosts=frozenset(resolved_hosts),
+        trusted_origins=frozenset(resolved_origins),
+        authorization=authorization,
+        unsafe_allow_unauthenticated=unsafe_allow_unauthenticated,
+    )
+
+
+def unsafe_network_warning(policy: ViewerNetworkPolicy) -> str | None:
+    if not policy.unsafe_allow_unauthenticated or policy.authorization is not None:
+        return None
+    return (
+        "Scout View is allowing unauthenticated access on "
+        f"{policy.bind_host}:{policy.port}. Any network client that can reach "
+        "this address may call viewer APIs."
+    )
+
+
+class HostValidationMiddleware:
+    def __init__(self, app: ASGIApp, policy: ViewerNetworkPolicy) -> None:
+        self.app = app
+        self.policy = policy
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            host = _single_header(scope, b"host", required=True)
+            authority = _parse_authority(host)
+        except ValueError:
+            await _reject(scope, receive, send, 400, "Invalid host header")
+            return
+
+        scheme = _http_scheme(str(scope.get("scheme", "http")).lower())
+        if not any(
+            _authority_matches(authority, trusted, scheme)
+            for trusted in self.policy.trusted_hosts
+        ):
+            await _reject(scope, receive, send, 400, "Invalid host header")
+            return
+
+        scope[_VALIDATED_HOST_SCOPE_KEY] = authority
+        await self.app(scope, receive, send)
+
+
+class BrowserOriginMiddleware:
+    def __init__(self, app: ASGIApp, policy: ViewerNetworkPolicy) -> None:
+        self.app = app
+        self.policy = policy
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            origin_value = _single_header(scope, b"origin", required=False)
+            fetch_site = _single_header(
+                scope, b"sec-fetch-site", required=False
+            ).lower()
+        except ValueError:
+            await _reject(scope, receive, send, 403, "Forbidden browser origin")
+            return
+
+        if fetch_site in ("cross-site", "same-site"):
+            await _reject(scope, receive, send, 403, "Forbidden browser origin")
+            return
+
+        request_host = scope.get(_VALIDATED_HOST_SCOPE_KEY)
+        request_scheme = _http_scheme(str(scope.get("scheme", "http")).lower())
+
+        if origin_value:
+            try:
+                origin = _parse_origin(origin_value)
+            except ValueError:
+                await _reject(scope, receive, send, 403, "Forbidden browser origin")
+                return
+
+            if (
+                origin not in self.policy.trusted_origins
+                or origin.scheme != request_scheme
+                or not isinstance(request_host, Authority)
+                or not _authority_matches(request_host, origin.authority, origin.scheme)
+            ):
+                await _reject(scope, receive, send, 403, "Forbidden browser origin")
+                return
+        elif fetch_site == "same-origin" and (
+            not isinstance(request_host, Authority)
+            or not any(
+                origin.scheme == request_scheme
+                and _authority_matches(request_host, origin.authority, origin.scheme)
+                for origin in self.policy.trusted_origins
+            )
+        ):
+            await _reject(scope, receive, send, 403, "Forbidden browser origin")
+            return
+
+        await self.app(scope, receive, send)
+
+
+class SecurityHeadersMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_security_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.append("Content-Security-Policy", "frame-ancestors 'none'")
+                headers["X-Frame-Options"] = "DENY"
+            await send(message)
+
+        await self.app(scope, receive, send_with_security_headers)
+
+
+def _absolute_root_path_origin(root_path: str) -> str | None:
+    if not root_path:
+        return None
+    try:
+        parsed = urlsplit(root_path)
+    except ValueError as ex:
+        raise ViewerNetworkPolicyError(
+            f"Invalid absolute root path {root_path!r}"
+        ) from ex
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.netloc:
+        return None
+    return f"{parsed.scheme.lower()}://{parsed.netloc}"
+
+
+def _parse_origin(value: str) -> Origin:
+    _validate_header_value(value)
+    if value == "null" or "?" in value or "#" in value or "\\" in value:
+        raise ValueError("Invalid origin")
+
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower()
+    if (
+        scheme not in ("http", "https")
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+        or parsed.hostname is None
+    ):
+        raise ValueError("Invalid origin")
+
+    try:
+        port = parsed.port
+    except ValueError as ex:
+        raise ValueError("Invalid origin port") from ex
+
+    if parsed.netloc.endswith(":") or (port is not None and not 1 <= port <= 65535):
+        raise ValueError("Invalid origin port")
+
+    if port == _default_port(scheme):
+        port = None
+
+    return Origin(
+        scheme=scheme,
+        authority=Authority(_canonical_hostname(parsed.hostname), port),
+    )
+
+
+def _parse_authority(value: str) -> Authority:
+    _validate_header_value(value)
+    if any(char in value for char in ("/", "\\", "@", ",", "#", "?")):
+        raise ValueError("Invalid authority")
+
+    if value.startswith("["):
+        close = value.find("]")
+        if close == -1:
+            raise ValueError("Invalid IPv6 authority")
+        host = value[1:close]
+        remainder = value[close + 1 :]
+        if remainder:
+            if not remainder.startswith(":"):
+                raise ValueError("Invalid IPv6 authority")
+            port = _parse_port(remainder[1:])
+        else:
+            port = None
+        canonical_host = _canonical_hostname(host)
+        if ":" not in canonical_host:
+            raise ValueError("Bracketed authority is not IPv6")
+        return Authority(canonical_host, port)
+
+    if value.count(":") > 1:
+        raise ValueError("IPv6 authorities must be bracketed")
+
+    if ":" in value:
+        host, port_value = value.rsplit(":", 1)
+        port = _parse_port(port_value)
+    else:
+        host = value
+        port = None
+
+    return Authority(_canonical_hostname(host), port)
+
+
+def _canonical_hostname(value: str) -> str:
+    _validate_header_value(value)
+    host = value[:-1] if value.endswith(".") else value
+    if not host or host.endswith(".") or "%" in host or "*" in host:
+        raise ViewerNetworkPolicyError(f"Invalid hostname: {value}")
+
+    try:
+        return ipaddress.ip_address(host).compressed.lower()
+    except ValueError:
+        pass
+
+    ascii_host = host.lower()
+    if len(ascii_host) > 253:
+        raise ViewerNetworkPolicyError(f"Invalid hostname: {value}")
+    labels = ascii_host.split(".")
+    if any(not _DNS_LABEL.fullmatch(label) for label in labels):
+        raise ViewerNetworkPolicyError(f"Invalid hostname: {value}")
+    return ascii_host
+
+
+def _parse_port(value: str) -> int:
+    if not value or not value.isascii() or not value.isdigit():
+        raise ValueError("Invalid port")
+    port = int(value)
+    if not 1 <= port <= 65535:
+        raise ValueError("Invalid port")
+    return port
+
+
+def _validate_header_value(value: str) -> None:
+    if (
+        not value
+        or not value.isascii()
+        or any(ord(char) <= 0x20 or ord(char) == 0x7F for char in value)
+    ):
+        raise ValueError("Invalid header value")
+
+
+def _single_header(scope: Scope, name: bytes, *, required: bool) -> str:
+    values: list[bytes] = [
+        value
+        for header_name, value in scope.get("headers", [])
+        if header_name.lower() == name
+    ]
+    if len(values) > 1 or (required and not values):
+        raise ValueError("Missing or duplicate header")
+    if not values:
+        return ""
+    try:
+        return values[0].decode("ascii")
+    except UnicodeDecodeError as ex:
+        raise ValueError("Invalid header encoding") from ex
+
+
+def _authority_matches(request: Authority, trusted: Authority, scheme: str) -> bool:
+    if request.host != trusted.host:
+        return False
+    if request.port == trusted.port:
+        return True
+    default_port = _default_port(scheme)
+    request_port = request.port if request.port is not None else default_port
+    trusted_port = trusted.port if trusted.port is not None else default_port
+    return request_port == trusted_port
+
+
+def _default_port(scheme: str) -> int | None:
+    if scheme == "http":
+        return 80
+    if scheme == "https":
+        return 443
+    return None
+
+
+def _http_scheme(scheme: str) -> str:
+    if scheme == "ws":
+        return "http"
+    if scheme == "wss":
+        return "https"
+    return scheme
+
+
+def _http_origin(host: str, port: int) -> Origin:
+    return Origin(
+        "http",
+        Authority(host, None if port == 80 else port),
+    )
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_wildcard_host(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host).is_unspecified
+    except ValueError:
+        return False
+
+
+def _loopback_default_hosts(bind_host: str) -> tuple[str, ...]:
+    if bind_host == "localhost":
+        return ("127.0.0.1", "localhost", "::1")
+    return (bind_host, "localhost")
+
+
+async def _reject(
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    status_code: int,
+    message: str,
+) -> None:
+    if scope["type"] == "websocket":
+        await send({"type": "websocket.close", "code": 1008})
+    else:
+        await PlainTextResponse(message, status_code=status_code)(scope, receive, send)

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -13,13 +14,21 @@ from inspect_ai._util.event_loop_monitor import event_loop_monitor
 from inspect_ai._util.file import filesystem
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import HTMLResponse
-from starlette.types import Scope
+from starlette.types import ASGIApp, Scope
 
 from inspect_scout._util.appdirs import scout_cache_dir
 from inspect_scout._util.constants import (
     DEFAULT_SCANS_DIR,
     DEFAULT_SERVER_HOST,
     DEFAULT_VIEW_PORT,
+)
+from inspect_scout._view.network import (
+    BrowserOriginMiddleware,
+    HostValidationMiddleware,
+    SecurityHeadersMiddleware,
+    ViewerNetworkPolicy,
+    resolve_viewer_network_policy,
+    unsafe_network_warning,
 )
 from inspect_scout._view.notify import notify_lifespan
 from inspect_scout._view.types import ViewConfig
@@ -30,6 +39,8 @@ from ._api_v2 import v2_api_app
 _IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
 _DIST_DIR = Path(__file__).parent / "dist"
 _REPO_URL = "https://github.com/meridianlabs-ai/inspect_scout.git"
+
+logger = logging.getLogger(__name__)
 
 
 class _ScoutStaticFiles(StaticFiles):
@@ -106,7 +117,20 @@ def view_server(
     authorization: str | None = None,
     fs_options: dict[str, Any] | None = None,
     root_path: str = "",
+    trusted_origins: tuple[str, ...] = (),
+    trusted_hosts: tuple[str, ...] = (),
+    unsafe_allow_unauthenticated: bool = False,
+    network_policy: ViewerNetworkPolicy | None = None,
 ) -> None:
+    network_policy = network_policy or resolve_viewer_network_policy(
+        bind_host=host,
+        port=port,
+        trusted_hosts=trusted_hosts,
+        trusted_origins=trusted_origins,
+        authorization=authorization,
+        unsafe_allow_unauthenticated=unsafe_allow_unauthenticated,
+        root_path=root_path,
+    )
     root_path = _normalize_root_path(root_path)
 
     # get filesystem and resolve scan_dir to full path
@@ -120,11 +144,55 @@ def view_server(
     # ensure we've resolved the dist directory
     directory = _resolve_dist_directory()
 
-    v2_api = v2_api_app(view_config=config, dist_path=directory)
+    app = standalone_view_app(
+        view_config=config,
+        network_policy=network_policy,
+        root_path=root_path,
+        directory=directory,
+    )
 
-    if authorization:
-        v2_api.add_middleware(AuthorizationMiddleware, authorization=authorization)
+    # run app
+    display().print("Scout View")
+    warning = unsafe_network_warning(network_policy)
+    if warning:
+        logger.warning(warning)
 
+    async def run_server() -> None:
+        config = uvicorn.Config(
+            app,
+            host=network_policy.bind_host,
+            port=network_policy.port,
+            root_path=root_path,
+            log_config=None,
+        )
+        server = uvicorn.Server(config)
+
+        async def announce_when_ready() -> None:
+            while not server.started:
+                await anyio.sleep(0.05)
+            # Print this for compatibility with the Inspect VSCode plugin:
+            url = view_url(network_policy.bind_host, network_policy.port, mode)
+            display().print(
+                f"======== Running on {url} ========\n(Press CTRL+C to quit)"
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(announce_when_ready)
+            await server.serve()
+
+    anyio.run(run_server)
+
+
+def standalone_view_app(
+    *,
+    view_config: ViewConfig | None,
+    network_policy: ViewerNetworkPolicy,
+    root_path: str = "",
+    directory: Path | None = None,
+) -> ASGIApp:
+    root_path = _normalize_root_path(root_path)
+    directory = directory or _resolve_dist_directory()
+    v2_api = v2_api_app(view_config=view_config, dist_path=directory)
     app = FastAPI(lifespan=notify_lifespan)
 
     if os.getenv("SCOUT_VIEW_EVENT_LOOP_MONITOR", "false").lower() in (
@@ -145,7 +213,7 @@ def view_server(
 
         app.middleware("http")(log_and_monitor)
 
-    app.mount("/api/v2", v2_api)
+    app.mount("/api/v2", BrowserOriginMiddleware(v2_api, network_policy))
 
     app.mount(
         "/",
@@ -157,29 +225,14 @@ def view_server(
         name="static",
     )
 
-    # run app
-    display().print("Scout View")
-
-    async def run_server() -> None:
-        config = uvicorn.Config(
-            app, host=host, port=port, root_path=root_path, log_config=None
+    if network_policy.authorization:
+        app.add_middleware(
+            AuthorizationMiddleware,
+            authorization=network_policy.authorization,
         )
-        server = uvicorn.Server(config)
 
-        async def announce_when_ready() -> None:
-            while not server.started:
-                await anyio.sleep(0.05)
-            # Print this for compatibility with the Inspect VSCode plugin:
-            url = view_url(host, port, mode)
-            display().print(
-                f"======== Running on {url} ========\n(Press CTRL+C to quit)"
-            )
-
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(announce_when_ready)
-            await server.serve()
-
-    anyio.run(run_server)
+    protected_app: ASGIApp = HostValidationMiddleware(app, network_policy)
+    return SecurityHeadersMiddleware(protected_app)
 
 
 def view_url(host: str, port: int, mode: Literal["default", "scans"]) -> str:
@@ -197,7 +250,9 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         auth_header = request.headers.get("authorization", None)
-        if auth_header != self.authorization:
+        if auth_header is None or not secrets.compare_digest(
+            auth_header.encode(), self.authorization.encode()
+        ):
             return Response("Unauthorized", status_code=401)
         return await call_next(request)
 

--- a/src/inspect_scout/_view/view.py
+++ b/src/inspect_scout/_view/view.py
@@ -9,6 +9,7 @@ from inspect_scout._project._project import read_project
 from inspect_scout._scan import top_level_async_init
 from inspect_scout._util.appdirs import scout_data_dir
 from inspect_scout._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
+from inspect_scout._view.network import resolve_viewer_network_policy
 from inspect_scout._view.server import view_server, view_url
 from inspect_scout._view.types import ViewConfig
 
@@ -27,7 +28,20 @@ def view(
     log_level: str | None = None,
     fs_options: dict[str, Any] | None = None,
     root_path: str = "",
+    trusted_origins: tuple[str, ...] = (),
+    trusted_hosts: tuple[str, ...] = (),
+    unsafe_allow_unauthenticated: bool = False,
 ) -> None:
+    network_policy = resolve_viewer_network_policy(
+        bind_host=host,
+        port=port,
+        trusted_hosts=trusted_hosts,
+        trusted_origins=trusted_origins,
+        authorization=authorization,
+        unsafe_allow_unauthenticated=unsafe_allow_unauthenticated,
+        root_path=root_path,
+    )
+
     with chdir(project_dir or "."):
         # top level init
         project = read_project()
@@ -53,4 +67,5 @@ def view(
             authorization=authorization,
             fs_options=fs_options,
             root_path=root_path,
+            network_policy=network_policy,
         )

--- a/tests/cli/test_view.py
+++ b/tests/cli/test_view.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+import click
+import inspect_scout._cli.view as view_cli
+import pytest
+from click.testing import CliRunner
+from inspect_scout._view.network import ViewerNetworkPolicyError
+
+
+def test_view_network_options_are_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_view(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(view_cli, "view", fake_view)
+    monkeypatch.setattr(view_cli, "process_common_options", lambda _options: None)
+    monkeypatch.setattr(view_cli, "resolve_view_authorization", lambda: None)
+
+    result = CliRunner().invoke(
+        view_cli.view_command,
+        [
+            "--trusted-origin",
+            "http://my-scout:7576",
+            "--trusted-origin",
+            "https://scout.example",
+            "--trusted-host",
+            "health.internal:7576",
+            "--unsafe-allow-unauthenticated",
+            "--root-path",
+            "/proxy",
+        ],
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["trusted_origins"] == (
+        "http://my-scout:7576",
+        "https://scout.example",
+    )
+    assert captured["trusted_hosts"] == ("health.internal:7576",)
+    assert captured["unsafe_allow_unauthenticated"] is True
+    assert captured["root_path"] == "/proxy"
+
+
+def test_view_authorization_is_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_view(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(view_cli, "view", fake_view)
+    monkeypatch.setattr(view_cli, "process_common_options", lambda _options: None)
+    monkeypatch.setattr(view_cli, "resolve_view_authorization", lambda: "secret")
+
+    result = CliRunner().invoke(
+        view_cli.view_command,
+        [],
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["authorization"] == "secret"
+
+
+def test_view_policy_errors_are_usage_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_view(**_kwargs: Any) -> None:
+        raise ViewerNetworkPolicyError("unsafe viewer configuration")
+
+    monkeypatch.setattr(view_cli, "view", fake_view)
+    monkeypatch.setattr(view_cli, "process_common_options", lambda _options: None)
+    monkeypatch.setattr(view_cli, "resolve_view_authorization", lambda: None)
+
+    result = CliRunner().invoke(
+        view_cli.view_command,
+        [],
+        standalone_mode=False,
+    )
+
+    assert isinstance(result.exception, click.UsageError)
+    assert "unsafe viewer configuration" in str(result.exception)

--- a/tests/view/test_view_network.py
+++ b/tests/view/test_view_network.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import base64
+import importlib
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+from inspect_scout._view.network import (
+    Authority,
+    Origin,
+    ViewerNetworkPolicy,
+    ViewerNetworkPolicyError,
+    resolve_viewer_network_policy,
+    unsafe_network_warning,
+)
+from inspect_scout._view.server import standalone_view_app, view_server
+from inspect_scout._view.types import ViewConfig
+from starlette.types import ASGIApp
+
+
+def _policy(
+    *,
+    bind_host: str = "127.0.0.1",
+    port: int = 7576,
+    trusted_hosts: tuple[str, ...] = (),
+    trusted_origins: tuple[str, ...] = (),
+    authorization: str | None = None,
+    unsafe_allow_unauthenticated: bool = False,
+    root_path: str = "",
+) -> ViewerNetworkPolicy:
+    return resolve_viewer_network_policy(
+        bind_host=bind_host,
+        port=port,
+        trusted_hosts=trusted_hosts,
+        trusted_origins=trusted_origins,
+        authorization=authorization,
+        unsafe_allow_unauthenticated=unsafe_allow_unauthenticated,
+        root_path=root_path,
+    )
+
+
+def _app(
+    tmp_path: Path,
+    policy: ViewerNetworkPolicy,
+    *,
+    root_path: str = "",
+) -> ASGIApp:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text(
+        "<html><head></head><body>viewer</body></html>",
+        encoding="utf-8",
+    )
+    return standalone_view_app(
+        view_config=ViewConfig(),
+        network_policy=policy,
+        root_path=root_path,
+        directory=dist_dir,
+    )
+
+
+def _assert_framing_headers(response: Response) -> None:
+    assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
+    assert response.headers["x-frame-options"] == "DENY"
+
+
+def _base64url(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+
+def test_loopback_policy_defaults() -> None:
+    policy = _policy()
+    assert Authority("127.0.0.1", 7576) in policy.trusted_hosts
+    assert Authority("localhost", 7576) in policy.trusted_hosts
+    assert Origin("http", Authority("127.0.0.1", 7576)) in policy.trusted_origins
+    assert Origin("http", Authority("localhost", 7576)) in policy.trusted_origins
+
+
+def test_custom_loopback_dns_origin_adds_host_authority() -> None:
+    policy = _policy(trusted_origins=("HTTP://My-Scout.:7576/",))
+    authority = Authority("my-scout", 7576)
+    assert authority in policy.trusted_hosts
+    assert Origin("http", authority) in policy.trusted_origins
+
+
+def test_absolute_root_path_supplies_compatibility_origin() -> None:
+    policy = _policy(root_path="https://scout.example/proxy/")
+    origin = Origin("https", Authority("scout.example"))
+    assert origin in policy.trusted_origins
+    assert origin.authority in policy.trusted_hosts
+
+
+def test_explicit_origin_takes_precedence_over_absolute_root_path() -> None:
+    policy = _policy(
+        trusted_origins=("https://configured.example",),
+        root_path="https://root-path.example/proxy/",
+    )
+    assert Origin("https", Authority("configured.example")) in policy.trusted_origins
+    assert Origin("https", Authority("root-path.example")) not in policy.trusted_origins
+
+
+def test_path_only_root_path_does_not_widen_trust() -> None:
+    policy = _policy(root_path="/proxy")
+    assert Origin("https", Authority("scout.example")) not in policy.trusted_origins
+
+
+def test_trusted_host_does_not_authorize_browser_origin() -> None:
+    policy = _policy(trusted_hosts=("health.internal:7576",))
+    authority = Authority("health.internal", 7576)
+    assert authority in policy.trusted_hosts
+    assert Origin("http", authority) not in policy.trusted_origins
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "null",
+        "ftp://scout.example",
+        "http://user@scout.example",
+        "http://scout.example/path",
+        "http://scout.example?query",
+        "http://scout.example#fragment",
+        "http://*.scout.example",
+        "http://scout_example",
+        "http://scout.example:",
+        "http://scout.example:0",
+        "http://scout.example:65536",
+    ],
+)
+def test_invalid_trusted_origins_rejected(origin: str) -> None:
+    with pytest.raises(ViewerNetworkPolicyError):
+        _policy(trusted_origins=(origin,))
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "*.scout.example",
+        "scout.example/path",
+        "user@scout.example",
+        "scout_example",
+        "[::1",
+        "::1",
+        "scout.example:0",
+        "scout.example:65536",
+    ],
+)
+def test_invalid_trusted_hosts_rejected(host: str) -> None:
+    with pytest.raises(ViewerNetworkPolicyError):
+        _policy(trusted_hosts=(host,))
+
+
+def test_non_loopback_and_wildcard_startup_policy() -> None:
+    with pytest.raises(ViewerNetworkPolicyError, match="without request authorization"):
+        _policy(bind_host="192.0.2.10")
+
+    with pytest.raises(ViewerNetworkPolicyError, match="explicit trusted"):
+        _policy(bind_host="0.0.0.0", authorization="secret")
+
+    policy = _policy(
+        bind_host="0.0.0.0",
+        authorization="secret",
+        root_path="https://scout.example/proxy/",
+    )
+    assert Origin("https", Authority("scout.example")) in policy.trusted_origins
+
+
+def test_explicit_unsafe_non_loopback_policy_warns() -> None:
+    policy = _policy(
+        bind_host="0.0.0.0",
+        trusted_origins=("http://192.0.2.10:7576",),
+        unsafe_allow_unauthenticated=True,
+    )
+    warning = unsafe_network_warning(policy)
+    assert warning is not None
+    assert "0.0.0.0:7576" in warning
+    assert "Any network client" in warning
+
+
+def test_attacker_selected_host_rejected_for_document_and_api(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy())
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        document = client.get("/", headers={"Host": "rebind.test:7576"})
+        api = client.get(
+            "/api/v2/app-config",
+            headers={
+                "Host": "rebind.test:7576",
+                "Origin": "http://rebind.test:7576",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+
+    assert document.status_code == 400
+    assert api.status_code == 400
+    _assert_framing_headers(document)
+    _assert_framing_headers(api)
+
+
+def test_duplicate_host_headers_are_rejected(tmp_path: Path) -> None:
+    app = _app(tmp_path, _policy())
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        response = client.get(
+            "/",
+            headers=[
+                ("Host", "localhost:7576"),
+                ("Host", "rebind.test:7576"),
+            ],
+        )
+
+    assert response.status_code == 400
+
+
+def test_matching_loopback_host_and_origin_can_read_api(tmp_path: Path) -> None:
+    app = _app(tmp_path, _policy())
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        with_origin = client.get(
+            "/api/v2/app-config",
+            headers={
+                "Origin": "http://localhost:7576",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+        without_origin = client.get(
+            "/api/v2/app-config",
+            headers={"Sec-Fetch-Site": "same-origin"},
+        )
+
+    assert with_origin.status_code == 200
+    assert without_origin.status_code == 200
+    assert "access-control-allow-origin" not in with_origin.headers
+
+
+def test_custom_loopback_dns_origin_is_configurable(tmp_path: Path) -> None:
+    trusted_app = _app(
+        tmp_path / "trusted",
+        _policy(trusted_origins=("http://my-scout:7576",)),
+    )
+    with TestClient(trusted_app, base_url="http://my-scout:7576") as client:
+        trusted = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "http://my-scout:7576"},
+        )
+
+    untrusted_app = _app(tmp_path / "untrusted", _policy())
+    with TestClient(untrusted_app, base_url="http://my-scout:7576") as client:
+        untrusted = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "http://my-scout:7576"},
+        )
+
+    assert trusted.status_code == 200
+    assert untrusted.status_code == 400
+
+
+def test_trusted_host_only_rejects_browser_fetch_but_allows_non_browser(
+    tmp_path: Path,
+) -> None:
+    app = _app(
+        tmp_path,
+        _policy(trusted_hosts=("health.internal:7576",)),
+    )
+    with TestClient(app, base_url="http://health.internal:7576") as client:
+        browser = client.get(
+            "/api/v2/app-config",
+            headers={"Sec-Fetch-Site": "same-origin"},
+        )
+        non_browser = client.get("/api/v2/app-config")
+
+    assert browser.status_code == 403
+    assert non_browser.status_code == 200
+
+
+def test_untrusted_or_mismatched_browser_origin_rejected(tmp_path: Path) -> None:
+    app = _app(
+        tmp_path,
+        _policy(
+            trusted_origins=(
+                "http://my-scout:7576",
+                "http://other-scout:7576",
+            )
+        ),
+    )
+    with TestClient(app, base_url="http://my-scout:7576") as client:
+        attacker = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "https://attacker.example"},
+        )
+        other_trusted_host = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "http://other-scout:7576"},
+        )
+
+    assert attacker.status_code == 403
+    assert other_trusted_host.status_code == 403
+
+
+def test_origin_scheme_must_match_request_scheme(tmp_path: Path) -> None:
+    app = _app(
+        tmp_path,
+        _policy(trusted_origins=("https://scout.example",)),
+    )
+    with TestClient(app, base_url="http://scout.example") as client:
+        response = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "https://scout.example"},
+        )
+
+    assert response.status_code == 403
+
+
+def test_fetch_metadata_and_malformed_origins_are_rejected(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy())
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        cross_site = client.get(
+            "/api/v2/app-config",
+            headers={"Sec-Fetch-Site": "cross-site"},
+        )
+        same_site = client.get(
+            "/api/v2/app-config",
+            headers={
+                "Origin": "http://localhost:7576",
+                "Sec-Fetch-Site": "same-site",
+            },
+        )
+        null_origin = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "null"},
+        )
+        duplicate_origin = client.get(
+            "/api/v2/app-config",
+            headers=[
+                ("Origin", "http://localhost:7576"),
+                ("Origin", "https://attacker.example"),
+            ],
+        )
+
+    assert cross_site.status_code == 403
+    assert same_site.status_code == 403
+    assert null_origin.status_code == 403
+    assert duplicate_origin.status_code == 403
+
+
+def test_authorized_extension_request_and_whole_app_authorization(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy(authorization="secret"))
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        api = client.get(
+            "/api/v2/app-config",
+            headers={"Authorization": "secret"},
+        )
+        static = client.get("/", headers={"Authorization": "secret"})
+        unauthorized_api = client.get("/api/v2/app-config")
+        unauthorized_static = client.get("/")
+
+    assert api.status_code == 200
+    assert static.status_code == 200
+    assert unauthorized_api.status_code == 401
+    assert unauthorized_static.status_code == 401
+    _assert_framing_headers(unauthorized_static)
+
+
+def test_authorization_does_not_bypass_origin_validation(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy(authorization="secret"))
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        response = client.get(
+            "/api/v2/app-config",
+            headers={
+                "Authorization": "secret",
+                "Origin": "https://attacker.example",
+            },
+        )
+
+    assert response.status_code == 403
+
+
+def test_absolute_root_path_reverse_proxy_origin_succeeds(
+    tmp_path: Path,
+) -> None:
+    root_path = "https://scout.example/proxy/"
+    policy = _policy(
+        bind_host="0.0.0.0",
+        authorization="secret",
+        root_path=root_path,
+    )
+    app = _app(tmp_path, policy, root_path=root_path)
+
+    with TestClient(app, base_url="https://scout.example") as client:
+        api = client.get(
+            "/api/v2/app-config",
+            headers={
+                "Authorization": "secret",
+                "Origin": "https://scout.example",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+        static = client.get("/", headers={"Authorization": "secret"})
+
+    assert api.status_code == 200
+    assert static.status_code == 200
+    assert "window.__SCOUT_BASE_PATH__='/proxy'" in static.text
+
+
+def test_origin_checks_block_scan_delete_before_handler(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy())
+    delete_url = (
+        f"/api/v2/scans/{_base64url(str(tmp_path / 'scans'))}/"
+        f"{_base64url(str(tmp_path / 'outside'))}"
+    )
+
+    with (
+        patch("inspect_scout._view._api_v2_scans.send2trash") as send2trash,
+        TestClient(app, base_url="http://localhost:7576") as client,
+    ):
+        switched = client.delete(
+            delete_url,
+            headers={
+                "Host": "rebind.test:7576",
+                "Origin": "http://rebind.test:7576",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+        cross_origin = client.delete(
+            delete_url,
+            headers={"Origin": "https://attacker.example"},
+        )
+
+    assert switched.status_code == 400
+    assert cross_origin.status_code == 403
+    send2trash.assert_not_called()
+
+
+def test_framing_headers_cover_static_and_error_responses(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path, _policy())
+    with TestClient(app, base_url="http://localhost:7576") as client:
+        root = client.get("/")
+        missing = client.get("/missing")
+        forbidden = client.get(
+            "/api/v2/app-config",
+            headers={"Origin": "https://attacker.example"},
+        )
+
+    assert root.status_code == 200
+    assert missing.status_code == 404
+    assert forbidden.status_code == 403
+    _assert_framing_headers(root)
+    _assert_framing_headers(missing)
+    _assert_framing_headers(forbidden)
+
+
+def test_unsafe_bind_is_rejected_before_port_acquisition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    view_module = importlib.import_module("inspect_scout._view.view")
+    acquired = False
+
+    def acquire_port(_app_dir: Path, _port: int) -> None:
+        nonlocal acquired
+        acquired = True
+
+    monkeypatch.setattr(view_module, "view_acquire_port", acquire_port)
+
+    with pytest.raises(ViewerNetworkPolicyError):
+        view_module.view(
+            host="0.0.0.0",
+            trusted_origins=("http://192.0.2.10:7576",),
+        )
+
+    assert acquired is False
+
+
+def test_existing_view_positional_parameter_order_is_preserved() -> None:
+    view_module = importlib.import_module("inspect_scout._view.view")
+    assert list(inspect.signature(view_module.view).parameters)[:11] == [
+        "project_dir",
+        "transcripts",
+        "scans",
+        "mode",
+        "host",
+        "port",
+        "browser",
+        "authorization",
+        "log_level",
+        "fs_options",
+        "root_path",
+    ]
+    assert list(inspect.signature(view_server).parameters)[:7] == [
+        "config",
+        "host",
+        "port",
+        "mode",
+        "authorization",
+        "fs_options",
+        "root_path",
+    ]


### PR DESCRIPTION
## Related viewer security PRs

- [UKGovernmentBEIS/inspect_ai#4368](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4368) - Inspect standalone Host, Origin, authorization, and framing trust.
- [meridianlabs-ai/inspect_scout#482](https://github.com/meridianlabs-ai/inspect_scout/pull/482) - Scout standalone Host, Origin, authorization, and framing trust.

## Summary

Harden the standalone Scout View network boundary while preserving default loopback, VS Code, and configured reverse-proxy workflows.

## Current behavior

Scout View accepts caller-selected `Host` values, does not validate browser `Origin`, and sends no anti-framing policy. Authorization protects only the v2 API rather than the complete standalone application.

Setting `--host` beyond loopback also exposes the viewer without requiring authorization or an explicit acknowledgement.

## New behavior

The standalone application now:

- validates exact Host authorities across static and API responses;
- validates browser Origin and Fetch Metadata on every `/api/v2` route;
- sends `frame-ancestors 'none'` and `X-Frame-Options: DENY`;
- applies configured authorization to documents, assets, errors, and APIs;
- requires authorization or `--unsafe-allow-unauthenticated` for non-loopback binds;
- requires wildcard binds to configure an exact trusted origin or host; and
- supports repeatable `--trusted-origin` and `--trusted-host` options.

An absolute `root_path` continues to provide its public origin when no explicit trusted origin is supplied. A path-only `root_path` does not widen Host or Origin trust.

## Compatibility

Default `scout view` and authorized VS Code requests remain unchanged.

`scout view --host 0.0.0.0` now requires authorization or the explicit unsafe acknowledgement. Wildcard binds also require a trusted origin or host. Reverse proxies and custom DNS aliases must declare their exact public origin.

Standalone iframe embedding is not currently documented; if it becomes a supported use case, a future exact trusted-ancestor allowlist could enable it without restoring unrestricted framing.

## Testing

- 195 Scout viewer and CLI tests passed;
- repository-wide Ruff passed across 423 files;
- repository-wide mypy passed across 427 source files;
- real Uvicorn requests returned 200 for loopback, 400 for an attacker Host, and 403 for an attacker Origin, with framing headers present;
- authenticated absolute-root-path proxy requests and injected base paths worked; and
- the headless-Chrome origin-switch PoC was rejected before the scan-delete handler and preserved its target.

The repository-wide pytest run reached 2,967 passed and 111 skipped. Its remaining failures reproduce on untouched main and come from the shared environment's outdated OpenAI/Anthropic packages and two Rich terminal-capture assertions.

Quarto was unavailable locally, so documentation rendering was not run.