### PR TITLE
Honor `--log-level` across import and scan subcommands

### DIFF
--- a/src/inspect_scout/_cli/common.py
+++ b/src/inspect_scout/_cli/common.py
@@ -89,9 +89,7 @@ def resolve_common_log_level(ctx: click.Context, options: CommonOptions) -> str 
 
     Returns the value only when it was provided explicitly on the command line;
     otherwise returns ``None`` so callers can fall back to the project (and then
-    default) log level. This matches the precedence used by ``scout scan``,
-    where an explicit CLI flag wins but the (defaulted) option value does not
-    override project configuration.
+    default) log level.
     """
     if ctx.get_parameter_source("log_level") == ParameterSource.COMMANDLINE:
         return options["log_level"]

--- a/src/inspect_scout/_cli/common.py
+++ b/src/inspect_scout/_cli/common.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Callable, Literal, TypeVar, cast
 
 import click
+from click.core import ParameterSource
 from inspect_ai._util.constants import ALL_LOG_LEVELS, DEFAULT_LOG_LEVEL
 from typing_extensions import TypedDict
 
@@ -81,6 +82,20 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         return cast(click.Context, func(*args, **kwargs))
 
     return wrapper
+
+
+def resolve_common_log_level(ctx: click.Context, options: CommonOptions) -> str | None:
+    """Resolve the effective ``--log-level`` for a command.
+
+    Returns the value only when it was provided explicitly on the command line;
+    otherwise returns ``None`` so callers can fall back to the project (and then
+    default) log level. This matches the precedence used by ``scout scan``,
+    where an explicit CLI flag wins but the (defaulted) option value does not
+    override project configuration.
+    """
+    if ctx.get_parameter_source("log_level") == ParameterSource.COMMANDLINE:
+        return options["log_level"]
+    return None
 
 
 def process_common_options(options: CommonOptions) -> None:

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -353,7 +353,12 @@ def import_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Import transcripts from a source."""
+    from inspect_scout._scan import top_level_async_init
+
     process_common_options(common)
+
+    # initialize logging (and platform/environment) with the resolved log level
+    top_level_async_init(common["log_level"])
 
     available_sources = _discover_sources()
 

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -20,6 +20,7 @@ from inspect_scout._cli.common import (
     process_common_options,
 )
 from inspect_scout._display._display import display
+from inspect_scout._init import top_level_async_init
 from inspect_scout._util.constants import DEFAULT_TRANSCRIPTS_DIR
 
 
@@ -353,8 +354,6 @@ def import_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Import transcripts from a source."""
-    from inspect_scout._init import top_level_async_init
-
     process_common_options(common)
 
     # initialize logging (and platform/environment) with the resolved log level

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -353,7 +353,7 @@ def import_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Import transcripts from a source."""
-    from inspect_scout._scan import top_level_async_init
+    from inspect_scout._init import top_level_async_init
 
     process_common_options(common)
 

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -356,7 +356,7 @@ def import_command(
     """Import transcripts from a source."""
     process_common_options(common)
 
-    # initialize logging (and platform/environment) with the resolved log level
+    # initialize logging (and platform/environment)
     top_level_async_init(common["log_level"])
 
     available_sources = _discover_sources()

--- a/src/inspect_scout/_cli/main.py
+++ b/src/inspect_scout/_cli/main.py
@@ -2,7 +2,7 @@ import click
 from inspect_ai._util.error import set_exception_hook
 
 from .. import __version__
-from .._scan import init_environment
+from .._init import init_environment
 from .db import db_command
 from .import_command import import_command
 from .info import info_command

--- a/src/inspect_scout/_cli/scan_complete.py
+++ b/src/inspect_scout/_cli/scan_complete.py
@@ -3,14 +3,21 @@ from typing_extensions import Unpack
 
 from inspect_scout._scan import scan_complete
 
-from .common import CommonOptions, common_options, process_common_options
+from .common import (
+    CommonOptions,
+    common_options,
+    process_common_options,
+    resolve_common_log_level,
+)
 from .scan import scan_command
 
 
 @scan_command.command("complete")
 @click.argument("scan_location", nargs=1)
 @common_options
+@click.pass_context
 def scan_complete_command(
+    ctx: click.Context,
     scan_location: str,
     **common: Unpack[CommonOptions],
 ) -> None:
@@ -18,4 +25,4 @@ def scan_complete_command(
     # Process common options
     process_common_options(common)
 
-    scan_complete(scan_location)
+    scan_complete(scan_location, log_level=resolve_common_log_level(ctx, common))

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -8,15 +8,23 @@ from inspect_scout._display.util import terminal_path
 from inspect_scout._project._project import read_project
 
 from .._display import display
+from .._scan import top_level_async_init
 from .._scanlist import scan_list
-from .common import CommonOptions, common_options, process_common_options
+from .common import (
+    CommonOptions,
+    common_options,
+    process_common_options,
+    resolve_common_log_level,
+)
 from .scan import scan_command
 
 
 @scan_command.command("list")
 @click.argument("scans_dir", default="")
 @common_options
+@click.pass_context
 def scan_list_command(
+    ctx: click.Context,
     scans_dir: str,
     **common: Unpack[CommonOptions],
 ) -> None:
@@ -24,9 +32,13 @@ def scan_list_command(
     # Process common options
     process_common_options(common)
 
+    # initialize logging with the resolved log level
+    project = read_project()
+    top_level_async_init(resolve_common_log_level(ctx, common) or project.log_level)
+
     # if there is no scans dir then get it from the project
     if len(scans_dir) == 0:
-        scans_dir = read_project().scans or "./scans"
+        scans_dir = project.scans or "./scans"
 
     # list the scans
     scans = scan_list(scans_dir)

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -8,7 +8,7 @@ from inspect_scout._display.util import terminal_path
 from inspect_scout._project._project import read_project
 
 from .._display import display
-from .._scan import top_level_async_init
+from .._init import top_level_async_init
 from .._scanlist import scan_list
 from .common import (
     CommonOptions,

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -32,17 +32,20 @@ def scan_list_command(
     # Process common options
     process_common_options(common)
 
-    # initialize logging with the resolved log level
-    project = read_project()
-    top_level_async_init(resolve_common_log_level(ctx, common) or project.log_level)
+    # read the project only when needed: to fall back to its log level (when
+    # --log-level is not passed) or to resolve a default scans dir (when none
+    # is given). Avoids touching scout.yaml for a fully-specified invocation.
+    log_level = resolve_common_log_level(ctx, common)
+    if log_level is None or len(scans_dir) == 0:
+        project = read_project()
+        log_level = log_level or project.log_level
+        if len(scans_dir) == 0:
+            scans_dir = project.scans or "./scans"
 
-    # if there is no scans dir then get it from the project
-    if len(scans_dir) == 0:
-        scans_dir = project.scans or "./scans"
+    # initialize logging with the resolved log level
+    top_level_async_init(log_level)
 
     # list the scans
-    scans = scan_list(scans_dir)
-
     scans = sorted(
         scan_list(scans_dir),
         key=lambda scan: scan.spec.timestamp.timestamp(),

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -32,15 +32,14 @@ def scan_list_command(
     # Process common options
     process_common_options(common)
 
-    # read the project only when needed: to fall back to its log level (when
-    # --log-level is not passed) or to resolve a default scans dir (when none
-    # is given). Avoids touching scout.yaml for a fully-specified invocation.
+    # if there is no scans dir then get it from the project
+    if len(scans_dir) == 0:
+        scans_dir = read_project().scans or "./scans"
+
+    # if log_level was not set in the CLI invocation, get it from the project
     log_level = resolve_common_log_level(ctx, common)
-    if log_level is None or len(scans_dir) == 0:
-        project = read_project()
-        log_level = log_level or project.log_level
-        if len(scans_dir) == 0:
-            scans_dir = project.scans or "./scans"
+    if log_level is None:
+        log_level = read_project().log_level
 
     # initialize logging with the resolved log level
     top_level_async_init(log_level)

--- a/src/inspect_scout/_cli/scan_resume.py
+++ b/src/inspect_scout/_cli/scan_resume.py
@@ -3,7 +3,12 @@ from typing_extensions import Unpack
 
 from inspect_scout._scan import scan_resume
 
-from .common import CommonOptions, common_options, process_common_options
+from .common import (
+    CommonOptions,
+    common_options,
+    process_common_options,
+    resolve_common_log_level,
+)
 from .scan import scan_command
 
 
@@ -20,7 +25,11 @@ def scan_resume_command(
     # Process common options
     process_common_options(common)
 
-    status = scan_resume(scan_location, fail_on_error=common["fail_on_error"])
+    status = scan_resume(
+        scan_location,
+        log_level=resolve_common_log_level(ctx, common),
+        fail_on_error=common["fail_on_error"],
+    )
 
     # exit non-zero when the user asked us to fail on error and the scan
     # didn't complete cleanly

--- a/src/inspect_scout/_cli/scan_status.py
+++ b/src/inspect_scout/_cli/scan_status.py
@@ -2,8 +2,8 @@ import click
 from typing_extensions import Unpack
 
 from inspect_scout._display._display import display
+from inspect_scout._init import top_level_async_init
 from inspect_scout._project._project import read_project
-from inspect_scout._scan import top_level_async_init
 from inspect_scout._scanresults import scan_status
 
 from .common import (

--- a/src/inspect_scout/_cli/scan_status.py
+++ b/src/inspect_scout/_cli/scan_status.py
@@ -2,22 +2,36 @@ import click
 from typing_extensions import Unpack
 
 from inspect_scout._display._display import display
+from inspect_scout._project._project import read_project
+from inspect_scout._scan import top_level_async_init
 from inspect_scout._scanresults import scan_status
 
-from .common import CommonOptions, common_options, process_common_options
+from .common import (
+    CommonOptions,
+    common_options,
+    process_common_options,
+    resolve_common_log_level,
+)
 from .scan import scan_command
 
 
 @scan_command.command("status")
 @click.argument("scan_location", nargs=1)
 @common_options
+@click.pass_context
 def scan_status_command(
+    ctx: click.Context,
     scan_location: str,
     **common: Unpack[CommonOptions],
 ) -> None:
     """Print the status of a scan."""
     # Process common options
     process_common_options(common)
+
+    # initialize logging with the resolved log level
+    top_level_async_init(
+        resolve_common_log_level(ctx, common) or read_project().log_level
+    )
 
     status = scan_status(scan_location)
     display().scan_status(status)

--- a/src/inspect_scout/_concurrency/_mp_subprocess.py
+++ b/src/inspect_scout/_concurrency/_mp_subprocess.py
@@ -23,7 +23,7 @@ from inspect_ai.util._concurrency import init_concurrency
 
 from inspect_scout._display._display import display
 
-from .._scan import top_level_async_init
+from .._init import top_level_async_init
 from .._scanner.result import ResultReport
 from .._transcript.types import TranscriptInfo
 from . import _mp_common

--- a/src/inspect_scout/_init.py
+++ b/src/inspect_scout/_init.py
@@ -1,0 +1,52 @@
+"""Process bootstrap helpers shared across entry points.
+
+These initialize the runtime environment (platform, dotenv, display, logging)
+used by the CLI commands, the view server, scan execution, and the multi-process
+subprocess entry point. They live here — rather than in ``_scan`` — so callers
+that only need to bootstrap (e.g. ``scout import``) don't pull in the full
+scanning machinery.
+"""
+
+from dotenv import find_dotenv, load_dotenv
+from inspect_ai._util.constants import DEFAULT_LOG_LEVEL
+from inspect_ai._util.platform import platform_init as init_platform
+
+from ._concurrency._mp_common import set_log_level
+from ._display._display import (
+    DisplayType,
+    display_type_initialized,
+    init_display_type,
+)
+from ._util.log import init_log
+
+_initialized_environment: bool = False
+
+
+def init_environment() -> None:
+    global _initialized_environment
+    if not _initialized_environment:
+        dotenv_file = find_dotenv(usecwd=True)
+        load_dotenv(dotenv_file)
+        _initialized_environment = True
+
+
+def top_level_sync_init(display: DisplayType | None) -> None:
+    init_environment()
+    init_display_type(display)
+
+
+def top_level_async_init(
+    log_level: str | None,
+    *,
+    main_process: bool = True,
+) -> None:
+    init_platform(hooks=False)
+    init_environment()
+
+    log_level = log_level or DEFAULT_LOG_LEVEL
+
+    if not display_type_initialized():
+        init_display_type("plain")
+    init_log(log_level)
+    if main_process:
+        set_log_level(log_level)

--- a/src/inspect_scout/_init.py
+++ b/src/inspect_scout/_init.py
@@ -2,9 +2,7 @@
 
 These initialize the runtime environment (platform, dotenv, display, logging)
 used by the CLI commands, the view server, scan execution, and the multi-process
-subprocess entry point. They live here — rather than in ``_scan`` — so callers
-that only need to bootstrap (e.g. ``scout import``) don't pull in the full
-scanning machinery.
+subprocess entry point.
 """
 
 from dotenv import find_dotenv, load_dotenv

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -9,16 +9,14 @@ from typing import Any, AsyncIterator, Mapping, Sequence, cast
 import anyio
 import yaml
 from anyio.abc import TaskGroup
-from dotenv import find_dotenv, load_dotenv
 from inspect_ai._eval.context import init_model_context
 from inspect_ai._util._async import run_coroutine
 from inspect_ai._util.background import set_background_task_group
 from inspect_ai._util.config import resolve_args
-from inspect_ai._util.constants import DEFAULT_LOG_LEVEL, DEFAULT_MAX_CONNECTIONS_BATCH
+from inspect_ai._util.constants import DEFAULT_MAX_CONNECTIONS_BATCH
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.json import jsonable_python
 from inspect_ai._util.path import pretty_path
-from inspect_ai._util.platform import platform_init as init_platform
 from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import Model, init_model_usage, model_usage, resolve_models
@@ -34,7 +32,6 @@ from rich import box
 from rich.table import Column, Table
 from typing_extensions import Unpack
 
-from inspect_scout._concurrency._mp_common import set_log_level
 from inspect_scout._project import read_project
 from inspect_scout._scanjob import merge_project_into_scanjob
 from inspect_scout._scanner.metrics import metrics_accumulators
@@ -54,9 +51,8 @@ from ._concurrency.single_process import single_process_strategy
 from ._display._display import (
     DisplayType,
     display,
-    display_type_initialized,
-    init_display_type,
 )
+from ._init import top_level_async_init, top_level_sync_init
 from ._recorder import summary as recorder_summary
 from ._recorder.active_scans_store import active_scans_store
 from ._recorder.factory import (
@@ -85,7 +81,6 @@ from ._transcript.types import (
 from ._transcript.util import union_transcript_contents
 from ._util.constants import DEFAULT_MAX_TRANSCRIPTS
 from ._util.deprecation import raise_results_error, show_results_warning
-from ._util.log import init_log
 
 logger = getLogger(__name__)
 
@@ -747,39 +742,6 @@ async def _scan_async_inner(
 
     finally:
         cleanup_task_files_cache()
-
-
-def top_level_sync_init(display: DisplayType | None) -> None:
-    init_environment()
-    init_display_type(display)
-
-
-def top_level_async_init(
-    log_level: str | None,
-    *,
-    main_process: bool = True,
-) -> None:
-    init_platform(hooks=False)
-    init_environment()
-
-    log_level = log_level or DEFAULT_LOG_LEVEL
-
-    if not display_type_initialized():
-        init_display_type("plain")
-    init_log(log_level)
-    if main_process:
-        set_log_level(log_level)
-
-
-def init_environment() -> None:
-    global _initialized_environment
-    if not _initialized_environment:
-        dotenv_file = find_dotenv(usecwd=True)
-        load_dotenv(dotenv_file)
-        _initialized_environment = True
-
-
-_initialized_environment: bool = False
 
 
 def init_scan_model_context(

--- a/src/inspect_scout/_transcript/database/factory.py
+++ b/src/inspect_scout/_transcript/database/factory.py
@@ -20,7 +20,7 @@ def transcripts_view(location: str) -> TranscriptsView:
     Returns:
         Read-only view for querying transcripts.
     """
-    from inspect_scout._scan import init_environment
+    from inspect_scout._init import init_environment
     from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
     from inspect_scout._transcript.eval_log import EvalLogTranscriptsView
     from inspect_scout._transcript.factory import _location_type
@@ -42,7 +42,7 @@ def transcripts_db(location: str) -> TranscriptsDB:
     Returns:
         Transcripts database for writing and reading.
     """
-    from inspect_scout._scan import init_environment
+    from inspect_scout._init import init_environment
     from inspect_scout._transcript.database.parquet import ParquetTranscriptsDB
     from inspect_scout._transcript.factory import _location_type
 

--- a/src/inspect_scout/_transcript/factory.py
+++ b/src/inspect_scout/_transcript/factory.py
@@ -27,7 +27,7 @@ def transcripts_from(location: str | Logs) -> Transcripts:
     Returns:
         Transcripts: Collection of transcripts for scanning.
     """
-    from inspect_scout._scan import init_environment
+    from inspect_scout._init import init_environment
 
     init_environment()
     locations = (

--- a/src/inspect_scout/_view/view.py
+++ b/src/inspect_scout/_view/view.py
@@ -5,8 +5,8 @@ from typing import Any, Literal
 from inspect_ai._util.path import chdir
 from inspect_ai._view.view import view_acquire_port
 
+from inspect_scout._init import top_level_async_init
 from inspect_scout._project._project import read_project
-from inspect_scout._scan import top_level_async_init
 from inspect_scout._util.appdirs import scout_data_dir
 from inspect_scout._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
 from inspect_scout._view.server import view_server, view_url

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -170,3 +170,22 @@ def test_absent_log_level_falls_back_to_project(
     _invoke(args)
     expected = "info" if project_aware else DEFAULT_LOG_LEVEL.lower()
     assert recorder.effective_level() == expected
+
+
+def test_scan_list_explicit_dir_and_level_skips_project(
+    recorder: _LevelRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`scan list <dir> --log-level X` must not read the project config.
+
+    With both the scans dir and the log level specified there is nothing to
+    resolve from scout.yaml, so a malformed scout.yaml must not break the
+    command (read_project() raises on invalid config).
+    """
+    import inspect_scout._cli.scan_list as scan_list_mod
+
+    def _fail() -> object:
+        raise AssertionError("read_project() should not be called")
+
+    monkeypatch.setattr(scan_list_mod, "read_project", _fail)
+    _invoke(["scan", "list", "somedir", "--log-level", "error"])
+    assert recorder.effective_level() == "error"

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -1,0 +1,172 @@
+"""Tests that CLI commands honor ``--log-level``.
+
+These commands (``import``, ``scan list``, ``scan status``, ``scan complete``,
+``scan resume``) previously ignored ``--log-level`` entirely. Each test asserts
+the level that is actually committed to logging initialization, covering the
+explicit / absent / project-configured cases.
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from click.core import ParameterSource
+from click.testing import CliRunner
+from inspect_ai._util.constants import DEFAULT_LOG_LEVEL
+from inspect_scout._cli.common import CommonOptions, resolve_common_log_level
+from inspect_scout._cli.main import scout
+
+# =============================================================================
+# resolve_common_log_level (unit)
+# =============================================================================
+
+
+def _common_options(log_level: str) -> CommonOptions:
+    return CommonOptions(
+        display="none",
+        log_level=log_level,
+        debug=False,
+        debug_port=5678,
+        fail_on_error=False,
+    )
+
+
+@pytest.fixture
+def mock_ctx() -> MagicMock:
+    """A Click context whose parameter sources can be configured per option."""
+    ctx = MagicMock()
+    sources: dict[str, ParameterSource] = {}
+
+    def get_parameter_source(option: str) -> ParameterSource | None:
+        return sources.get(option)
+
+    def set_parameter_source(option: str, source: ParameterSource) -> None:
+        sources[option] = source
+
+    ctx.get_parameter_source = get_parameter_source
+    ctx.set_parameter_source = set_parameter_source
+    return ctx
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        # only an explicit command-line flag overrides project/default config
+        (ParameterSource.COMMANDLINE, "debug"),
+        (ParameterSource.ENVIRONMENT, None),
+        (ParameterSource.DEFAULT, None),
+        (ParameterSource.DEFAULT_MAP, None),
+    ],
+)
+def test_resolve_common_log_level(
+    mock_ctx: MagicMock, source: ParameterSource, expected: str | None
+) -> None:
+    mock_ctx.set_parameter_source("log_level", source)
+    result = resolve_common_log_level(mock_ctx, _common_options("debug"))
+    assert result == expected
+
+
+# =============================================================================
+# end-to-end: the resolved level reaches logging initialization
+# =============================================================================
+
+
+class _StopInit(Exception):
+    """Raised by the recorder to abort a command immediately after log init."""
+
+
+class _LevelRecorder:
+    def __init__(self) -> None:
+        self.level: str | None = None
+        self.called: bool = False
+
+    def __call__(self, log_level: str | None, **kwargs: Any) -> None:
+        self.level = log_level
+        self.called = True
+        raise _StopInit()
+
+    def effective_level(self) -> str:
+        """The level that would actually be applied (None => built-in default)."""
+        assert self.called, "command did not initialize logging"
+        return (self.level or DEFAULT_LOG_LEVEL).lower()
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _LevelRecorder:
+    """Capture the log level committed to ``top_level_async_init``.
+
+    All five commands funnel the resolved level into ``top_level_async_init``:
+    ``import``, ``scan list``, and ``scan status`` call it directly, while
+    ``scan complete``/``scan resume`` reach it via ``scan_complete()``/
+    ``scan_resume()`` in ``inspect_scout._scan``. Patch each binding a command
+    actually reaches.
+    """
+    import inspect_scout._cli.scan_list as scan_list_mod
+    import inspect_scout._cli.scan_status as scan_status_mod
+    import inspect_scout._scan as scan_mod
+
+    rec = _LevelRecorder()
+    monkeypatch.setattr(scan_mod, "top_level_async_init", rec)
+    monkeypatch.setattr(scan_list_mod, "top_level_async_init", rec)
+    monkeypatch.setattr(scan_status_mod, "top_level_async_init", rec)
+    return rec
+
+
+# (id, cli args, whether the command resolves a project-configured log level)
+_COMMANDS: list[tuple[str, list[str], bool]] = [
+    ("import", ["import", "--sources"], False),
+    ("scan-list", ["scan", "list"], True),
+    ("scan-status", ["scan", "status", "someloc"], True),
+    ("scan-complete", ["scan", "complete", "someloc"], True),
+    ("scan-resume", ["scan", "resume", "someloc"], True),
+]
+_COMMAND_IDS = [command[0] for command in _COMMANDS]
+_COMMAND_ARGS = [command[1] for command in _COMMANDS]
+_COMMAND_ARGS_AWARE = [(command[1], command[2]) for command in _COMMANDS]
+
+
+def _invoke(args: list[str]) -> None:
+    # commands abort via _StopInit once the level is captured
+    CliRunner().invoke(scout, args, catch_exceptions=True)
+
+
+@pytest.mark.parametrize("args", _COMMAND_ARGS, ids=_COMMAND_IDS)
+def test_explicit_log_level_is_applied(
+    recorder: _LevelRecorder, args: list[str]
+) -> None:
+    """An explicit ``--log-level`` is committed to logging init for every command."""
+    _invoke([*args, "--log-level", "error"])
+    assert recorder.effective_level() == "error"
+
+
+@pytest.mark.parametrize("args", _COMMAND_ARGS, ids=_COMMAND_IDS)
+def test_absent_log_level_uses_default_without_project(
+    recorder: _LevelRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    args: list[str],
+) -> None:
+    """With no flag and no project config, the built-in default level is used."""
+    monkeypatch.chdir(tmp_path)
+    _invoke(args)
+    assert recorder.effective_level() == DEFAULT_LOG_LEVEL.lower()
+
+
+@pytest.mark.parametrize("args, project_aware", _COMMAND_ARGS_AWARE, ids=_COMMAND_IDS)
+def test_absent_log_level_falls_back_to_project(
+    recorder: _LevelRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    args: list[str],
+    project_aware: bool,
+) -> None:
+    """With no flag, project ``log_level`` is used by project-aware commands.
+
+    ``import`` is not project-scoped, so it keeps the default level.
+    """
+    (tmp_path / "scout.yaml").write_text("log_level: info\n")
+    monkeypatch.chdir(tmp_path)
+    _invoke(args)
+    expected = "info" if project_aware else DEFAULT_LOG_LEVEL.lower()
+    assert recorder.effective_level() == expected

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -97,18 +97,18 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> _LevelRecorder:
     """Capture the log level committed to ``top_level_async_init``.
 
     All five commands funnel the resolved level into ``top_level_async_init``
-    (defined in ``inspect_scout._init``): ``import`` imports it lazily from
-    ``_init``; ``scan list``/``scan status`` bind it at import time; ``scan
-    complete``/``scan resume`` reach it via ``scan_complete()``/``scan_resume()``
-    in ``inspect_scout._scan``. Patch every binding a command actually reaches.
+    (defined in ``inspect_scout._init``). ``import``, ``scan list``, and ``scan
+    status`` bind it at import time, so patch each command module's binding;
+    ``scan complete``/``scan resume`` reach it via ``scan_complete()``/
+    ``scan_resume()`` in ``inspect_scout._scan``, so patch that binding too.
     """
+    import inspect_scout._cli.import_command as import_mod
     import inspect_scout._cli.scan_list as scan_list_mod
     import inspect_scout._cli.scan_status as scan_status_mod
-    import inspect_scout._init as init_mod
     import inspect_scout._scan as scan_mod
 
     rec = _LevelRecorder()
-    monkeypatch.setattr(init_mod, "top_level_async_init", rec)
+    monkeypatch.setattr(import_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_list_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_status_mod, "top_level_async_init", rec)

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -96,17 +96,19 @@ class _LevelRecorder:
 def recorder(monkeypatch: pytest.MonkeyPatch) -> _LevelRecorder:
     """Capture the log level committed to ``top_level_async_init``.
 
-    All five commands funnel the resolved level into ``top_level_async_init``:
-    ``import``, ``scan list``, and ``scan status`` call it directly, while
-    ``scan complete``/``scan resume`` reach it via ``scan_complete()``/
-    ``scan_resume()`` in ``inspect_scout._scan``. Patch each binding a command
-    actually reaches.
+    All five commands funnel the resolved level into ``top_level_async_init``
+    (defined in ``inspect_scout._init``): ``import`` imports it lazily from
+    ``_init``; ``scan list``/``scan status`` bind it at import time; ``scan
+    complete``/``scan resume`` reach it via ``scan_complete()``/``scan_resume()``
+    in ``inspect_scout._scan``. Patch every binding a command actually reaches.
     """
     import inspect_scout._cli.scan_list as scan_list_mod
     import inspect_scout._cli.scan_status as scan_status_mod
+    import inspect_scout._init as init_mod
     import inspect_scout._scan as scan_mod
 
     rec = _LevelRecorder()
+    monkeypatch.setattr(init_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_list_mod, "top_level_async_init", rec)
     monkeypatch.setattr(scan_status_mod, "top_level_async_init", rec)


### PR DESCRIPTION
The `--log-level` common CLI option was silently ignored by `scout import`, `scout scan list`, `scout scan status`, `scout scan complete`, and `scout scan resume`.

Add `resolve_common_log_level()` to apply CLI > project > default precedence (matching `scout scan`) and wire it into each command. Add table-driven tests covering the explicit/absent/project-configured cases per command.

### Refactor: extract bootstrap helpers into `_init`

Wiring the fix into these commands surfaced an existing smell: `top_level_async_init` / `init_environment` are generic process bootstrap (platform, dotenv, display, logging) — not scan-specific — yet lived in `_scan`. That forced lightweight callers like `scout import` to import from the heavy scanning module.

This PR moves them to a dedicated `inspect_scout/_init` module and repoints all call sites (CLI commands, view server, multi-process subprocess, transcript factories). No behavior change.