### PR TITLE
Honour `--log-level` consistently across CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Scout View: Fix broken commit links for ssh-style GitHub origins
 - Scout View: Improve MathJax Sanitization
 - Bugfix: Per-key validation metrics for dict/multi-label targets now bucket each key against its own target value. Previously the whole-dict positivity (always positive for a non-empty dict) was applied to every key, so a key whose target was `False`/negative was scored TP/FN instead of TN/FP, inflating per-key precision and specificity.
+- Bugfix: Respect `--log-level` CLI arg and `SCOUT_LOG_LEVEL` env var across all `scout` commands.
 
 ## 0.4.41 (12 June 2026)
 

--- a/src/inspect_scout/_cli/common.py
+++ b/src/inspect_scout/_cli/common.py
@@ -3,11 +3,15 @@ import os
 from typing import Any, Callable, Literal, TypeVar, cast
 
 import click
+from click.core import ParameterSource
 from inspect_ai._util.constants import ALL_LOG_LEVELS, DEFAULT_LOG_LEVEL
 from typing_extensions import TypedDict
 
+from inspect_scout._concurrency._mp_common import set_log_level
 from inspect_scout._display._display import DisplayType, display, init_display_type
+from inspect_scout._project._project import read_project
 from inspect_scout._util.constants import DEFAULT_DISPLAY, DEFAULT_SERVER_HOST
+from inspect_scout._util.log import init_log
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -83,10 +87,53 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     return wrapper
 
 
-def process_common_options(options: CommonOptions) -> None:
+def resolve_log_level(ctx: click.Context, options: CommonOptions) -> str:
+    """Resolve the effective log level for a CLI command.
+
+    Precedence (highest to lowest):
+
+    1. The ``--log-level`` argument when supplied explicitly on the command line.
+    2. The ``log_level`` field of the project configuration (``scout.yaml``).
+    3. The ``SCOUT_LOG_LEVEL`` environment variable.
+    4. The built-in default (``DEFAULT_LOG_LEVEL``).
+
+    Environment variable and default both surface as ``options["log_level"]``
+    (click resolves them into the option value), so they are handled by the
+    final fallback.
+
+    Args:
+        ctx: The click context for the command (used to determine whether
+            ``--log-level`` was supplied on the command line).
+        options: The resolved common options for the command.
+
+    Returns:
+        The effective log level.
+    """
+    # an explicit command-line argument always wins
+    if ctx.get_parameter_source("log_level") == ParameterSource.COMMANDLINE:
+        return options["log_level"]
+
+    # otherwise prefer a project-configured value
+    project_log_level = read_project().log_level
+    if project_log_level is not None:
+        return project_log_level
+
+    # fall back to the click-resolved value (environment variable or default)
+    return options["log_level"]
+
+
+def process_common_options(ctx: click.Context, options: CommonOptions) -> None:
     # propagate display
     display_type = cast(DisplayType, options["display"].lower().strip())
     init_display_type(display_type)
+
+    # write the resolved log_level back so commands that forward it into the
+    # scan/view runtime pass an already-resolved value (the runtime's
+    # `log_level or project.log_level` keeps a truthy log_level as-is).
+    log_level = resolve_log_level(ctx, options)
+    options["log_level"] = log_level
+    init_log(log_level)
+    set_log_level(log_level)
 
     # attach debugger if requested
     if options["debug"]:

--- a/src/inspect_scout/_cli/common.py
+++ b/src/inspect_scout/_cli/common.py
@@ -122,7 +122,9 @@ def resolve_log_level(ctx: click.Context, options: CommonOptions) -> str:
     return options["log_level"]
 
 
-def process_common_options(ctx: click.Context, options: CommonOptions) -> None:
+def process_common_options(
+    ctx: click.Context, options: CommonOptions, *, init_logging: bool = True
+) -> None:
     # propagate display
     display_type = cast(DisplayType, options["display"].lower().strip())
     init_display_type(display_type)
@@ -132,8 +134,16 @@ def process_common_options(ctx: click.Context, options: CommonOptions) -> None:
     # `log_level or project.log_level` keeps a truthy log_level as-is).
     log_level = resolve_log_level(ctx, options)
     options["log_level"] = log_level
-    init_log(log_level)
-    set_log_level(log_level)
+
+    # initialize logging now for commands that won't enter a runtime that does
+    # it for them. `scout scan` passes init_logging=False: it resolves a more
+    # specific level from the scanjob config *file* after this point and
+    # initializes logging itself, and the logging handler is installed once per
+    # process (first caller wins) — so an eager init here would lock in the
+    # less-specific level and silently drop the scanjob file's log_level.
+    if init_logging:
+        init_log(log_level)
+        set_log_level(log_level)
 
     # attach debugger if requested
     if options["debug"]:

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -340,7 +340,9 @@ async def _run_dry_run(
     help="Overwrite existing transcripts directory without prompting.",
 )
 @common_options
+@click.pass_context
 def import_command(
+    ctx: click.Context,
     source: str | None,
     transcripts: str,
     limit: int | None,
@@ -353,7 +355,7 @@ def import_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Import transcripts from a source."""
-    process_common_options(common)
+    process_common_options(ctx, common)
 
     available_sources = _discover_sources()
 

--- a/src/inspect_scout/_cli/scan.py
+++ b/src/inspect_scout/_cli/scan.py
@@ -483,7 +483,7 @@ def scan_command(
         return
 
     # Process common options
-    process_common_options(common)
+    process_common_options(ctx, common)
 
     # Handle deprecated --results option
     if results is not None:

--- a/src/inspect_scout/_cli/scan.py
+++ b/src/inspect_scout/_cli/scan.py
@@ -482,8 +482,9 @@ def scan_command(
     if ctx.invoked_subcommand is not None:
         return
 
-    # Process common options
-    process_common_options(ctx, common)
+    # Process common options. Defer logging init: scan resolves a more specific
+    # log level from the scanjob config below and initializes logging itself.
+    process_common_options(ctx, common, init_logging=False)
 
     # Handle deprecated --results option
     if results is not None:

--- a/src/inspect_scout/_cli/scan_complete.py
+++ b/src/inspect_scout/_cli/scan_complete.py
@@ -10,12 +10,14 @@ from .scan import scan_command
 @scan_command.command("complete")
 @click.argument("scan_location", nargs=1)
 @common_options
+@click.pass_context
 def scan_complete_command(
+    ctx: click.Context,
     scan_location: str,
     **common: Unpack[CommonOptions],
 ) -> None:
     """Complete a scan which is incomplete due to errors (errors are not retried)."""
     # Process common options
-    process_common_options(common)
+    process_common_options(ctx, common)
 
-    scan_complete(scan_location)
+    scan_complete(scan_location, log_level=common["log_level"])

--- a/src/inspect_scout/_cli/scan_list.py
+++ b/src/inspect_scout/_cli/scan_list.py
@@ -16,13 +16,15 @@ from .scan import scan_command
 @scan_command.command("list")
 @click.argument("scans_dir", default="")
 @common_options
+@click.pass_context
 def scan_list_command(
+    ctx: click.Context,
     scans_dir: str,
     **common: Unpack[CommonOptions],
 ) -> None:
     """List the scans within the scans dir."""
     # Process common options
-    process_common_options(common)
+    process_common_options(ctx, common)
 
     # if there is no scans dir then get it from the project
     if len(scans_dir) == 0:

--- a/src/inspect_scout/_cli/scan_resume.py
+++ b/src/inspect_scout/_cli/scan_resume.py
@@ -18,9 +18,13 @@ def scan_resume_command(
 ) -> None:
     """Resume a scan which is incomplete due to interruption or errors (errors are retried)."""
     # Process common options
-    process_common_options(common)
+    process_common_options(ctx, common)
 
-    status = scan_resume(scan_location, fail_on_error=common["fail_on_error"])
+    status = scan_resume(
+        scan_location,
+        log_level=common["log_level"],
+        fail_on_error=common["fail_on_error"],
+    )
 
     # exit non-zero when the user asked us to fail on error and the scan
     # didn't complete cleanly

--- a/src/inspect_scout/_cli/scan_status.py
+++ b/src/inspect_scout/_cli/scan_status.py
@@ -11,13 +11,15 @@ from .scan import scan_command
 @scan_command.command("status")
 @click.argument("scan_location", nargs=1)
 @common_options
+@click.pass_context
 def scan_status_command(
+    ctx: click.Context,
     scan_location: str,
     **common: Unpack[CommonOptions],
 ) -> None:
     """Print the status of a scan."""
     # Process common options
-    process_common_options(common)
+    process_common_options(ctx, common)
 
     status = scan_status(scan_location)
     display().scan_status(status)

--- a/src/inspect_scout/_cli/view.py
+++ b/src/inspect_scout/_cli/view.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from typing import Literal
 
 import click
+from inspect_ai._util.path import chdir
 from typing_extensions import Unpack
 
 from inspect_scout._cli.common import (
@@ -54,7 +55,9 @@ def view_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """View scan results."""
-    process_common_options(ctx, common)
+    # chdir to correctly resolve log level based on the relevant project_dir
+    with chdir(project_dir or "."):
+        process_common_options(ctx, common, init_logging=False)
 
     view(
         project_dir=project_dir,

--- a/src/inspect_scout/_cli/view.py
+++ b/src/inspect_scout/_cli/view.py
@@ -40,7 +40,9 @@ logger = getLogger(__name__)
 )
 @view_options
 @common_options
+@click.pass_context
 def view_command(
+    ctx: click.Context,
     project_dir: str | None,
     transcripts: str | None,
     scans: str | None,
@@ -52,7 +54,7 @@ def view_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """View scan results."""
-    process_common_options(common)
+    process_common_options(ctx, common)
 
     view(
         project_dir=project_dir,

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -329,3 +329,86 @@ def test_scan_applies_scanjob_file_log_level(tmp_path: Path) -> None:
 def test_scan_default_console_level_without_scanjob_level(tmp_path: Path) -> None:
     """Without a scanjob ``log_level`` (or project/flag), the default is used."""
     assert _scan_console_level(tmp_path, None) == DEFAULT_LOG_LEVEL.upper()
+
+
+# =============================================================================
+# `scout view <project_dir>`: the level is resolved against the *target*
+# project, not the caller's cwd
+# =============================================================================
+
+# `view` changes into ``project_dir`` before it reads the project config, so its
+# log level must be resolved against that project — not the cwd the command was
+# launched from. We run from an empty cwd (no scout.yaml) with the project's
+# config under a separate ``project_dir`` to prove the target project drives the
+# level. A fresh process is required because the handler installs once per
+# process; the server is stopped right after logging init (before it blocks).
+
+
+def _view_console_level(
+    tmp_path: Path, project_log_level: str | None, *, cli_level: str | None = None
+) -> str:
+    """Run ``scout view <project_dir>`` from an empty cwd in a fresh process.
+
+    Returns the level name (e.g. ``"DEBUG"``) of the installed logging
+    handler's display level after view initializes logging.
+    """
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    if project_log_level is not None:
+        (project_dir / "scout.yaml").write_text(
+            f"log_level: {project_log_level}\n", encoding="utf-8"
+        )
+
+    cwd = tmp_path / "cwd"  # empty: no scout.yaml on the caller's path
+    cwd.mkdir()
+
+    args = ["view", str(project_dir), "--no-browser", "--display", "none"]
+    if cli_level is not None:
+        args += ["--log-level", cli_level]
+
+    snippet = "\n".join(
+        [
+            "import logging",
+            "from click.testing import CliRunner",
+            "from inspect_scout._cli.main import scout",
+            "import inspect_scout._view.view as viewmod",
+            "import inspect_scout._util.log as logmod",
+            # stop right after logging init, before the blocking server
+            "class _Stop(Exception): pass",
+            "def _stop(*a, **k): raise _Stop()",
+            "viewmod.view_acquire_port = _stop",
+            f"CliRunner().invoke(scout, {args!r}, catch_exceptions=True)",
+            "h = logmod._scout_log_handler['handler']",
+            "print(logging.getLevelName(h.display_level) if h else 'NONE')",
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(cwd),  # caller cwd has no project; the level must come from project_dir
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_view_applies_target_project_log_level(tmp_path: Path) -> None:
+    """Regression: ``scout view <project_dir>`` honors that project's log_level.
+
+    The level must resolve against ``project_dir``'s ``scout.yaml`` even when
+    the command is launched from a directory with no project config. Resolving
+    against the caller's cwd (or eagerly installing the handler before the
+    chdir into ``project_dir``) would leave the console at the default level.
+    """
+    assert _view_console_level(tmp_path, "debug") == "DEBUG"
+
+
+def test_view_default_console_level_without_project(tmp_path: Path) -> None:
+    """With no target project ``log_level`` (or flag), the default is used."""
+    assert _view_console_level(tmp_path, None) == DEFAULT_LOG_LEVEL.upper()
+
+
+def test_view_cli_level_overrides_target_project(tmp_path: Path) -> None:
+    """An explicit ``--log-level`` wins over the target project's ``log_level``."""
+    assert _view_console_level(tmp_path, "debug", cli_level="error") == "ERROR"

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -10,6 +10,7 @@ Precedence (highest to lowest): CLI argument > project config > environment
 variable > default.
 """
 
+import json
 import re
 import subprocess
 import sys
@@ -295,8 +296,10 @@ def _scan_console_level(tmp_path: Path, scanjob_log_level: str | None) -> str:
         "--model",
         "mockllm/model",
     ]
+    syspath_json = json.dumps(sys.path)
     snippet = (
-        "import logging;"
+        "import logging, json, sys;"
+        f"sys.path = json.loads({syspath_json!r});"
         "from click.testing import CliRunner;"
         "from inspect_scout._cli.main import scout;"
         "import inspect_scout._util.log as logmod;"
@@ -366,9 +369,11 @@ def _view_console_level(
     if cli_level is not None:
         args += ["--log-level", cli_level]
 
+    syspath_json = json.dumps(sys.path)
     snippet = "\n".join(
         [
-            "import logging",
+            "import logging, json, sys",
+            f"sys.path = json.loads({syspath_json!r})",
             "from click.testing import CliRunner",
             "from inspect_scout._cli.main import scout",
             "import inspect_scout._view.view as viewmod",

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -1,0 +1,246 @@
+"""Tests that CLI commands honor ``--log-level``.
+
+``scout import``, ``scan list``, ``scan status``, ``scan complete`` and
+``scan resume`` previously accepted ``--log-level`` but never applied it. These
+tests pin the resolution precedence and verify, per command, that the resolved
+level actually reaches logging initialization — guarding against that
+regression.
+
+Precedence (highest to lowest): CLI argument > project config > environment
+variable > default.
+"""
+
+from pathlib import Path
+from typing import Any, Literal
+from unittest.mock import MagicMock
+
+import inspect_scout._cli.common as common
+import pytest
+from click.core import ParameterSource
+from click.testing import CliRunner
+from inspect_ai._util.constants import DEFAULT_LOG_LEVEL
+from inspect_scout._cli.common import CommonOptions, resolve_log_level
+from inspect_scout._cli.main import scout
+from inspect_scout._project.types import ProjectConfig
+
+LogLevel = Literal[
+    "debug", "http", "sandbox", "info", "warning", "error", "critical", "notset"
+]
+
+
+def _common_options(log_level: str) -> CommonOptions:
+    """Build a CommonOptions dict as click would supply it to a command."""
+    return CommonOptions(
+        display="none",
+        log_level=log_level,
+        debug=False,
+        debug_port=5678,
+        fail_on_error=False,
+    )
+
+
+# =============================================================================
+# resolve_log_level (unit): the shared precedence logic
+# =============================================================================
+
+
+@pytest.fixture
+def mock_ctx() -> MagicMock:
+    """A Click context whose parameter sources can be configured per option."""
+    ctx = MagicMock()
+    sources: dict[str, ParameterSource] = {}
+
+    def get_parameter_source(option: str) -> ParameterSource | None:
+        return sources.get(option)
+
+    def set_parameter_source(option: str, source: ParameterSource) -> None:
+        sources[option] = source
+
+    ctx.get_parameter_source = get_parameter_source
+    ctx.set_parameter_source = set_parameter_source
+    return ctx
+
+
+def _patch_project(monkeypatch: pytest.MonkeyPatch, level: LogLevel | None) -> None:
+    """Make ``read_project()`` (as seen by common.py) return ``level``."""
+    monkeypatch.setattr(common, "read_project", lambda: ProjectConfig(log_level=level))
+
+
+# (parameter source of --log-level, project log_level, option value, expected)
+_RESOLVE_CASES: list[tuple[ParameterSource, LogLevel | None, str, str]] = [
+    # an explicit command-line flag wins over everything
+    (ParameterSource.COMMANDLINE, "info", "debug", "debug"),
+    # otherwise the project value wins over env and default...
+    (ParameterSource.DEFAULT, "info", "warning", "info"),
+    (ParameterSource.ENVIRONMENT, "info", "error", "info"),
+    # ...and with no project value the click value (env / default) is used
+    (ParameterSource.ENVIRONMENT, None, "error", "error"),
+    (ParameterSource.DEFAULT, None, "warning", "warning"),
+]
+
+
+@pytest.mark.parametrize(
+    "source, project_level, option_value, expected",
+    _RESOLVE_CASES,
+)
+def test_resolve_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ctx: MagicMock,
+    source: ParameterSource,
+    project_level: LogLevel | None,
+    option_value: str,
+    expected: str,
+) -> None:
+    mock_ctx.set_parameter_source("log_level", source)
+    _patch_project(monkeypatch, project_level)
+    assert resolve_log_level(mock_ctx, _common_options(option_value)) == expected
+
+
+def test_resolve_log_level_cli_arg_skips_project(
+    monkeypatch: pytest.MonkeyPatch, mock_ctx: MagicMock
+) -> None:
+    """An explicit ``--log-level`` must not even read the project config.
+
+    (read_project() raises on a malformed scout.yaml; an explicit flag should
+    not be hostage to that.)
+    """
+    mock_ctx.set_parameter_source("log_level", ParameterSource.COMMANDLINE)
+
+    def _fail() -> ProjectConfig:
+        raise AssertionError("read_project should not be called for an explicit flag")
+
+    monkeypatch.setattr(common, "read_project", _fail)
+    assert resolve_log_level(mock_ctx, _common_options("debug")) == "debug"
+
+
+# =============================================================================
+# end-to-end: the resolved level reaches logging initialization, per command
+# =============================================================================
+
+
+class _StopInit(Exception):
+    """Raised by the recorder to abort a command immediately after log init."""
+
+
+class _LevelRecorder:
+    """Capture the level handed to ``init_log`` and abort the command.
+
+    Every ``--log-level`` command funnels its resolved level into
+    ``init_log`` via ``process_common_options``, so patching that single
+    binding intercepts the value for all of them. Aborting lets commands that
+    would otherwise need real data (a scan location, a scans dir) run far
+    enough to resolve and apply the level, then stop.
+    """
+
+    def __init__(self) -> None:
+        self.level: str | None = None
+        self.called: bool = False
+
+    def __call__(self, log_level: str | None, **kwargs: Any) -> None:
+        self.level = log_level
+        self.called = True
+        raise _StopInit()
+
+    def effective_level(self) -> str:
+        assert self.called, "command did not initialize logging"
+        return (self.level or DEFAULT_LOG_LEVEL).lower()
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _LevelRecorder:
+    rec = _LevelRecorder()
+    monkeypatch.setattr(common, "init_log", rec)
+    return rec
+
+
+def _invoke(args: list[str], env: dict[str, str] | None = None) -> None:
+    # commands abort via _StopInit once the level is captured
+    CliRunner().invoke(scout, args, env=env or {}, catch_exceptions=True)
+
+
+# commands that previously ignored --log-level (id -> CLI args)
+_COMMANDS: list[tuple[str, list[str]]] = [
+    ("import", ["import", "--sources"]),
+    ("scan-list", ["scan", "list"]),
+    ("scan-status", ["scan", "status", "someloc"]),
+    ("scan-complete", ["scan", "complete", "someloc"]),
+    ("scan-resume", ["scan", "resume", "someloc"]),
+]
+_COMMAND_IDS = [name for name, _ in _COMMANDS]
+_COMMAND_ARGS = [args for _, args in _COMMANDS]
+
+
+@pytest.mark.parametrize("args", _COMMAND_ARGS, ids=_COMMAND_IDS)
+def test_explicit_log_level_is_applied(
+    recorder: _LevelRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    args: list[str],
+) -> None:
+    """Regression: an explicit ``--log-level`` is applied by every command."""
+    monkeypatch.chdir(tmp_path)
+    _invoke([*args, "--log-level", "error"])
+    assert recorder.effective_level() == "error"
+
+
+@pytest.mark.parametrize("args", _COMMAND_ARGS, ids=_COMMAND_IDS)
+def test_absent_log_level_uses_default_without_project(
+    recorder: _LevelRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    args: list[str],
+) -> None:
+    """With no flag and no project config, the built-in default is used."""
+    monkeypatch.chdir(tmp_path)
+    _invoke(args)
+    assert recorder.effective_level() == DEFAULT_LOG_LEVEL.lower()
+
+
+@pytest.mark.parametrize("args", _COMMAND_ARGS, ids=_COMMAND_IDS)
+def test_absent_log_level_falls_back_to_project(
+    recorder: _LevelRecorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    args: list[str],
+) -> None:
+    """With no flag, the project ``log_level`` is used by every command."""
+    (tmp_path / "scout.yaml").write_text("log_level: info\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _invoke(args)
+    assert recorder.effective_level() == "info"
+
+
+def test_import_honors_env_var(
+    recorder: _LevelRecorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``SCOUT_LOG_LEVEL`` is honored when there is no flag and no project."""
+    monkeypatch.chdir(tmp_path)
+    _invoke(["import", "--sources"], env={"SCOUT_LOG_LEVEL": "error"})
+    assert recorder.effective_level() == "error"
+
+
+def test_import_project_beats_env(
+    recorder: _LevelRecorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A project ``log_level`` takes precedence over ``SCOUT_LOG_LEVEL``."""
+    (tmp_path / "scout.yaml").write_text("log_level: info\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _invoke(["import", "--sources"], env={"SCOUT_LOG_LEVEL": "error"})
+    assert recorder.effective_level() == "info"
+
+
+def test_scan_list_explicit_dir_and_level_skips_project(
+    recorder: _LevelRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``scan list <dir> --log-level X`` must not read the project config.
+
+    With both the scans dir and the level given explicitly, a malformed
+    scout.yaml (read_project() raises) must not break the command.
+    """
+
+    def _fail() -> object:
+        raise AssertionError("read_project() should not be called")
+
+    monkeypatch.setattr(common, "read_project", _fail)
+    _invoke(["scan", "list", "somedir", "--log-level", "error"])
+    assert recorder.effective_level() == "error"

--- a/tests/cli/test_log_level.py
+++ b/tests/cli/test_log_level.py
@@ -10,6 +10,9 @@ Precedence (highest to lowest): CLI argument > project config > environment
 variable > default.
 """
 
+import re
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -244,3 +247,85 @@ def test_scan_list_explicit_dir_and_level_skips_project(
     monkeypatch.setattr(common, "read_project", _fail)
     _invoke(["scan", "list", "somedir", "--log-level", "error"])
     assert recorder.effective_level() == "error"
+
+
+# =============================================================================
+# `scout scan`: the scanjob config *file* log_level is applied to the logger
+# =============================================================================
+
+# `scan` resolves a more specific level (from the scanjob config file) than
+# process_common_options does, and installs the logging handler itself. Since
+# the handler installs once per process, asserting the *applied* console level
+# requires a fresh process — hence a subprocess.
+_BROKEN_SCANNER = Path(__file__).parent / "broken_scanner.py"
+_EXAMPLE_LOGS = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+
+def _scanner_name() -> str:
+    match = re.search(r"def (\w+)\(", _BROKEN_SCANNER.read_text())
+    assert match is not None
+    return match.group(1)
+
+
+def _scan_console_level(tmp_path: Path, scanjob_log_level: str | None) -> str:
+    """Run a real ``scout scan`` in a fresh process and report the console gate.
+
+    Returns the level name (e.g. ``"DEBUG"``) of the installed logging
+    handler's display level after the scan.
+    """
+    job = tmp_path / "job.yaml"
+    config = f"scanners:\n  - name: {_scanner_name()}\n    file: {_BROKEN_SCANNER}\n"
+    if scanjob_log_level is not None:
+        config += f"log_level: {scanjob_log_level}\n"
+    job.write_text(config, encoding="utf-8")
+
+    args = [
+        "scan",
+        str(job),
+        "-T",
+        str(_EXAMPLE_LOGS),
+        "--scans",
+        str(tmp_path / "scans"),
+        "--limit",
+        "1",
+        "--max-processes",
+        "1",
+        "--display",
+        "none",
+        "--model",
+        "mockllm/model",
+    ]
+    snippet = (
+        "import logging;"
+        "from click.testing import CliRunner;"
+        "from inspect_scout._cli.main import scout;"
+        "import inspect_scout._util.log as logmod;"
+        f"r = CliRunner().invoke(scout, {args!r}, catch_exceptions=False);"
+        "assert r.exit_code == 0, r.output;"
+        "h = logmod._scout_log_handler['handler'];"
+        "print(logging.getLevelName(h.display_level) if h else 'NONE')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(tmp_path),  # hermetic: no stray scout.yaml on the resolution path
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_scan_applies_scanjob_file_log_level(tmp_path: Path) -> None:
+    """Regression: a scanjob config file's ``log_level`` reaches the logger.
+
+    An eager logging init in ``process_common_options`` would install the
+    one-shot handler at the less-specific (project/default) level before the
+    scanjob file was read, silently dropping its ``log_level``.
+    """
+    assert _scan_console_level(tmp_path, "debug") == "DEBUG"
+
+
+def test_scan_default_console_level_without_scanjob_level(tmp_path: Path) -> None:
+    """Without a scanjob ``log_level`` (or project/flag), the default is used."""
+    assert _scan_console_level(tmp_path, None) == DEFAULT_LOG_LEVEL.upper()


### PR DESCRIPTION
## Summary

The `--log-level` common CLI option was accepted by many commands but only actually honored by `scout scan` and `scout view`. Specifically:

- **`scout import`** never initialized logging at all — the flag was completely inert.
- **`scout scan resume` / `scout scan complete`** accepted `--log-level` but never forwarded it into the runtime, so it was silently dropped.
- **`scout scan list` / `scout scan status`** accepted it but never applied it.
- **`scout scan`** worked correctly (via its own scanjob-aware resolution).
- **`scout view`** worked, but its project-config fallback was effectively dead code.

This PR makes every command that offers `--log-level` resolve and apply it identically.

## Approach

Resolution and logging initialization are centralized in `process_common_options` (the shared `@common_options` entry point that every such command already calls first):

- A new `resolve_log_level(ctx, options)` applies the precedence **CLI arg > project config > env var > default**.
- The resolved value is written back into `options["log_level"]`, so commands that forward it into the scan/view runtime pass an already-resolved value.
- Logging is initialized once, at the CLI entry point, for every command — including the ones (like `import`) that never enter the async runtime.

## Design decisions & rationale

**Precedence is `CLI arg > project > env > default` (project beats env).** This matches the existing, deliberate `scout scan` behavior. **This might be contentious** and I'd be open to going a different direction if we're willing to change how `scout scan` currently applies precedence.

**Write the resolved value back into `options["log_level"]`.** Commands that enter the scan/view runtime forward `options["log_level"]`, and the runtime evaluates `log_level or project.log_level`. Because the written-back value is always truthy (worst case the `"warning"` default), that `or` short-circuits to our resolved value — so the single resolution in `process_common_options` stays authoritative and the runtime never re-resolves and clobbers it (e.g. overriding an explicit `--log-level` with a project value). Without the write-back, a command with no flag but a project `log_level` would forward the bare default and the runtime's project fallback would never fire — which is exactly why `view`'s fallback was previously dead.

**Keep the runtime's `log_level or project.log_level`.** `scan`, `scan_resume`, `scan_complete`, and `view` are part of the public programmatic API (exported in `__all__`) and can be called directly from Python without going through the CLI. For those callers, `resolve_log_level` never runs, so the runtime fallback remains load-bearing — it's the only thing that supplies a project default. It is redundant only for the CLI path (where it short-circuits).

**`scan` keeps its own resolution and defers logging init.** `scan` resolves `log_level` against the merged scanjob value (which can come from a scanjob config *file*, not just the project), so it retains its existing `resolve_scan_option` handling. Because the logging handler is installed once per process (first caller wins), `scan` passes `init_logging=False` to `process_common_options` and initializes logging itself *after* the scanjob value is known — otherwise the eager init would lock the handler at the less-specific (project/default) level and silently drop the scanjob file's `log_level`. A subprocess regression test asserts the scanjob-file level is actually applied to the console logger.