### PR TITLE
Store transcript/scan-result columns as compact JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Store transcript and scan-result event/input columns as compact JSON (`indent=None`), substantially reducing on-disk Parquet size and the bytes streamed to Scout View (e.g. ~700 MiB → ~200 MiB for a large events column).
 - Security: Remove terminal control sequences from scanner names, scan metadata, errors, progress text, and filenames before rendering console output.
 - Security: Build DuckDB queries from bound Parquet sources and quoted, schema-validated identifiers so malicious transcript/scan filenames and sort or distinct columns cannot inject SQL.
 - Add `timeline` option to `transcript_messages()` and `llm_scanner()` for selecting a named timeline.

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -11,7 +11,7 @@ from shortuuid import uuid
 
 from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
 from inspect_scout._transcript.types import Transcript
-from inspect_scout._util._json import to_json_compact
+from inspect_scout._util._json import to_json_str_compact
 
 logger = getLogger(__name__)
 
@@ -139,7 +139,7 @@ class ResultReport(BaseModel):
                     columns["value_type"] = "null"
 
             else:
-                columns["value"] = to_json_compact(self.result.value)
+                columns["value"] = to_json_str_compact(self.result.value)
                 if self.result.type is not None:
                     columns["value_type"] = self.result.type
                 else:
@@ -148,12 +148,12 @@ class ResultReport(BaseModel):
                     )
             columns["answer"] = self.result.answer
             columns["explanation"] = self.result.explanation
-            columns["metadata"] = to_json_compact(self.result.metadata or {})
+            columns["metadata"] = to_json_str_compact(self.result.metadata or {})
 
             # references
             def references_json(type: str) -> str:
                 assert self.result
-                return to_json_compact(
+                return to_json_str_compact(
                     [ref for ref in self.result.references if ref.type == type]
                 )
 
@@ -171,9 +171,9 @@ class ResultReport(BaseModel):
             columns["value_type"] = "null"
             columns["answer"] = None
             columns["explanation"] = None
-            columns["metadata"] = to_json_compact({})
-            columns["message_references"] = to_json_compact([])
-            columns["event_references"] = to_json_compact([])
+            columns["metadata"] = to_json_str_compact({})
+            columns["message_references"] = to_json_str_compact([])
+            columns["event_references"] = to_json_str_compact([])
             columns["scan_error"] = self.error.error
             columns["scan_error_traceback"] = self.error.traceback
             columns["scan_error_type"] = "refusal"
@@ -184,8 +184,8 @@ class ResultReport(BaseModel):
 
         # report validation
         if self.validation is not None:
-            columns["validation_target"] = to_json_compact(self.validation.target)
-            columns["validation_result"] = to_json_compact(self.validation.valid)
+            columns["validation_target"] = to_json_str_compact(self.validation.target)
+            columns["validation_result"] = to_json_str_compact(self.validation.valid)
             columns["validation_predicate"] = self.validation.predicate
             columns["validation_split"] = self.validation.split
             if isinstance(self.validation.valid, dict):
@@ -204,8 +204,8 @@ class ResultReport(BaseModel):
             total_tokens += usage.total_tokens
 
         columns["scan_total_tokens"] = total_tokens
-        columns["scan_model_usage"] = to_json_compact(self.model_usage)
-        columns["scan_events"] = to_json_compact(self.events)
+        columns["scan_model_usage"] = to_json_str_compact(self.model_usage)
+        columns["scan_events"] = to_json_str_compact(self.events)
 
         return columns
 
@@ -222,16 +222,16 @@ def _serialize_input(
         (input_json, input_data_json | None)
     """
     if not pool_dedup or input_type not in ("transcript", "events"):
-        return to_json_compact(input), None
+        return to_json_str_compact(input), None
 
     if input_type == "transcript":
         assert isinstance(input, Transcript)
         condensed_events, events_data = condense_events(input.events)
         condensed = input.model_copy(update={"events": condensed_events})
-        return to_json_compact(condensed), to_json_compact(events_data)
+        return to_json_str_compact(condensed), to_json_str_compact(events_data)
 
     # input_type == "events"
     assert isinstance(input, Sequence)
     events = cast(Sequence[Event], input)
     condensed_events, events_data = condense_events(events)
-    return to_json_compact(condensed_events), to_json_compact(events_data)
+    return to_json_str_compact(condensed_events), to_json_str_compact(events_data)

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -2,7 +2,7 @@ import json
 from logging import getLogger
 from typing import Any, Literal, Sequence, cast
 
-from inspect_ai._util.json import jsonable_python, to_json_str_safe
+from inspect_ai._util.json import jsonable_python
 from inspect_ai.event._event import Event
 from inspect_ai.log import condense_events
 from inspect_ai.model import ModelUsage
@@ -11,6 +11,7 @@ from shortuuid import uuid
 
 from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
 from inspect_scout._transcript.types import Transcript
+from inspect_scout._util._json import to_json_compact
 
 logger = getLogger(__name__)
 
@@ -138,7 +139,7 @@ class ResultReport(BaseModel):
                     columns["value_type"] = "null"
 
             else:
-                columns["value"] = to_json_str_safe(self.result.value)
+                columns["value"] = to_json_compact(self.result.value)
                 if self.result.type is not None:
                     columns["value_type"] = self.result.type
                 else:
@@ -147,12 +148,12 @@ class ResultReport(BaseModel):
                     )
             columns["answer"] = self.result.answer
             columns["explanation"] = self.result.explanation
-            columns["metadata"] = to_json_str_safe(self.result.metadata or {})
+            columns["metadata"] = to_json_compact(self.result.metadata or {})
 
             # references
             def references_json(type: str) -> str:
                 assert self.result
-                return to_json_str_safe(
+                return to_json_compact(
                     [ref for ref in self.result.references if ref.type == type]
                 )
 
@@ -170,9 +171,9 @@ class ResultReport(BaseModel):
             columns["value_type"] = "null"
             columns["answer"] = None
             columns["explanation"] = None
-            columns["metadata"] = to_json_str_safe({})
-            columns["message_references"] = to_json_str_safe([])
-            columns["event_references"] = to_json_str_safe([])
+            columns["metadata"] = to_json_compact({})
+            columns["message_references"] = to_json_compact([])
+            columns["event_references"] = to_json_compact([])
             columns["scan_error"] = self.error.error
             columns["scan_error_traceback"] = self.error.traceback
             columns["scan_error_type"] = "refusal"
@@ -183,8 +184,8 @@ class ResultReport(BaseModel):
 
         # report validation
         if self.validation is not None:
-            columns["validation_target"] = to_json_str_safe(self.validation.target)
-            columns["validation_result"] = to_json_str_safe(self.validation.valid)
+            columns["validation_target"] = to_json_compact(self.validation.target)
+            columns["validation_result"] = to_json_compact(self.validation.valid)
             columns["validation_predicate"] = self.validation.predicate
             columns["validation_split"] = self.validation.split
             if isinstance(self.validation.valid, dict):
@@ -203,8 +204,8 @@ class ResultReport(BaseModel):
             total_tokens += usage.total_tokens
 
         columns["scan_total_tokens"] = total_tokens
-        columns["scan_model_usage"] = to_json_str_safe(self.model_usage)
-        columns["scan_events"] = to_json_str_safe(self.events)
+        columns["scan_model_usage"] = to_json_compact(self.model_usage)
+        columns["scan_events"] = to_json_compact(self.events)
 
         return columns
 
@@ -221,16 +222,16 @@ def _serialize_input(
         (input_json, input_data_json | None)
     """
     if not pool_dedup or input_type not in ("transcript", "events"):
-        return to_json_str_safe(input), None
+        return to_json_compact(input), None
 
     if input_type == "transcript":
         assert isinstance(input, Transcript)
         condensed_events, events_data = condense_events(input.events)
         condensed = input.model_copy(update={"events": condensed_events})
-        return to_json_str_safe(condensed), to_json_str_safe(events_data)
+        return to_json_compact(condensed), to_json_compact(events_data)
 
     # input_type == "events"
     assert isinstance(input, Sequence)
     events = cast(Sequence[Event], input)
     condensed_events, events_data = condense_events(events)
-    return to_json_str_safe(condensed_events), to_json_str_safe(events_data)
+    return to_json_compact(condensed_events), to_json_compact(events_data)

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -16,7 +16,6 @@ import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import filesystem
-from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.path import pretty_path
 from inspect_ai.log import condense_events, expand_events
 from inspect_ai.util import trace_action, trace_message
@@ -28,6 +27,7 @@ from inspect_scout._display._display import display
 from inspect_scout._scanspec import ScanTranscripts
 from inspect_scout._transcript.database.factory import transcripts_from_db_snapshot
 from inspect_scout._transcript.util import LazyJSONDict
+from inspect_scout._util._json import to_json_compact
 from inspect_scout._util.filesystem import ensure_filesystem_dependencies
 
 from ...._query import Query
@@ -1042,8 +1042,10 @@ class ParquetTranscriptsDB(TranscriptsDB):
 
         if pool_dedup:
             condensed_events, events_data = condense_events(transcript.events)
-            events_json = to_json_str_safe(condensed_events)
-            events_data_json = to_json_str_safe(events_data)
+            # Compact JSON to reduce storage: pretty-printing significantly
+            # increases the size of structures like range-encoded input_refs.
+            events_json = to_json_compact(condensed_events)
+            events_data_json = to_json_compact(events_data)
         else:
             events_json = json.dumps(
                 [event.model_dump() for event in transcript.events]

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -27,7 +27,7 @@ from inspect_scout._display._display import display
 from inspect_scout._scanspec import ScanTranscripts
 from inspect_scout._transcript.database.factory import transcripts_from_db_snapshot
 from inspect_scout._transcript.util import LazyJSONDict
-from inspect_scout._util._json import to_json_compact
+from inspect_scout._util._json import to_json_str_compact
 from inspect_scout._util.filesystem import ensure_filesystem_dependencies
 
 from ...._query import Query
@@ -1044,8 +1044,8 @@ class ParquetTranscriptsDB(TranscriptsDB):
             condensed_events, events_data = condense_events(transcript.events)
             # Compact JSON to reduce storage: pretty-printing significantly
             # increases the size of structures like range-encoded input_refs.
-            events_json = to_json_compact(condensed_events)
-            events_data_json = to_json_compact(events_data)
+            events_json = to_json_str_compact(condensed_events)
+            events_data_json = to_json_str_compact(events_data)
         else:
             events_json = json.dumps(
                 [event.model_dump() for event in transcript.events]

--- a/src/inspect_scout/_util/_json.py
+++ b/src/inspect_scout/_util/_json.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from inspect_ai._util.json import to_json_safe
+
+
+def to_json_compact(x: Any) -> str:
+    """Serialize to JSON without pretty-print whitespace.
+
+    Wraps ``to_json_safe`` (surrogate-safe) with ``indent=None``. Use for
+    machine-read payloads such as stored parquet columns and bytes streamed to
+    the viewer, where the default ``indent=2`` only bloats the representation
+    without benefit since the data is never human-consumed.
+
+    In extreme cases, this reduces serialized JSON from 700 MiB -> 200 MiB.
+    """
+    return to_json_safe(x, indent=None).decode("utf-8")

--- a/src/inspect_scout/_util/_json.py
+++ b/src/inspect_scout/_util/_json.py
@@ -3,13 +3,13 @@ from typing import Any
 from inspect_ai._util.json import to_json_safe
 
 
-def to_json_compact(x: Any) -> str:
+def to_json_str_compact(x: Any) -> str:
     """Serialize to JSON without pretty-print whitespace.
 
-    Wraps ``to_json_safe`` (surrogate-safe) with ``indent=None``. Use for
-    machine-read payloads such as stored parquet columns and bytes streamed to
-    the viewer, where the default ``indent=2`` only bloats the representation
-    without benefit since the data is never human-consumed.
+    Wraps ``to_json_safe`` (surrogate-safe) with ``indent=None`` and decodes to
+    ``str``. Use for machine-read payloads such as stored parquet  columns and
+    bytes streamed to the viewer, where the default ``indent=2`` only bloats the
+    representation without benefit since the data is never human-consumed.
 
     In extreme cases, this reduces serialized JSON from 700 MiB -> 200 MiB.
     """

--- a/tests/test_event_expansion.py
+++ b/tests/test_event_expansion.py
@@ -79,6 +79,49 @@ def test_events_expanded_in_results_df() -> None:
         assert not _has_unresolved_refs(events)
 
 
+def test_results_input_columns_are_compact_json() -> None:
+    """Pooled input/input_data columns are stored as compact JSON on disk.
+
+    Regression guard: the results serializer must use indent=None so that the
+    on-disk parquet (and the bytes streamed to the viewer) are not bloated by
+    pretty-print whitespace. These columns are machine-read via json.loads /
+    expand_events, never human-consumed. Reads the raw parquet rather than
+    scan_results_df, which expands and drops input_data before returning.
+    """
+    import pyarrow.parquet as pq
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[events_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+            max_processes=1,
+        )
+
+        parquet_path = Path(status.location) / "events_scanner.parquet"
+        assert parquet_path.exists()
+
+        # ParquetFile.read() avoids dataset partition inference: status.location
+        # is a scan_id=... directory, which read_table would treat as a
+        # partition column conflicting with the in-file scan_id column.
+        table = pq.ParquetFile(str(parquet_path)).read()
+        input_json = table.column("input").to_pylist()[0]
+        input_data_json = table.column("input_data").to_pylist()[0]
+
+        # Pooled events path populates both columns.
+        assert input_json
+        assert input_data_json
+
+        # Compact serialization: no pretty-print whitespace (indent=2 adds newlines).
+        assert "\n" not in input_json
+        assert "\n" not in input_data_json
+
+        # Still valid JSON that parses back.
+        assert isinstance(json.loads(input_json), list)
+        assert isinstance(json.loads(input_data_json), dict)
+
+
 def test_transcript_input_expanded_in_results_df() -> None:
     """Transcript-type inputs have events expanded and input_data dropped."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/transcript/test_parquet_db.py
+++ b/tests/transcript/test_parquet_db.py
@@ -1997,6 +1997,45 @@ async def test_pool_dedup_read_content_equality(test_location: Path) -> None:
         assert e_np.call.request["messages"] == e_p.call.request["messages"]
 
 
+@pytest.mark.asyncio
+async def test_pool_dedup_events_json_is_compact(test_location: Path) -> None:
+    """Pool-dedup events/events_data columns are stored as compact JSON.
+
+    Regression guard: the serializer must use indent=None so that on-disk
+    (and the streamed-to-viewer) representation is not bloated by pretty-print
+    whitespace. Indented JSON would contain newlines.
+    """
+    import pyarrow.parquet as pq
+
+    db = ParquetTranscriptsDB(str(test_location))
+    await db.connect()
+    try:
+        await db.insert([_transcript_with_repeated_inputs()])
+    finally:
+        await db.disconnect()
+
+    parquet_files = list(test_location.glob(PARQUET_TRANSCRIPTS_GLOB))
+    assert len(parquet_files) == 1
+
+    table = pq.read_table(str(parquet_files[0]))
+    events_json = table.column("events").to_pylist()[0]
+    events_data_json = table.column("events_data").to_pylist()[0]
+
+    # Compact serialization: no pretty-print whitespace (indent=2 adds newlines).
+    assert isinstance(events_json, str)
+    assert isinstance(events_data_json, str)
+    assert "\n" not in events_json
+    assert "\n" not in events_data_json
+
+    events = json.loads(events_json)
+    events_data = json.loads(events_data_json)
+
+    # Pooling actually populated both columns for this poolable fixture
+    # (not just an empty "[]"/"{}" that would still be truthy as a string).
+    assert isinstance(events, list) and events
+    assert isinstance(events_data, dict) and events_data
+
+
 # --- Phase 3: read_messages_events() pool resolution tests ---
 
 


### PR DESCRIPTION
## Summary

The transcript and scan-result write paths serialized condensed events and pooled inputs with the default `indent=2`. The pretty-print whitespace bloats both the on-disk parquet columns and the bytes streamed to the viewer. These columns are machine-read (`json.loads` / `expand_events`) and as far as I'm aware, never human-consumed.

This switches them to compact JSON (`indent=None`) via a shared `to_json_compact` helper.

## Motivation

A large transcript which I've been working with has an `events` column which is ~700 MiB. This is largely because the model events' `input_refs` are is made up of many non-contiguous event index ranges. This occupies more than 95% of the file. Granted, when written to disk as a Parquet file, this will be heavily compressed. But when streamed to the viewer (`scout view`), it exceeds the [existing 350 MiB limit](https://github.com/meridianlabs-ai/inspect_scout/blob/c6ac88d612bfdb1d196170beabb6afe332a2c074/src/inspect_scout/_view/_api_v2_transcripts.py#L35). With `indent=None` the 700 MiB becomes 200 MiB.

## Downsides

If the files or parquet columns are human-read (e.g. for debugging), it will be harder to follow. But a simple `jq . events.json > events-out.json` will restore the whitespace.