### PR TITLE
Scout View: constrain paths to startup capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Security: Restrict Scout viewer scan, transcript, project, and scan-start paths to capabilities granted by startup configuration.
 - Security: Remove terminal control sequences from scanner names, scan metadata, errors, progress text, and filenames before rendering console output.
 - Security: Build DuckDB queries from bound Parquet sources and quoted, schema-validated identifiers so malicious transcript/scan filenames and sort or distinct columns cannot inject SQL.
 - Add `timeline` option to `transcript_messages()` and `llm_scanner()` for selecting a named timeline.

--- a/docs/projects.qmd
+++ b/docs/projects.qmd
@@ -51,6 +51,8 @@ Note that `scout.yaml` project files are intended to be checked in to version co
 
 When you run `scout view` from a project directory it uses the project settings to initialize the **Transcripts** and **Results** panes. You can also edit the project settings by clicking on the **Project** button at the top right:
 
+The viewer treats the transcript, scans, project, and configured file locations present when it starts as its maximum capabilities. Project settings may select a location within those roots, but expanding to another directory, bucket, or filesystem requires editing `scout.yaml` outside the viewer or changing the `scout view` command and restarting it.
+
 ![](images/project.png){.border}
 
 ## Project Settings

--- a/src/inspect_scout/_view/_api_v2.py
+++ b/src/inspect_scout/_view/_api_v2.py
@@ -14,6 +14,7 @@ from ._api_v2_search import create_search_router
 from ._api_v2_topics import create_topics_router
 from ._api_v2_transcripts import create_transcripts_router
 from ._api_v2_validations import create_validation_router
+from .capabilities import ViewerCapabilities
 from .types import ViewConfig
 
 API_VERSION = "2.0.0-alpha"
@@ -23,6 +24,7 @@ def v2_api_app(
     view_config: ViewConfig | None = None,
     streaming_batch_size: int = 1024,
     dist_path: PathlibPath | None = None,
+    capabilities: ViewerCapabilities | None = None,
 ) -> FastAPI:
     """Create V2 API FastAPI app.
 
@@ -42,13 +44,23 @@ def v2_api_app(
     ) -> JSONResponse:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
-    app.include_router(create_config_router(view_config=view_config))
+    app.include_router(
+        create_config_router(
+            view_config=view_config,
+            capabilities=capabilities,
+        )
+    )
     app.include_router(create_dist_router(dist_path=dist_path))
     app.include_router(create_topics_router())
-    app.include_router(create_transcripts_router())
-    app.include_router(create_scans_router(streaming_batch_size=streaming_batch_size))
+    app.include_router(create_transcripts_router(capabilities=capabilities))
+    app.include_router(
+        create_scans_router(
+            streaming_batch_size=streaming_batch_size,
+            capabilities=capabilities,
+        )
+    )
     app.include_router(create_scanners_router())
     app.include_router(create_validation_router(PathlibPath.cwd()))
-    app.include_router(create_search_router())
+    app.include_router(create_search_router(capabilities=capabilities))
 
     return app

--- a/src/inspect_scout/_view/_api_v2_config.py
+++ b/src/inspect_scout/_view/_api_v2_config.py
@@ -24,17 +24,20 @@ from .._project.types import ProjectConfig
 from .._util.constants import DEFAULT_SCANS_DIR
 from ._api_v2_types import AppConfig, AppDir
 from ._server_common import InspectPydanticJSONResponse
+from .capabilities import ViewerCapabilities
 from .invalidationTopics import notify_topics
 from .types import ViewConfig
 
 
 def create_config_router(
     view_config: ViewConfig | None = None,
+    capabilities: ViewerCapabilities | None = None,
 ) -> APIRouter:
     """Create config API router.
 
     Args:
         view_config: View configuration.
+        capabilities: Maximum paths and files granted at viewer startup.
 
     Returns:
         Configured APIRouter with config endpoints.
@@ -105,6 +108,9 @@ def create_config_router(
         ),
     ) -> Response:
         """Update project configuration with comment preservation."""
+        if capabilities is not None:
+            capabilities.validate_project_update(config)
+
         # Parse the If-Match header (may be quoted), None means force save
         expected_etag = if_match.strip('"') if if_match else None
 

--- a/src/inspect_scout/_view/_api_v2_config.py
+++ b/src/inspect_scout/_view/_api_v2_config.py
@@ -109,7 +109,7 @@ def create_config_router(
     ) -> Response:
         """Update project configuration with comment preservation."""
         if capabilities is not None:
-            capabilities.validate_project_update(config)
+            config = capabilities.resolve_scan_job(config)
 
         # Parse the If-Match header (may be quoted), None means force save
         expected_etag = if_match.strip('"') if if_match else None

--- a/src/inspect_scout/_view/_api_v2_config.py
+++ b/src/inspect_scout/_view/_api_v2_config.py
@@ -109,7 +109,7 @@ def create_config_router(
     ) -> Response:
         """Update project configuration with comment preservation."""
         if capabilities is not None:
-            config = capabilities.resolve_scan_job(config)
+            capabilities.validate_project_update(config)
 
         # Parse the If-Match header (may be quoted), None means force save
         expected_etag = if_match.strip('"') if if_match else None

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -27,6 +27,7 @@ from starlette.status import (
 )
 from upath import UPath
 
+from .._project import read_project
 from .._query import Query, ScalarValue
 from .._query.order_by import OrderBy
 from .._recorder.active_scans_store import ActiveScanInfo, active_scans_store
@@ -45,6 +46,7 @@ from ._api_v2_types import (
 )
 from ._pagination_helpers import build_pagination_context
 from ._server_common import InspectPydanticJSONResponse, decode_base64url
+from .capabilities import PathCapability, ViewerCapabilities
 from .invalidationTopics import notify_topics
 
 # Scan result columns that are stored as pre-serialized JSON strings in
@@ -63,10 +65,16 @@ def _build_scan_zip(scan_path: UPath) -> Response:
             detail=f"Scan not found: {scan_path}",
         )
 
+    scan_scope = PathCapability.parse("directory", str(scan_path))
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for child in scan_path.iterdir():
             if child.is_file():
+                if not scan_scope.allows(str(child)):
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Scan archive entry escapes the selected scan directory",
+                    )
                 with file(child.as_posix(), "rb") as f:
                     zf.writestr(child.name, f.read())
 
@@ -82,16 +90,28 @@ def _build_scan_zip(scan_path: UPath) -> Response:
 
 def create_scans_router(
     streaming_batch_size: int = 1024,
+    capabilities: ViewerCapabilities | None = None,
 ) -> APIRouter:
     """Create scans API router.
 
     Args:
         streaming_batch_size: Batch size for Arrow IPC streaming.
+        capabilities: Maximum paths and files granted at viewer startup.
 
     Returns:
         Configured APIRouter with scans endpoints.
     """
     router = APIRouter(tags=["scans"])
+
+    def scoped_root(value: str) -> str:
+        return capabilities.require_scans(value) if capabilities else value
+
+    def scoped_scan(root: str, child: str) -> UPath:
+        return (
+            capabilities.resolve_scan(root, child)
+            if capabilities
+            else UPath(root) / child
+        )
 
     @router.post(
         "/scans/{dir}",
@@ -106,7 +126,7 @@ def create_scans_router(
         body: ScansRequest | None = None,
     ) -> ScansResponse:
         """Filter scan jobs from the scans directory."""
-        scans_dir = decode_base64url(dir)
+        scans_dir = scoped_root(decode_base64url(dir))
 
         ctx = build_pagination_context(body, "scan_id")
 
@@ -148,7 +168,7 @@ def create_scans_router(
         body: DistinctRequest | None = None,
     ) -> list[ScalarValue]:
         """Get distinct values for a column."""
-        scans_dir = decode_base64url(dir)
+        scans_dir = scoped_root(decode_base64url(dir))
         if body is None:
             return []
         async with await scan_jobs_view(scans_dir) as view:
@@ -164,7 +184,14 @@ def create_scans_router(
     async def active_scans() -> ActiveScansResponse:
         """Get info on all active scans from the KV store."""
         with active_scans_store() as store:
-            return ActiveScansResponse(items=store.read_all())
+            items = store.read_all()
+        if capabilities is not None:
+            items = {
+                scan_id: info
+                for scan_id, info in items.items()
+                if capabilities.allows_scans(info.location)
+            }
+        return ActiveScansResponse(items=items)
 
     @router.post(
         "/startscan",
@@ -175,6 +202,9 @@ def create_scans_router(
     )
     async def run_llm_scanner(body: ScanJobConfig) -> ScanStatus:
         """Run an llm_scanner scan via subprocess."""
+        if capabilities is not None:
+            capabilities.validate_project_update(read_project())
+            capabilities.validate_scan_job(body)
         proc, temp_path, _stdout_lines, stderr_lines = _spawn_scan_subprocess(body)
         pid = proc.pid
 
@@ -232,8 +262,8 @@ def create_scans_router(
         Content negotiation: returns JSON by default, or a zip archive
         when the client sends Accept: application/zip.
         """
-        scans_dir = decode_base64url(dir)
-        scan_path = UPath(scans_dir) / decode_base64url(scan)
+        scans_dir = scoped_root(decode_base64url(dir))
+        scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
         accept = request.headers.get("accept", "")
         if "application/zip" in accept:
@@ -276,8 +306,8 @@ def create_scans_router(
         """Stream scanner results as Arrow IPC with LZ4 compression."""
         excluded = [c.strip() for c in exclude_column if c.strip()]
 
-        scans_dir = decode_base64url(dir)
-        scan_path = UPath(scans_dir) / decode_base64url(scan)
+        scans_dir = scoped_root(decode_base64url(dir))
+        scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
         result = await scan_results_arrow_async(str(scan_path))
         if scanner not in result.scanners:
@@ -347,8 +377,8 @@ def create_scans_router(
 
         requested = list(dict.fromkeys(c.strip() for c in column if c.strip()))
 
-        scans_dir = decode_base64url(dir)
-        scan_path = UPath(scans_dir) / decode_base64url(scan)
+        scans_dir = scoped_root(decode_base64url(dir))
+        scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
         result = await scan_results_arrow_async(str(scan_path))
         if scanner not in result.scanners:
@@ -394,8 +424,8 @@ def create_scans_router(
         scan: str = Path(description="Scan path (base64url-encoded)"),
     ) -> None:
         """Delete a scan directory."""
-        scans_dir = decode_base64url(dir)
-        scan_path = UPath(scans_dir) / decode_base64url(scan)
+        scans_dir = scoped_root(decode_base64url(dir))
+        scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
         # Check if scan exists
         if not scan_path.exists():

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -17,6 +17,7 @@ import pyarrow.ipc as pa_ipc
 from fastapi import APIRouter, HTTPException, Path, Request, Response
 from fastapi import Query as QueryParam
 from fastapi.responses import StreamingResponse
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import file
 from send2trash import send2trash
 from starlette.status import (
@@ -231,9 +232,20 @@ def create_scans_router(
                     detail="Scan subprocess failed to register within timeout",
                 )
 
-        return await scan_recorder_for_location(active_info.location).status(
-            active_info.location
+        active_location = (
+            capabilities.require_scans(active_info.location)
+            if capabilities is not None
+            else active_info.location
         )
+        active_status = await scan_recorder_for_location(active_location).status(
+            active_location
+        )
+        if active_status.spec.scan_id != active_info.scan_id:
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Scan subprocess registered an inconsistent location",
+            )
+        return active_status
 
     @router.get(
         "/scans/{dir}/{scan}",
@@ -428,24 +440,26 @@ def create_scans_router(
         scans_dir = scoped_root(decode_base64url(dir))
         scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
-        # Delete only an actual scan directory, never the scans root or an
-        # unrelated descendant that happens to exist.
-        if not scan_path.is_dir() or not (scan_path / "_scan.json").is_file():
+        scan_location = str(scan_path)
+        try:
+            scan_status = await scan_recorder_for_location(scan_location).status(
+                scan_location
+            )
+        except (FileNotFoundError, PrerequisiteError, ValueError):
             raise HTTPException(
                 status_code=HTTP_404_NOT_FOUND,
                 detail="Scan not found",
-            )
+            ) from None
 
         # Check if scan is active (prevent deletion of running scans)
-        scan_location_str = str(scan_path)
         with active_scans_store() as store:
             active_scans = store.read_all()
-            for active_info in active_scans.values():
-                if active_info.location == scan_location_str:
-                    raise HTTPException(
-                        status_code=HTTP_409_CONFLICT,
-                        detail=f"Cannot delete active scan: {active_info.scan_id}",
-                    )
+        active_info = active_scans.get(scan_status.spec.scan_id)
+        if active_info is not None:
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail=f"Cannot delete active scan: {active_info.scan_id}",
+            )
 
         send2trash(scan_path.path)
 

--- a/src/inspect_scout/_view/_api_v2_scans.py
+++ b/src/inspect_scout/_view/_api_v2_scans.py
@@ -70,12 +70,13 @@ def _build_scan_zip(scan_path: UPath) -> Response:
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for child in scan_path.iterdir():
             if child.is_file():
-                if not scan_scope.allows(str(child)):
+                resolved_child = scan_scope.resolve(str(child))
+                if resolved_child is None:
                     raise HTTPException(
                         status_code=403,
                         detail="Scan archive entry escapes the selected scan directory",
                     )
-                with file(child.as_posix(), "rb") as f:
+                with file(resolved_child, "rb") as f:
                     zf.writestr(child.name, f.read())
 
     scan_id = scan_path.name
@@ -204,7 +205,7 @@ def create_scans_router(
         """Run an llm_scanner scan via subprocess."""
         if capabilities is not None:
             capabilities.validate_project_update(read_project())
-            capabilities.validate_scan_job(body)
+            body = capabilities.resolve_scan_job(body)
         proc, temp_path, _stdout_lines, stderr_lines = _spawn_scan_subprocess(body)
         pid = proc.pid
 
@@ -427,8 +428,9 @@ def create_scans_router(
         scans_dir = scoped_root(decode_base64url(dir))
         scan_path = scoped_scan(scans_dir, decode_base64url(scan))
 
-        # Check if scan exists
-        if not scan_path.exists():
+        # Delete only an actual scan directory, never the scans root or an
+        # unrelated descendant that happens to exist.
+        if not scan_path.is_dir() or not (scan_path / "_scan.json").is_file():
             raise HTTPException(
                 status_code=HTTP_404_NOT_FOUND,
                 detail="Scan not found",

--- a/src/inspect_scout/_view/_api_v2_search.py
+++ b/src/inspect_scout/_view/_api_v2_search.py
@@ -29,6 +29,7 @@ from ._api_v2_types import (
     SearchResponse,
 )
 from ._server_common import InspectPydanticJSONResponse, decode_base64url
+from .capabilities import ViewerCapabilities
 
 LLM_SEARCH_TEMPLATE = """\
 You are a search assistant for LLM transcript analysis. A user is searching \
@@ -179,13 +180,18 @@ def _search_result_store() -> KVStore:
     return KVStore(db_path.as_posix(), max_entries=MAX_ENTRIES)
 
 
-def create_search_router() -> APIRouter:
+def create_search_router(
+    capabilities: ViewerCapabilities | None = None,
+) -> APIRouter:
     """Create search API router.
 
     Returns:
         Configured APIRouter with search endpoints.
     """
     router = APIRouter(tags=["search"])
+
+    def scoped_root(value: str) -> str:
+        return capabilities.require_transcripts(value) if capabilities else value
 
     @router.get("/searches", summary="List recent search inputs")
     async def list_search_inputs(
@@ -221,7 +227,7 @@ def create_search_router() -> APIRouter:
 
         Returns cached results if the same search was run before.
         """
-        transcript_dir = decode_base64url(dir)
+        transcript_dir = scoped_root(decode_base64url(dir))
         sid = _search_id(request)
         key = _result_key(
             transcript_dir,
@@ -303,7 +309,7 @@ def create_search_router() -> APIRouter:
         ),
     ) -> Result:
         """Get a cached search result by search input ID and transcript scope."""
-        transcript_dir = decode_base64url(dir)
+        transcript_dir = scoped_root(decode_base64url(dir))
         key = _result_key(
             transcript_dir,
             id,

--- a/src/inspect_scout/_view/_api_v2_transcripts.py
+++ b/src/inspect_scout/_view/_api_v2_transcripts.py
@@ -28,6 +28,7 @@ from ._api_v2_types import (
 )
 from ._pagination_helpers import build_pagination_context
 from ._server_common import InspectPydanticJSONResponse, decode_base64url
+from .capabilities import ViewerCapabilities
 
 # Supported compression algorithms for X-Accept-Raw-Encoding header
 RawEncoding = Literal["zstd"]
@@ -35,13 +36,18 @@ RawEncoding = Literal["zstd"]
 MAX_TRANSCRIPT_BYTES = 350 * 1024 * 1024  # 350MB
 
 
-def create_transcripts_router() -> APIRouter:
+def create_transcripts_router(
+    capabilities: ViewerCapabilities | None = None,
+) -> APIRouter:
     """Create transcripts API router.
 
     Returns:
         Configured APIRouter with transcripts endpoints.
     """
     router = APIRouter(tags=["transcripts"])
+
+    def scoped_root(value: str) -> str:
+        return capabilities.require_transcripts(value) if capabilities else value
 
     @router.post(
         "/transcripts/{dir}",
@@ -55,7 +61,7 @@ def create_transcripts_router() -> APIRouter:
         body: TranscriptsRequest | None = None,
     ) -> TranscriptsResponse:
         """Filter transcript metadata from the transcripts directory."""
-        transcripts_dir = decode_base64url(dir)
+        transcripts_dir = scoped_root(decode_base64url(dir))
 
         try:
             ctx = build_pagination_context(
@@ -115,7 +121,7 @@ def create_transcripts_router() -> APIRouter:
         id: str = Path(description="Transcript ID"),
     ) -> TranscriptInfo:
         """Get transcript info (metadata only) by ID."""
-        transcripts_dir = decode_base64url(dir)
+        transcripts_dir = scoped_root(decode_base64url(dir))
 
         async with transcripts_view(transcripts_dir) as view:
             condition = Column("transcript_id") == id
@@ -162,7 +168,7 @@ def create_transcripts_router() -> APIRouter:
             "server transcodes to deflate for automatic browser decompression.",
         ),
     ) -> StreamingResponse:
-        transcripts_dir = decode_base64url(dir)
+        transcripts_dir = scoped_root(decode_base64url(dir))
 
         # Parse accepted raw encodings from header
         accepted_raw_encodings: set[str] = set()
@@ -229,7 +235,7 @@ def create_transcripts_router() -> APIRouter:
         body: DistinctRequest | None = None,
     ) -> list[ScalarValue]:
         """Get distinct values for a column."""
-        transcripts_dir = decode_base64url(dir)
+        transcripts_dir = scoped_root(decode_base64url(dir))
         if body is None:
             return []
         async with transcripts_view(transcripts_dir) as view:

--- a/src/inspect_scout/_view/_api_v2_validations.py
+++ b/src/inspect_scout/_view/_api_v2_validations.py
@@ -76,9 +76,7 @@ def create_validation_router(
     def create_validation(body: CreateValidationSetRequest) -> str:
         """Create a new validation file."""
         # Convert URI to path
-        file_path = _resolve_new_validation_path(
-            _uri_to_path(body.path), project_dir
-        )
+        file_path = _resolve_new_validation_path(_uri_to_path(body.path), project_dir)
 
         # Convert request cases to ValidationCase objects
         cases: list[ValidationCase] = []

--- a/src/inspect_scout/_view/_api_v2_validations.py
+++ b/src/inspect_scout/_view/_api_v2_validations.py
@@ -15,7 +15,11 @@ from starlette.status import (
 )
 from upath import UPath
 
-from .._validation.file_scanner import scan_validation_files
+from .._validation.file_scanner import (
+    VALIDATION_EXTENSIONS,
+    is_validation_file,
+    scan_validation_files,
+)
 from .._validation.predicates import PredicateType
 from .._validation.types import ValidationCase
 from .._validation.writer import ValidationFileWriter, _unflatten_columns
@@ -72,10 +76,9 @@ def create_validation_router(
     def create_validation(body: CreateValidationSetRequest) -> str:
         """Create a new validation file."""
         # Convert URI to path
-        file_path = _uri_to_path(body.path)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
+        file_path = _resolve_new_validation_path(
+            _uri_to_path(body.path), project_dir
+        )
 
         # Convert request cases to ValidationCase objects
         cases: list[ValidationCase] = []
@@ -121,10 +124,9 @@ def create_validation_router(
     ) -> list[dict[str, Any]]:
         """Get all cases from a validation file."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
 
         try:
             writer = ValidationFileWriter(file_path)
@@ -148,16 +150,9 @@ def create_validation_router(
     ) -> None:
         """Delete a validation file."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
-
-        if not file_path.exists():
-            raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
-                detail="Validation file not found",
-            )
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
 
         send2trash(str(file_path))
 
@@ -173,16 +168,9 @@ def create_validation_router(
     ) -> str:
         """Rename a validation file."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
-
-        if not file_path.exists():
-            raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
-                detail="Validation file not found",
-            )
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
 
         # Validate new name
         new_name = body.name.strip()
@@ -205,7 +193,7 @@ def create_validation_router(
         new_path = file_path.parent / f"{new_name}{extension}"
 
         # Validate new path is within project directory
-        _validate_path_within_project(new_path, project_dir)
+        new_path = _resolve_new_validation_path(new_path, project_dir)
 
         # Check if target already exists
         if new_path.exists():
@@ -235,11 +223,10 @@ def create_validation_router(
     ) -> dict[str, Any]:
         """Get a specific case by ID."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
         decoded_case_id = _decode_case_id(case_id)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
 
         try:
             writer = ValidationFileWriter(file_path)
@@ -273,11 +260,10 @@ def create_validation_router(
     ) -> dict[str, Any]:
         """Create or update a case."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
         decoded_case_id = _decode_case_id(case_id)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
 
         _validate_target_or_labels(body.target, body.labels, "")
 
@@ -317,11 +303,10 @@ def create_validation_router(
     ) -> None:
         """Delete a case from a validation file."""
         file_uri = decode_base64url(uri)
-        file_path = _uri_to_path(file_uri)
+        file_path = _resolve_existing_validation_file(
+            _uri_to_path(file_uri), project_dir
+        )
         decoded_case_id = _decode_case_id(case_id)
-
-        # Validate path is within project directory
-        _validate_path_within_project(file_path, project_dir)
 
         try:
             writer = ValidationFileWriter(file_path)
@@ -383,22 +368,61 @@ def _decode_case_id(encoded_id: str) -> str | list[str]:
     return decoded
 
 
-def _validate_path_within_project(path: Path, project_dir: Path) -> None:
-    """Validate that a path is within the project directory.
-
-    Raises HTTPException with 400 status if path traversal is detected.
-    """
+def _resolve_project_file_path(path: Path, project_dir: Path) -> Path:
+    """Resolve a strict project descendant for a file operation."""
     try:
         resolved = path.resolve()
         project_resolved = project_dir.resolve()
-
-        # Check that the path is within project_dir
-        resolved.relative_to(project_resolved)
+        relative = resolved.relative_to(project_resolved)
+        if not relative.parts:
+            raise ValueError
     except ValueError:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
-            detail="Path must be within project directory",
+            detail="Path must be a file within the project directory",
         ) from None
+    return resolved
+
+
+def _resolve_new_validation_path(path: Path, project_dir: Path) -> Path:
+    resolved = _resolve_project_file_path(path, project_dir)
+    if resolved.suffix.lower() not in VALIDATION_EXTENSIONS:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Path must use a supported validation file extension",
+        )
+    return resolved
+
+
+def _resolve_existing_validation_file(path: Path, project_dir: Path) -> Path:
+    if path.is_symlink():
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Validation file symlinks are not supported",
+        )
+    resolved = _resolve_new_validation_path(path, project_dir)
+    if not resolved.exists():
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail="Validation file not found",
+        )
+    if not _is_validation_set_file(resolved):
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Path is not a valid validation file",
+        )
+    return resolved
+
+
+def _is_validation_set_file(path: Path) -> bool:
+    if is_validation_file(path):
+        return True
+    if path.suffix.lower() not in {".yaml", ".yml", ".json", ".jsonl"}:
+        return False
+    try:
+        return ValidationFileWriter(path).read_cases() == []
+    except Exception:
+        return False
 
 
 def _uri_to_path(uri: str) -> Path:

--- a/src/inspect_scout/_view/capabilities.py
+++ b/src/inspect_scout/_view/capabilities.py
@@ -6,7 +6,7 @@ import re
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Iterable, Literal
+from typing import Iterable, Literal, TypeVar
 
 from fastapi import HTTPException
 from fsspec.core import split_protocol  # type: ignore
@@ -19,6 +19,7 @@ from inspect_scout._util.constants import DEFAULT_SCANS_DIR
 from inspect_scout._view.types import ViewConfig
 
 CapabilityKind = Literal["directory", "file"]
+ConfigT = TypeVar("ConfigT", bound=ScanJobConfig)
 _WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
 
 
@@ -28,6 +29,11 @@ class _RemotePath:
     authority: str
     path: PurePosixPath
     query: str
+
+    def location(self) -> str:
+        return urllib.parse.urlunsplit(
+            (self.scheme, self.authority, self.path.as_posix(), self.query, "")
+        )
 
 
 @dataclass(frozen=True)
@@ -49,31 +55,40 @@ class PathCapability:
                 raise ValueError("Scout directory capabilities cannot contain a query")
         return cls(kind=kind, _local=local, _remote=remote)
 
-    def allows(self, location: str) -> bool:
+    def resolve(self, location: str) -> str | None:
+        """Resolve an allowed location to the exact path used for I/O."""
         if self._local is not None:
             candidate = _canonical_local_path(location)
             if candidate is None:
-                return False
+                return None
             if self.kind == "file":
-                return candidate == self._local
-            return candidate.is_relative_to(self._local)
+                return str(candidate) if candidate == self._local else None
+            return str(candidate) if candidate.is_relative_to(self._local) else None
 
         remote_candidate = _canonical_remote_path(location)
         if remote_candidate is None or self._remote is None:
-            return False
+            return None
         if (
             remote_candidate.scheme != self._remote.scheme
             or remote_candidate.authority != self._remote.authority
         ):
-            return False
+            return None
         if self.kind == "file":
-            return (
+            allowed = (
                 remote_candidate.path == self._remote.path
                 and remote_candidate.query == self._remote.query
             )
+            return remote_candidate.location() if allowed else None
         if remote_candidate.query:
-            return False
-        return remote_candidate.path.is_relative_to(self._remote.path)
+            return None
+        return (
+            remote_candidate.location()
+            if remote_candidate.path.is_relative_to(self._remote.path)
+            else None
+        )
+
+    def allows(self, location: str) -> bool:
+        return self.resolve(location) is not None
 
 
 @dataclass(frozen=True)
@@ -130,32 +145,73 @@ class ViewerCapabilities:
         if _is_absolute_or_traversing(child):
             raise _forbidden("Scan path must be relative to the configured scans root")
         candidate = str(UPath(root) / child)
-        self.require_scans(candidate)
-        return UPath(candidate)
+        resolved = self.require_scans(candidate)
+        if resolved == root:
+            raise _forbidden("Scan path must be a child of the configured scans root")
+        return UPath(resolved)
 
     def validate_project_update(self, config: ProjectConfig) -> None:
         self.validate_scan_job(config)
 
     def validate_scan_job(self, config: ScanJobConfig) -> None:
+        self.resolve_scan_job(config)
+
+    def resolve_scan_job(self, config: ConfigT) -> ConfigT:
+        updates: dict[str, object] = {}
         if config.transcripts is not None:
-            self.require_transcripts(config.transcripts)
+            updates["transcripts"] = self.require_transcripts(config.transcripts)
         if config.scans is not None:
-            self.require_scans(config.scans)
+            updates["scans"] = self.require_scans(config.scans)
         if isinstance(config.model_args, str):
-            self.require_file(config.model_args, "model arguments")
-        for scanner in _scanner_specs(config.scanners):
-            if scanner.file is not None:
-                self.require_file(scanner.file, "scanner")
+            updates["model_args"] = self.require_file(
+                config.model_args, "model arguments"
+            )
+        if isinstance(config.scanners, list):
+            updates["scanners"] = [
+                scanner.model_copy(
+                    update={
+                        "file": self.require_file(scanner.file, "scanner")
+                        if scanner.file is not None
+                        else None
+                    }
+                )
+                for scanner in config.scanners
+            ]
+        elif isinstance(config.scanners, dict):
+            updates["scanners"] = {
+                name: scanner.model_copy(
+                    update={
+                        "file": self.require_file(scanner.file, "scanner")
+                        if scanner.file is not None
+                        else None
+                    }
+                )
+                for name, scanner in config.scanners.items()
+            }
         if config.validation:
-            for validation in config.validation.values():
-                if isinstance(validation, str):
+            updates["validation"] = {
+                name: (
                     self.require_file(validation, "validation")
+                    if isinstance(validation, str)
+                    else validation
+                )
+                for name, validation in config.validation.items()
+            }
+        return config.model_copy(update=updates)
 
     def require_file(self, location: str, label: str) -> str:
-        if self.project.allows(location) or any(
-            capability.allows(location) for capability in self.files
-        ):
-            return location
+        resolved = self.project.resolve(location)
+        if resolved is None:
+            resolved = next(
+                (
+                    candidate
+                    for capability in self.files
+                    if (candidate := capability.resolve(location)) is not None
+                ),
+                None,
+            )
+        if resolved is not None:
+            return resolved
         raise _forbidden(
             f"{label.capitalize()} file is outside the viewer's startup capabilities"
         )
@@ -166,8 +222,16 @@ class ViewerCapabilities:
         location: str,
         label: str,
     ) -> str:
-        if any(capability.allows(location) for capability in capabilities):
-            return location
+        resolved = next(
+            (
+                candidate
+                for capability in capabilities
+                if (candidate := capability.resolve(location)) is not None
+            ),
+            None,
+        )
+        if resolved is not None:
+            return resolved
         raise _forbidden(
             f"Requested {label} location is outside the viewer's startup capabilities"
         )
@@ -304,5 +368,22 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         scheme=protocol.lower(),
         authority=parsed.netloc.lower(),
         path=PurePosixPath(path),
-        query=parsed.query,
+        query=_canonical_query(parsed.query),
     )
+
+
+def _canonical_query(query: str) -> str:
+    if not query:
+        return ""
+
+    def encode(value: str) -> str:
+        return urllib.parse.quote(urllib.parse.unquote(value), safe="-._~")
+
+    fields: list[str] = []
+    for field in query.split("&"):
+        if "=" in field:
+            name, value = field.split("=", 1)
+            fields.append(f"{encode(name)}={encode(value)}")
+        else:
+            fields.append(encode(field))
+    return "&".join(fields)

--- a/src/inspect_scout/_view/capabilities.py
+++ b/src/inspect_scout/_view/capabilities.py
@@ -5,7 +5,7 @@ import posixpath
 import re
 import urllib.parse
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Iterable, Literal
 
 from fastapi import HTTPException
@@ -27,6 +27,7 @@ class _RemotePath:
     scheme: str
     authority: str
     path: PurePosixPath
+    query: str
 
 
 @dataclass(frozen=True)
@@ -41,8 +42,11 @@ class PathCapability:
         remote = None if local is not None else _canonical_remote_path(location)
         if local is None and remote is None:
             raise ValueError(f"Invalid Scout capability path: {location}")
-        if kind == "directory" and remote and remote.scheme in ("http", "https"):
-            raise ValueError(f"Unsupported Scout directory scheme: {remote.scheme}")
+        if kind == "directory" and remote:
+            if remote.scheme in ("http", "https"):
+                raise ValueError(f"Unsupported Scout directory scheme: {remote.scheme}")
+            if remote.query:
+                raise ValueError("Scout directory capabilities cannot contain a query")
         return cls(kind=kind, _local=local, _remote=remote)
 
     def allows(self, location: str) -> bool:
@@ -63,7 +67,12 @@ class PathCapability:
         ):
             return False
         if self.kind == "file":
-            return remote_candidate.path == self._remote.path
+            return (
+                remote_candidate.path == self._remote.path
+                and remote_candidate.query == self._remote.query
+            )
+        if remote_candidate.query:
+            return False
         return remote_candidate.path.is_relative_to(self._remote.path)
 
 
@@ -217,32 +226,58 @@ def _canonical_local_path(location: str) -> Path | None:
     if protocol is None:
         path = location
     elif protocol.lower() == "file":
-        try:
-            parsed = urllib.parse.urlsplit(location)
-        except ValueError:
+        file_path = _local_path_from_file_uri(location)
+        if file_path is None:
             return None
-        if (
-            parsed.query
-            or parsed.fragment
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.netloc.lower() not in ("", "localhost")
-        ):
-            return None
-        path = urllib.parse.unquote(parsed.path)
-        if (
-            os.name == "nt"
-            and path.startswith("/")
-            and len(path) > 3
-            and path[2] == ":"
-        ):
-            path = path[1:]
+        path = file_path
     else:
         return None
     try:
         return Path(path).resolve()
     except (OSError, RuntimeError, ValueError):
         return None
+
+
+def _local_path_from_file_uri(
+    location: str,
+    *,
+    windows: bool | None = None,
+) -> str | None:
+    windows = os.name == "nt" if windows is None else windows
+    try:
+        parsed = urllib.parse.urlsplit(location)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+    ):
+        return None
+
+    decoded_path = urllib.parse.unquote(parsed.path)
+    if "\\" in decoded_path:
+        return None
+
+    authority = parsed.hostname or ""
+    if authority and authority.lower() != "localhost":
+        if not windows or not decoded_path.startswith("/"):
+            return None
+        if len(PurePosixPath(decoded_path).parts) < 2:
+            return None
+        return str(PureWindowsPath(f"//{authority}{decoded_path}"))
+
+    if (
+        windows
+        and decoded_path.startswith("/")
+        and len(decoded_path) > 3
+        and decoded_path[2] == ":"
+    ):
+        return decoded_path[1:]
+    return decoded_path
 
 
 def _canonical_remote_path(location: str) -> _RemotePath | None:
@@ -255,7 +290,6 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         return None
     if (
         not parsed.netloc
-        or parsed.query
         or parsed.fragment
         or parsed.username is not None
         or parsed.password is not None
@@ -270,4 +304,5 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         scheme=protocol.lower(),
         authority=parsed.netloc.lower(),
         path=PurePosixPath(path),
+        query=parsed.query,
     )

--- a/src/inspect_scout/_view/capabilities.py
+++ b/src/inspect_scout/_view/capabilities.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Literal
+
+from fastapi import HTTPException
+from fsspec.core import split_protocol  # type: ignore
+from upath import UPath
+
+from inspect_scout._project.types import ProjectConfig
+from inspect_scout._scanjob_config import ScanJobConfig
+from inspect_scout._scanspec import ScannerSpec
+from inspect_scout._util.constants import DEFAULT_SCANS_DIR
+from inspect_scout._view.types import ViewConfig
+
+CapabilityKind = Literal["directory", "file"]
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+@dataclass(frozen=True)
+class _RemotePath:
+    scheme: str
+    authority: str
+    path: PurePosixPath
+
+
+@dataclass(frozen=True)
+class PathCapability:
+    kind: CapabilityKind
+    _local: Path | None
+    _remote: _RemotePath | None
+
+    @classmethod
+    def parse(cls, kind: CapabilityKind, location: str) -> "PathCapability":
+        local = _canonical_local_path(location)
+        remote = None if local is not None else _canonical_remote_path(location)
+        if local is None and remote is None:
+            raise ValueError(f"Invalid Scout capability path: {location}")
+        if kind == "directory" and remote and remote.scheme in ("http", "https"):
+            raise ValueError(f"Unsupported Scout directory scheme: {remote.scheme}")
+        return cls(kind=kind, _local=local, _remote=remote)
+
+    def allows(self, location: str) -> bool:
+        if self._local is not None:
+            candidate = _canonical_local_path(location)
+            if candidate is None:
+                return False
+            if self.kind == "file":
+                return candidate == self._local
+            return candidate.is_relative_to(self._local)
+
+        remote_candidate = _canonical_remote_path(location)
+        if remote_candidate is None or self._remote is None:
+            return False
+        if (
+            remote_candidate.scheme != self._remote.scheme
+            or remote_candidate.authority != self._remote.authority
+        ):
+            return False
+        if self.kind == "file":
+            return remote_candidate.path == self._remote.path
+        return remote_candidate.path.is_relative_to(self._remote.path)
+
+
+@dataclass(frozen=True)
+class ViewerCapabilities:
+    """Maximum path and execution capabilities granted at viewer startup."""
+
+    project: PathCapability
+    transcripts: tuple[PathCapability, ...]
+    scans: tuple[PathCapability, ...]
+    files: tuple[PathCapability, ...]
+
+    @classmethod
+    def from_view_config(
+        cls,
+        view_config: ViewConfig,
+        project_dir: Path,
+    ) -> "ViewerCapabilities":
+        project = PathCapability.parse("directory", str(project_dir.resolve()))
+        transcript_location = (
+            view_config.transcripts_cli or view_config.project.transcripts
+        )
+        scans_location = (
+            view_config.scans_cli or view_config.project.scans or DEFAULT_SCANS_DIR
+        )
+        transcripts = (
+            (PathCapability.parse("directory", transcript_location),)
+            if transcript_location
+            else ()
+        )
+        scans = (PathCapability.parse("directory", scans_location),)
+        files = tuple(
+            PathCapability.parse("file", location)
+            for location in _configured_files(view_config.project)
+            if not project.allows(location)
+        )
+        return cls(
+            project=project,
+            transcripts=transcripts,
+            scans=scans,
+            files=files,
+        )
+
+    def require_transcripts(self, location: str) -> str:
+        return self._require_directory(self.transcripts, location, "transcripts")
+
+    def require_scans(self, location: str) -> str:
+        return self._require_directory(self.scans, location, "scans")
+
+    def allows_scans(self, location: str) -> bool:
+        return any(capability.allows(location) for capability in self.scans)
+
+    def resolve_scan(self, scans_root: str, child: str) -> UPath:
+        root = self.require_scans(scans_root)
+        if _is_absolute_or_traversing(child):
+            raise _forbidden("Scan path must be relative to the configured scans root")
+        candidate = str(UPath(root) / child)
+        self.require_scans(candidate)
+        return UPath(candidate)
+
+    def validate_project_update(self, config: ProjectConfig) -> None:
+        self.validate_scan_job(config)
+
+    def validate_scan_job(self, config: ScanJobConfig) -> None:
+        if config.transcripts is not None:
+            self.require_transcripts(config.transcripts)
+        if config.scans is not None:
+            self.require_scans(config.scans)
+        if isinstance(config.model_args, str):
+            self.require_file(config.model_args, "model arguments")
+        for scanner in _scanner_specs(config.scanners):
+            if scanner.file is not None:
+                self.require_file(scanner.file, "scanner")
+        if config.validation:
+            for validation in config.validation.values():
+                if isinstance(validation, str):
+                    self.require_file(validation, "validation")
+
+    def require_file(self, location: str, label: str) -> str:
+        if self.project.allows(location) or any(
+            capability.allows(location) for capability in self.files
+        ):
+            return location
+        raise _forbidden(
+            f"{label.capitalize()} file is outside the viewer's startup capabilities"
+        )
+
+    def _require_directory(
+        self,
+        capabilities: tuple[PathCapability, ...],
+        location: str,
+        label: str,
+    ) -> str:
+        if any(capability.allows(location) for capability in capabilities):
+            return location
+        raise _forbidden(
+            f"Requested {label} location is outside the viewer's startup capabilities"
+        )
+
+
+def _configured_files(config: ProjectConfig) -> set[str]:
+    files: set[str] = set()
+    if isinstance(config.model_args, str):
+        files.add(config.model_args)
+    for scanner in _scanner_specs(config.scanners):
+        if scanner.file:
+            files.add(scanner.file)
+    if config.validation:
+        files.update(
+            value for value in config.validation.values() if isinstance(value, str)
+        )
+    return files
+
+
+def _scanner_specs(
+    scanners: list[ScannerSpec] | dict[str, ScannerSpec] | None,
+) -> Iterable[ScannerSpec]:
+    if scanners is None:
+        return ()
+    return scanners.values() if isinstance(scanners, dict) else scanners
+
+
+def _forbidden(detail: str) -> HTTPException:
+    return HTTPException(status_code=403, detail=detail)
+
+
+def _is_absolute_or_traversing(location: str) -> bool:
+    protocol, _ = split_protocol(location)
+    if protocol is not None:
+        return True
+    if Path(location).is_absolute() or _WINDOWS_DRIVE_PATH.match(location):
+        return True
+    decoded = urllib.parse.unquote(location)
+    decoded_protocol, _ = split_protocol(decoded)
+    return (
+        decoded_protocol is not None
+        or PurePosixPath(decoded).is_absolute()
+        or bool(_WINDOWS_DRIVE_PATH.match(decoded))
+        or "\\" in decoded
+        or ".." in PurePosixPath(decoded).parts
+    )
+
+
+def _canonical_local_path(location: str) -> Path | None:
+    if not location:
+        return None
+    if os.name == "nt" and _WINDOWS_DRIVE_PATH.match(location):
+        protocol = None
+    else:
+        protocol, _ = split_protocol(location)
+    if protocol is None:
+        path = location
+    elif protocol.lower() == "file":
+        try:
+            parsed = urllib.parse.urlsplit(location)
+        except ValueError:
+            return None
+        if (
+            parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.netloc.lower() not in ("", "localhost")
+        ):
+            return None
+        path = urllib.parse.unquote(parsed.path)
+        if (
+            os.name == "nt"
+            and path.startswith("/")
+            and len(path) > 3
+            and path[2] == ":"
+        ):
+            path = path[1:]
+    else:
+        return None
+    try:
+        return Path(path).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _canonical_remote_path(location: str) -> _RemotePath | None:
+    protocol, _ = split_protocol(location)
+    if protocol is None or protocol.lower() == "file":
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(location)
+    except ValueError:
+        return None
+    if (
+        not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or "\\" in parsed.path
+    ):
+        return None
+    decoded_path = urllib.parse.unquote(parsed.path)
+    if "\\" in decoded_path or ".." in PurePosixPath(decoded_path).parts:
+        return None
+    path = posixpath.normpath("/" + decoded_path.lstrip("/"))
+    return _RemotePath(
+        scheme=protocol.lower(),
+        authority=parsed.netloc.lower(),
+        path=PurePosixPath(path),
+    )

--- a/src/inspect_scout/_view/capabilities.py
+++ b/src/inspect_scout/_view/capabilities.py
@@ -37,33 +37,64 @@ class _RemotePath:
 
 
 @dataclass(frozen=True)
+class _OpaqueHttpFile:
+    scheme: str
+    authority: str
+    location: str
+
+
+@dataclass(frozen=True)
 class PathCapability:
     kind: CapabilityKind
     _local: Path | None
     _remote: _RemotePath | None
+    _opaque_http: _OpaqueHttpFile | None
 
     @classmethod
     def parse(cls, kind: CapabilityKind, location: str) -> "PathCapability":
+        opaque_http = _parse_opaque_http_file(location) if kind == "file" else None
         local = _canonical_local_path(location)
-        remote = None if local is not None else _canonical_remote_path(location)
-        if local is None and remote is None:
+        remote = (
+            None
+            if local is not None or opaque_http is not None
+            else _canonical_remote_path(location)
+        )
+        if local is None and remote is None and opaque_http is None:
             raise ValueError(f"Invalid Scout capability path: {location}")
         if kind == "directory" and remote:
             if remote.scheme in ("http", "https"):
                 raise ValueError(f"Unsupported Scout directory scheme: {remote.scheme}")
             if remote.query:
                 raise ValueError("Scout directory capabilities cannot contain a query")
-        return cls(kind=kind, _local=local, _remote=remote)
+        return cls(
+            kind=kind,
+            _local=local,
+            _remote=remote,
+            _opaque_http=opaque_http,
+        )
 
     def resolve(self, location: str) -> str | None:
         """Resolve an allowed location to the exact path used for I/O."""
+        if self._opaque_http is not None:
+            opaque_candidate = _parse_opaque_http_file(location)
+            return (
+                self._opaque_http.location
+                if opaque_candidate is not None
+                and opaque_candidate.location == self._opaque_http.location
+                else None
+            )
+
         if self._local is not None:
-            candidate = _canonical_local_path(location)
-            if candidate is None:
+            local_candidate = _canonical_local_path(location)
+            if local_candidate is None:
                 return None
             if self.kind == "file":
-                return str(candidate) if candidate == self._local else None
-            return str(candidate) if candidate.is_relative_to(self._local) else None
+                return str(local_candidate) if local_candidate == self._local else None
+            return (
+                str(local_candidate)
+                if local_candidate.is_relative_to(self._local)
+                else None
+            )
 
         remote_candidate = _canonical_remote_path(location)
         if remote_candidate is None or self._remote is None:
@@ -361,7 +392,12 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
     ):
         return None
     decoded_path = urllib.parse.unquote(parsed.path)
-    if "\\" in decoded_path or ".." in PurePosixPath(decoded_path).parts:
+    if (
+        "\\" in decoded_path
+        or "?" in decoded_path
+        or "#" in decoded_path
+        or ".." in PurePosixPath(decoded_path).parts
+    ):
         return None
     path = posixpath.normpath("/" + decoded_path.lstrip("/"))
     return _RemotePath(
@@ -387,3 +423,25 @@ def _canonical_query(query: str) -> str:
         else:
             fields.append(encode(field))
     return "&".join(fields)
+
+
+def _parse_opaque_http_file(location: str) -> _OpaqueHttpFile | None:
+    try:
+        parsed = urllib.parse.urlsplit(location)
+        _ = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() not in ("http", "https")
+        or not parsed.netloc
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or "\\" in parsed.path
+    ):
+        return None
+    return _OpaqueHttpFile(
+        scheme=parsed.scheme.lower(),
+        authority=parsed.netloc.lower(),
+        location=location,
+    )

--- a/src/inspect_scout/_view/server.py
+++ b/src/inspect_scout/_view/server.py
@@ -21,6 +21,7 @@ from inspect_scout._util.constants import (
     DEFAULT_SERVER_HOST,
     DEFAULT_VIEW_PORT,
 )
+from inspect_scout._view.capabilities import ViewerCapabilities
 from inspect_scout._view.notify import notify_lifespan
 from inspect_scout._view.types import ViewConfig
 
@@ -120,7 +121,12 @@ def view_server(
     # ensure we've resolved the dist directory
     directory = _resolve_dist_directory()
 
-    v2_api = v2_api_app(view_config=config, dist_path=directory)
+    capabilities = ViewerCapabilities.from_view_config(config, Path.cwd())
+    v2_api = v2_api_app(
+        view_config=config,
+        dist_path=directory,
+        capabilities=capabilities,
+    )
 
     if authorization:
         v2_api.add_middleware(AuthorizationMiddleware, authorization=authorization)

--- a/tests/view/test_validation_api.py
+++ b/tests/view/test_validation_api.py
@@ -182,6 +182,25 @@ class TestCreateValidation:
         assert response.status_code == 200
         assert file_path.exists()
 
+    def test_create_empty_validation_can_receive_first_case(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        file_path = tmp_path / "empty.yaml"
+        create_response = client.post(
+            "/validations",
+            json={"path": file_path.as_uri()},
+        )
+        encoded_uri = _base64url(file_path.as_uri())
+        encoded_case_id = _base64url("first")
+
+        upsert_response = client.post(
+            f"/validations/{encoded_uri}/{encoded_case_id}",
+            json={"target": True},
+        )
+
+        assert create_response.status_code == 200
+        assert upsert_response.status_code == 200
+
     def test_create_validation_conflict(
         self, client: TestClient, validation_csv: Path
     ) -> None:
@@ -365,6 +384,39 @@ class TestDeleteValidation:
         response = client.delete(f"/validations/{encoded_uri}")
 
         assert response.status_code == HTTP_400_BAD_REQUEST
+
+    def test_delete_validation_rejects_project_root(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        encoded_uri = _base64url(tmp_path.as_uri())
+
+        response = client.delete(f"/validations/{encoded_uri}")
+
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert tmp_path.exists()
+
+    @pytest.mark.parametrize(
+        ("name", "contents"),
+        [
+            ("important.txt", "do not delete"),
+            ("package.json", "{}"),
+        ],
+    )
+    def test_delete_validation_rejects_non_validation_files(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+        name: str,
+        contents: str,
+    ) -> None:
+        file_path = tmp_path / name
+        file_path.write_text(contents, encoding="utf-8")
+        encoded_uri = _base64url(file_path.as_uri())
+
+        response = client.delete(f"/validations/{encoded_uri}")
+
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert file_path.read_text(encoding="utf-8") == contents
 
 
 class TestGetValidationCase:

--- a/tests/view/test_view_capabilities.py
+++ b/tests/view/test_view_capabilities.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import base64
+import io
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from inspect_scout._project.types import ProjectConfig
+from inspect_scout._scanjob_config import ScanJobConfig
+from inspect_scout._scanspec import ScannerSpec
+from inspect_scout._view._api_v2 import v2_api_app
+from inspect_scout._view.capabilities import (
+    PathCapability,
+    ViewerCapabilities,
+)
+from inspect_scout._view.types import ViewConfig
+from starlette.exceptions import HTTPException
+
+
+def _encode(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+
+def _capabilities(
+    project_dir: Path,
+    transcripts: str,
+    scans: str,
+    *,
+    project: ProjectConfig | None = None,
+) -> ViewerCapabilities:
+    return ViewerCapabilities.from_view_config(
+        ViewConfig(
+            project=project or ProjectConfig(transcripts=transcripts, scans=scans)
+        ),
+        project_dir,
+    )
+
+
+def test_local_and_remote_path_capabilities(tmp_path: Path) -> None:
+    local = tmp_path / "logs"
+    sibling = tmp_path / "logs-archive"
+    local.mkdir()
+    sibling.mkdir()
+    local_scope = PathCapability.parse("directory", str(local))
+    assert local_scope.allows(str(local / "run.eval"))
+    assert not local_scope.allows(str(sibling / "run.eval"))
+
+    remote_scope = PathCapability.parse("directory", "s3://bucket/logs")
+    assert remote_scope.allows("s3://bucket/logs/run.eval")
+    assert not remote_scope.allows("s3://bucket/logs-archive/run.eval")
+    assert not remote_scope.allows("s3://other/logs/run.eval")
+    assert not remote_scope.allows("s3://bucket/logs/%2e%2e/private")
+
+
+def test_capabilities_resolve_relative_scan_children(tmp_path: Path) -> None:
+    scans = tmp_path / "scans"
+    transcripts = tmp_path / "transcripts"
+    scans.mkdir()
+    transcripts.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    resolved = capabilities.resolve_scan(str(scans), "scan_id=abc")
+    assert resolved == scans / "scan_id=abc"
+
+    for child in (
+        str(tmp_path / "outside"),
+        "../outside",
+        "%2Fetc",
+        "s3://bucket/scan",
+        "%73%33://bucket/scan",
+    ):
+        with pytest.raises(HTTPException):
+            capabilities.resolve_scan(str(scans), child)
+
+
+def test_project_updates_may_narrow_but_not_expand_capabilities(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    capabilities.validate_project_update(
+        ProjectConfig(
+            transcripts=str(transcripts / "subset"),
+            scans=str(scans / "team"),
+        )
+    )
+
+    with pytest.raises(HTTPException, match="outside"):
+        capabilities.validate_project_update(
+            ProjectConfig(
+                transcripts=str(tmp_path / "other-transcripts"),
+                scans=str(scans),
+            )
+        )
+
+
+def test_scan_job_files_are_limited_to_project_or_startup_files(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    outside = tmp_path.parent / "outside-scanner.py"
+    transcripts.mkdir()
+    scans.mkdir()
+    project_scanner = tmp_path / "scanner.py"
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    capabilities.validate_scan_job(
+        ScanJobConfig(scanners=[ScannerSpec(name="scanner", file=str(project_scanner))])
+    )
+    with pytest.raises(HTTPException, match="Scanner file"):
+        capabilities.validate_scan_job(
+            ScanJobConfig(scanners=[ScannerSpec(name="scanner", file=str(outside))])
+        )
+
+
+def test_scans_api_rejects_out_of_scope_roots_and_absolute_children(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    outside = tmp_path / "outside"
+    transcripts.mkdir()
+    scans.mkdir()
+    outside.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    with TestClient(v2_api_app(capabilities=capabilities)) as client:
+        outside_root = client.post(f"/scans/{_encode(str(outside))}", json={})
+        absolute_child = client.get(
+            f"/scans/{_encode(str(scans))}/{_encode(str(outside))}",
+            headers={"Accept": "application/zip"},
+        )
+
+    assert outside_root.status_code == 403
+    assert absolute_child.status_code == 403
+
+
+def test_scan_zip_rejects_symlinked_files_outside_scan(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    scan = scans / "scan_id=test"
+    outside = tmp_path / "secret.txt"
+    transcripts.mkdir()
+    scan.mkdir(parents=True)
+    outside.write_text("secret", encoding="utf-8")
+    symlink = scan / "result.txt"
+    try:
+        symlink.symlink_to(outside)
+    except OSError:
+        pytest.skip("Creating file symlinks is not supported")
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    with TestClient(v2_api_app(capabilities=capabilities)) as client:
+        response = client.get(
+            f"/scans/{_encode(str(scans))}/{_encode('scan_id=test')}",
+            headers={"Accept": "application/zip"},
+        )
+
+    assert response.status_code == 403
+    assert response.content != outside.read_bytes()
+    with pytest.raises(zipfile.BadZipFile):
+        zipfile.ZipFile(io.BytesIO(response.content))
+
+
+def test_transcript_and_search_routes_reject_out_of_scope_roots(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    outside = tmp_path / "outside"
+    transcripts.mkdir()
+    scans.mkdir()
+    outside.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    with TestClient(v2_api_app(capabilities=capabilities)) as client:
+        listing = client.post(f"/transcripts/{_encode(str(outside))}", json={})
+        search = client.post(
+            f"/transcripts/{_encode(str(outside))}/id/search",
+            json={"type": "grep", "query": "test"},
+        )
+
+    assert listing.status_code == 403
+    assert search.status_code == 403
+
+
+def test_active_scans_hide_out_of_scope_locations(tmp_path: Path) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    store = MagicMock()
+    store.read_all.return_value = {
+        "outside": MagicMock(location=str(tmp_path / "outside"))
+    }
+
+    @contextmanager
+    def fake_store() -> Iterator[MagicMock]:
+        yield store
+
+    with (
+        patch(
+            "inspect_scout._view._api_v2_scans.active_scans_store",
+            fake_store,
+        ),
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        response = client.get("/scans/active")
+
+    assert response.status_code == 200
+    assert response.json()["items"] == {}
+
+
+def test_start_scan_rejects_path_expansion_before_spawning(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    outside = tmp_path / "outside"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+
+    with (
+        patch("inspect_scout._view._api_v2_scans._spawn_scan_subprocess") as spawn,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        response = client.post(
+            "/startscan",
+            json={
+                "transcripts": str(outside),
+                "scanners": [{"name": "inspect_scout/llm_scanner"}],
+            },
+        )
+
+    assert response.status_code == 403
+    spawn.assert_not_called()
+
+
+def test_start_scan_revalidates_project_config_before_spawning(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    expanded_project = ProjectConfig(
+        transcripts=str(tmp_path / "outside"),
+        scans=str(scans),
+    )
+
+    with (
+        patch(
+            "inspect_scout._view._api_v2_scans.read_project",
+            return_value=expanded_project,
+        ),
+        patch("inspect_scout._view._api_v2_scans._spawn_scan_subprocess") as spawn,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        response = client.post(
+            "/startscan",
+            json={
+                "scanners": [{"name": "inspect_scout/llm_scanner"}],
+            },
+        )
+
+    assert response.status_code == 403
+    spawn.assert_not_called()
+
+
+def test_project_api_rejects_capability_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    monkeypatch.chdir(tmp_path)
+
+    with TestClient(v2_api_app(capabilities=capabilities)) as client:
+        response = client.put(
+            "/project/config",
+            json={
+                "transcripts": str(tmp_path / "outside"),
+                "scans": str(scans),
+            },
+        )
+
+    assert response.status_code == 403
+    assert not (tmp_path / "scout.yaml").exists()

--- a/tests/view/test_view_capabilities.py
+++ b/tests/view/test_view_capabilities.py
@@ -94,13 +94,11 @@ def test_remote_capabilities_preserve_exact_queries() -> None:
 
     canonical = PathCapability.parse(
         "file",
-        "https://example.test/scanner.py?"
-        "credential=team%2Fmember&label=hello%20world",
+        "https://example.test/scanner.py?credential=team%2Fmember&label=hello%20world",
     )
     assert (
         canonical.resolve(
-            "https://example.test/scanner.py?"
-            "credential=team/member&label=hello world"
+            "https://example.test/scanner.py?credential=team/member&label=hello world"
         )
         == "https://example.test/scanner.py?"
         "credential=team%2Fmember&label=hello%20world"
@@ -116,9 +114,7 @@ def test_scan_job_paths_are_replaced_with_resolved_locations(tmp_path: Path) -> 
     selected_file = "memory://bucket/config/selected.json"
     capabilities = ViewerCapabilities(
         project=PathCapability.parse("directory", str(tmp_path)),
-        transcripts=(
-            PathCapability.parse("directory", "memory://bucket/transcripts"),
-        ),
+        transcripts=(PathCapability.parse("directory", "memory://bucket/transcripts"),),
         scans=(PathCapability.parse("directory", "memory://bucket/scans"),),
         files=(PathCapability.parse("file", selected_file),),
     )
@@ -203,9 +199,7 @@ def test_delete_scan_requires_strict_valid_scan_child(tmp_path: Path) -> None:
         patch("inspect_scout._view._api_v2_scans.send2trash") as trash,
         TestClient(v2_api_app(capabilities=capabilities)) as client,
     ):
-        root_response = client.delete(
-            f"/scans/{_encode(str(scans))}/{_encode('.')}"
-        )
+        root_response = client.delete(f"/scans/{_encode(str(scans))}/{_encode('.')}")
         unrelated_response = client.delete(
             f"/scans/{_encode(str(scans))}/{_encode('unrelated')}"
         )

--- a/tests/view/test_view_capabilities.py
+++ b/tests/view/test_view_capabilities.py
@@ -57,6 +57,12 @@ def test_local_and_remote_path_capabilities(tmp_path: Path) -> None:
     assert not remote_scope.allows("s3://other/logs/run.eval")
     assert not remote_scope.allows("s3://bucket/logs/%2e%2e/private")
 
+    remote_file = PathCapability.parse("file", "memory://bucket/logs/secret")
+    assert (
+        remote_file.resolve("memory://bucket/logs//secret")
+        == "memory://bucket/logs/secret"
+    )
+
 
 def test_local_capability_retains_selected_symlink_target(tmp_path: Path) -> None:
     first = tmp_path / "first"
@@ -86,10 +92,58 @@ def test_remote_capabilities_preserve_exact_queries() -> None:
     )
     assert not capability.allows("https://example.test/scanner.py")
 
+    canonical = PathCapability.parse(
+        "file",
+        "https://example.test/scanner.py?"
+        "credential=team%2Fmember&label=hello%20world",
+    )
+    assert (
+        canonical.resolve(
+            "https://example.test/scanner.py?"
+            "credential=team/member&label=hello world"
+        )
+        == "https://example.test/scanner.py?"
+        "credential=team%2Fmember&label=hello%20world"
+    )
+
     directory = PathCapability.parse("directory", "s3://bucket/scans")
     assert not directory.allows("s3://bucket/scans/run?version=selected")
     with pytest.raises(ValueError, match="cannot contain a query"):
         PathCapability.parse("directory", "s3://bucket/scans?version=selected")
+
+
+def test_scan_job_paths_are_replaced_with_resolved_locations(tmp_path: Path) -> None:
+    selected_file = "memory://bucket/config/selected.json"
+    capabilities = ViewerCapabilities(
+        project=PathCapability.parse("directory", str(tmp_path)),
+        transcripts=(
+            PathCapability.parse("directory", "memory://bucket/transcripts"),
+        ),
+        scans=(PathCapability.parse("directory", "memory://bucket/scans"),),
+        files=(PathCapability.parse("file", selected_file),),
+    )
+
+    resolved = capabilities.resolve_scan_job(
+        ScanJobConfig(
+            transcripts="memory://bucket/transcripts//team",
+            scans="memory://bucket/scans//team",
+            model_args="memory://bucket/config//selected.json",
+            scanners=[
+                ScannerSpec(
+                    name="scanner",
+                    file="memory://bucket/config//selected.json",
+                )
+            ],
+            validation={"scanner": "memory://bucket/config//selected.json"},
+        )
+    )
+
+    assert resolved.transcripts == "memory://bucket/transcripts/team"
+    assert resolved.scans == "memory://bucket/scans/team"
+    assert resolved.model_args == selected_file
+    assert isinstance(resolved.scanners, list)
+    assert resolved.scanners[0].file == selected_file
+    assert resolved.validation == {"scanner": selected_file}
 
 
 def test_file_uri_parsing_supports_windows_unc_paths() -> None:
@@ -113,6 +167,7 @@ def test_capabilities_resolve_relative_scan_children(tmp_path: Path) -> None:
     assert resolved == scans / "scan_id=abc"
 
     for child in (
+        ".",
         str(tmp_path / "outside"),
         "../outside",
         "%2Fetc",
@@ -121,6 +176,47 @@ def test_capabilities_resolve_relative_scan_children(tmp_path: Path) -> None:
     ):
         with pytest.raises(HTTPException):
             capabilities.resolve_scan(str(scans), child)
+
+
+def test_delete_scan_requires_strict_valid_scan_child(tmp_path: Path) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    unrelated = scans / "unrelated"
+    scan = scans / "scan_id=test"
+    transcripts.mkdir()
+    unrelated.mkdir(parents=True)
+    scan.mkdir()
+    (scan / "_scan.json").write_text("{}", encoding="utf-8")
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    store = MagicMock()
+    store.read_all.return_value = {}
+
+    @contextmanager
+    def fake_store() -> Iterator[MagicMock]:
+        yield store
+
+    with (
+        patch(
+            "inspect_scout._view._api_v2_scans.active_scans_store",
+            fake_store,
+        ),
+        patch("inspect_scout._view._api_v2_scans.send2trash") as trash,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        root_response = client.delete(
+            f"/scans/{_encode(str(scans))}/{_encode('.')}"
+        )
+        unrelated_response = client.delete(
+            f"/scans/{_encode(str(scans))}/{_encode('unrelated')}"
+        )
+        scan_response = client.delete(
+            f"/scans/{_encode(str(scans))}/{_encode('scan_id=test')}"
+        )
+
+    assert root_response.status_code == 403
+    assert unrelated_response.status_code == 404
+    assert scan_response.status_code == 204
+    trash.assert_called_once_with(str(scan))
 
 
 def test_project_updates_may_narrow_but_not_expand_capabilities(

--- a/tests/view/test_view_capabilities.py
+++ b/tests/view/test_view_capabilities.py
@@ -6,10 +6,11 @@ import zipfile
 from contextlib import contextmanager
 from pathlib import Path, PureWindowsPath
 from typing import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from inspect_scout._project._project import read_project_config_with_etag
 from inspect_scout._project.types import ProjectConfig
 from inspect_scout._scanjob_config import ScanJobConfig
 from inspect_scout._scanspec import ScannerSpec
@@ -94,14 +95,27 @@ def test_remote_capabilities_preserve_exact_queries() -> None:
 
     canonical = PathCapability.parse(
         "file",
-        "https://example.test/scanner.py?credential=team%2Fmember&label=hello%20world",
+        "s3://bucket/scanner.py?credential=team%2Fmember&label=hello%20world",
     )
     assert (
         canonical.resolve(
-            "https://example.test/scanner.py?credential=team/member&label=hello world"
+            "s3://bucket/scanner.py?credential=team/member&label=hello world"
         )
-        == "https://example.test/scanner.py?"
-        "credential=team%2Fmember&label=hello%20world"
+        == "s3://bucket/scanner.py?credential=team%2Fmember&label=hello%20world"
+    )
+
+    opaque = "https://example.test/scanner.py?token=a%26b&credential=team%2Fmember"
+    opaque_capability = PathCapability.parse("file", opaque)
+    assert opaque_capability.resolve(opaque) == opaque
+    assert (
+        opaque_capability.resolve(
+            "https://example.test/scanner.py?token=a&b&credential=team%2Fmember"
+        )
+        is None
+    )
+    encoded_path = "https://example.test/a%3Fb%23c.py"
+    assert (
+        PathCapability.parse("file", encoded_path).resolve(encoded_path) == encoded_path
     )
 
     directory = PathCapability.parse("directory", "s3://bucket/scans")
@@ -186,6 +200,16 @@ def test_delete_scan_requires_strict_valid_scan_child(tmp_path: Path) -> None:
     capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
     store = MagicMock()
     store.read_all.return_value = {}
+    recorder = MagicMock()
+    status = MagicMock()
+    status.spec.scan_id = "test"
+
+    async def read_status(location: str) -> MagicMock:
+        if location == str(scan):
+            return status
+        raise FileNotFoundError
+
+    recorder.status = AsyncMock(side_effect=read_status)
 
     @contextmanager
     def fake_store() -> Iterator[MagicMock]:
@@ -197,6 +221,10 @@ def test_delete_scan_requires_strict_valid_scan_child(tmp_path: Path) -> None:
             fake_store,
         ),
         patch("inspect_scout._view._api_v2_scans.send2trash") as trash,
+        patch(
+            "inspect_scout._view._api_v2_scans.scan_recorder_for_location",
+            return_value=recorder,
+        ),
         TestClient(v2_api_app(capabilities=capabilities)) as client,
     ):
         root_response = client.delete(f"/scans/{_encode(str(scans))}/{_encode('.')}")
@@ -211,6 +239,78 @@ def test_delete_scan_requires_strict_valid_scan_child(tmp_path: Path) -> None:
     assert unrelated_response.status_code == 404
     assert scan_response.status_code == 204
     trash.assert_called_once_with(str(scan))
+
+
+def test_delete_scan_rejects_forged_validation_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    victim = scans / "important-data"
+    transcripts.mkdir()
+    victim.mkdir(parents=True)
+    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("inspect_scout._view._api_v2_scans.send2trash") as trash,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        create_response = client.post(
+            "/validations",
+            json={
+                "path": (victim / "_scan.json").as_uri(),
+                "cases": [{"id": "x", "target": True}],
+            },
+        )
+        delete_response = client.delete(
+            f"/scans/{_encode(str(scans))}/{_encode('important-data')}"
+        )
+
+    assert create_response.status_code == 200
+    assert delete_response.status_code == 404
+    trash.assert_not_called()
+
+
+def test_delete_scan_blocks_active_scan_path_alias(tmp_path: Path) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    scan = scans / "scan_id=test"
+    transcripts.mkdir()
+    scan.mkdir(parents=True)
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    status = MagicMock()
+    status.spec.scan_id = "test"
+    recorder = MagicMock()
+    recorder.status = AsyncMock(return_value=status)
+    store = MagicMock()
+    store.read_all.return_value = {
+        "test": MagicMock(scan_id="test", location="scans/scan_id=test")
+    }
+
+    @contextmanager
+    def fake_store() -> Iterator[MagicMock]:
+        yield store
+
+    with (
+        patch(
+            "inspect_scout._view._api_v2_scans.active_scans_store",
+            fake_store,
+        ),
+        patch(
+            "inspect_scout._view._api_v2_scans.scan_recorder_for_location",
+            return_value=recorder,
+        ),
+        patch("inspect_scout._view._api_v2_scans.send2trash") as trash,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        response = client.delete(
+            f"/scans/{_encode(str(scans))}/{_encode('scan_id=test')}"
+        )
+
+    assert response.status_code == 409
+    trash.assert_not_called()
 
 
 def test_project_updates_may_narrow_but_not_expand_capabilities(
@@ -417,6 +517,50 @@ def test_start_scan_revalidates_project_config_before_spawning(
     spawn.assert_not_called()
 
 
+def test_start_scan_rejects_child_reported_location_outside_capabilities(
+    tmp_path: Path,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    outside = tmp_path / "outside"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    proc = MagicMock(pid=123)
+    active_info = MagicMock(scan_id="test", location=str(outside))
+
+    with (
+        patch(
+            "inspect_scout._view._api_v2_scans.read_project",
+            return_value=ProjectConfig(
+                transcripts=str(transcripts),
+                scans=str(scans),
+            ),
+        ),
+        patch(
+            "inspect_scout._view._api_v2_scans._spawn_scan_subprocess",
+            return_value=(proc, str(tmp_path / "missing.json"), [], []),
+        ),
+        patch(
+            "inspect_scout._view._api_v2_scans._wait_for_active_scan",
+            new=AsyncMock(return_value=active_info),
+        ),
+        patch(
+            "inspect_scout._view._api_v2_scans.scan_recorder_for_location"
+        ) as recorder,
+        TestClient(v2_api_app(capabilities=capabilities)) as client,
+    ):
+        response = client.post(
+            "/startscan",
+            json={
+                "scanners": [{"name": "inspect_scout/llm_scanner"}],
+            },
+        )
+
+    assert response.status_code == 403
+    recorder.assert_not_called()
+
+
 def test_project_api_rejects_capability_expansion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -439,3 +583,29 @@ def test_project_api_rejects_capability_expansion(
 
     assert response.status_code == 403
     assert not (tmp_path / "scout.yaml").exists()
+
+
+def test_project_api_preserves_relative_path_spelling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcripts = tmp_path / "transcripts"
+    scans = tmp_path / "scans"
+    transcripts.mkdir()
+    scans.mkdir()
+    capabilities = _capabilities(tmp_path, str(transcripts), str(scans))
+    monkeypatch.chdir(tmp_path)
+
+    with TestClient(v2_api_app(capabilities=capabilities)) as client:
+        response = client.put(
+            "/project/config",
+            json={
+                "transcripts": "./transcripts",
+                "scans": "./scans",
+            },
+        )
+
+    saved, _etag = read_project_config_with_etag()
+    assert response.status_code == 200
+    assert saved.transcripts == "./transcripts"
+    assert saved.scans == "./scans"

--- a/tests/view/test_view_capabilities.py
+++ b/tests/view/test_view_capabilities.py
@@ -4,7 +4,7 @@ import base64
 import io
 import zipfile
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Iterator
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +17,7 @@ from inspect_scout._view._api_v2 import v2_api_app
 from inspect_scout._view.capabilities import (
     PathCapability,
     ViewerCapabilities,
+    _local_path_from_file_uri,
 )
 from inspect_scout._view.types import ViewConfig
 from starlette.exceptions import HTTPException
@@ -55,6 +56,50 @@ def test_local_and_remote_path_capabilities(tmp_path: Path) -> None:
     assert not remote_scope.allows("s3://bucket/logs-archive/run.eval")
     assert not remote_scope.allows("s3://other/logs/run.eval")
     assert not remote_scope.allows("s3://bucket/logs/%2e%2e/private")
+
+
+def test_local_capability_retains_selected_symlink_target(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    selected = tmp_path / "selected"
+    first.mkdir()
+    second.mkdir()
+    (second / "secret.txt").write_text("secret", encoding="utf-8")
+    try:
+        selected.symlink_to(first, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creating directory symlinks is not supported")
+
+    capability = PathCapability.parse("directory", str(selected))
+    selected.unlink()
+    selected.symlink_to(second, target_is_directory=True)
+
+    assert not capability.allows(str(selected / "secret.txt"))
+
+
+def test_remote_capabilities_preserve_exact_queries() -> None:
+    selected = "https://example.test/scanner.py?expires=60&signature=selected"
+    capability = PathCapability.parse("file", selected)
+    assert capability.allows(selected)
+    assert not capability.allows(
+        "https://example.test/scanner.py?expires=60&signature=other"
+    )
+    assert not capability.allows("https://example.test/scanner.py")
+
+    directory = PathCapability.parse("directory", "s3://bucket/scans")
+    assert not directory.allows("s3://bucket/scans/run?version=selected")
+    with pytest.raises(ValueError, match="cannot contain a query"):
+        PathCapability.parse("directory", "s3://bucket/scans?version=selected")
+
+
+def test_file_uri_parsing_supports_windows_unc_paths() -> None:
+    assert _local_path_from_file_uri(
+        "file://server/share/scans/run", windows=True
+    ) == str(PureWindowsPath("//server/share/scans/run"))
+    assert (
+        _local_path_from_file_uri("file://server/share/scans/run", windows=False)
+        is None
+    )
 
 
 def test_capabilities_resolve_relative_scan_children(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related viewer security PRs

- [UKGovernmentBEIS/inspect_ai#4370](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4370) - Inspect canonical standalone and scoped-authorized path capabilities.
- [meridianlabs-ai/inspect_vscode#123](https://github.com/meridianlabs-ai/inspect_vscode/pull/123) - VS Code host-selected file and directory scopes.
- [meridianlabs-ai/inspect_scout#483](https://github.com/meridianlabs-ai/inspect_scout/pull/483) - Scout startup filesystem and execution capabilities.

## Current behavior

Scout routes accept base64-encoded scan and transcript roots from each request. An absolute decoded scan child discards the supplied scans root, allowing ZIP reads and `send2trash` calls against another local directory.

Project Settings can persist arbitrary transcript and scans locations, and `/startscan` accepts path-bearing transcript, output, scanner, validation, and model-argument configuration. Route parameters and scan-start bodies therefore act as capability grants rather than selections within an existing grant.

## New behavior

Scout resolves and retains a maximum capability set at viewer startup from:

- the project directory;
- effective CLI or startup-project transcript and scans roots; and
- exact external scanner, validation, and model-argument files already present in trusted startup configuration.

The API now:

- freezes selected local symlink targets at startup;
- requires scan, transcript, and search roots to remain within those startup capabilities;
- requires scan children to be relative, canonically contained, and strict descendants of the selected scans root;
- uses the resolved canonical location for filesystem I/O rather than the caller-supplied alias;
- limits validation file operations to strict project descendants that are validation sets;
- parses scan metadata before deletion and protects active scans by parsed scan ID rather than path spelling;
- revalidates child-reported scan locations before status I/O;
- preserves user-authored relative path spelling when saving Project Settings;
- rejects absolute, encoded-absolute, traversal, sibling-prefix, other-scheme, other-authority, and symlink-escape paths;
- retains HTTP(S) files as opaque exact URL capabilities, compares canonical queries for other exact remote files, and rejects queries for directory capabilities;
- parses Windows UNC file URIs as local paths on Windows while rejecting remote file authorities elsewhere;
- permits Project Settings to select or narrow paths within the startup maximum but not enlarge it;
- validates both the current `scout.yaml` and the `/startscan` request before spawning a subprocess;
- constrains scanner, validation, model-argument, transcript, and output paths;
- hides active scans outside the configured scans capability; and
- rejects ZIP entries whose symlink target escapes the selected scan directory.

Direct construction of the alpha `v2_api_app()` remains available without a capability object for trusted embedding and existing unit tests. The standalone Scout server always supplies the startup capability set.

## Compatibility

Normal use of configured local and remote transcript/scans roots is unchanged. Routes may select descendants and Project Settings may narrow within the startup maximum.

Expanding to another directory, bucket, scheme, scanner file, or output root now requires changing `scout.yaml` outside the viewer or changing the `scout view` command and restarting the process.

Scout and Inspect intentionally retain local Python implementations while using matching conformance cases. Consolidation will be evaluated after rollout in [#484](https://github.com/meridianlabs-ai/inspect_scout/issues/484).

## Testing

- 174 Scout View tests passed.
- Ruff formatting and lint passed for the changed modules.
- mypy passed for the changed modules and tests.
- Added immutable-root, signed-query, directory-query, and platform-independent Windows UNC parsing coverage.
- This repository does not currently run Windows CI; native UNC filesystem resolution still requires a manual Windows smoke test.

## Known limitation

Viewer-started scans inherit the host process environment. Deprecated `SCOUT_SCAN_*` variables are treated as trusted ambient startup configuration and are not frozen into `ViewerCapabilities` by this PR. An API caller cannot choose a new arbitrary environment path, but omitting a request field can allow a preconfigured environment value to affect the child scan.

Freezing the complete effective child configuration, while preserving provider and cloud credentials, is tracked in [#485](https://github.com/meridianlabs-ai/inspect_scout/issues/485).