### PR TITLE
UX: `scout import` when no transcripts are imported

### DIFF
--- a/design/scout-import.md
+++ b/design/scout-import.md
@@ -48,7 +48,7 @@ scout import claude_code --dry-run --limit 5
 | `--sources` | | List available sources and their parameters | False |
 | `--dry-run` | | Fetch and display summary without writing | False |
 
-The import command always prints the `scout view` command after a successful import.
+After an import, the command prints the scout view command for the transcripts database. If the source produced no transcripts, it instead prints a notice ("No transcripts were imported") and skips the scout view hint.
 
 ## Parameter Parsing (`-P`)
 

--- a/src/inspect_scout/_cli/import_command.py
+++ b/src/inspect_scout/_cli/import_command.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, AsyncIterator, Callable
 
 import click
 import yaml
@@ -238,12 +238,29 @@ async def _run_import(
 ) -> None:
     """Execute the import: call source function and write to database."""
     from inspect_scout._transcript.database.factory import transcripts_db
+    from inspect_scout._transcript.types import Transcript
 
     d = display()
     d.print(f"\nImporting from [bold]{source_name}[/bold]...\n", markup=True)
 
+    # Count transcripts as they stream through to the database.
+    # Note that the DB does not overwrite existing items, so this count
+    # represents the number of items we processed, not necessarily the number
+    # actually written.
+    count = 0
+
+    async def counted() -> AsyncIterator[Transcript]:
+        nonlocal count
+        async for transcript in source_fn(**kwargs):
+            count += 1
+            yield transcript
+
     async with transcripts_db(transcripts_dir) as db:
-        await db.insert(source_fn(**kwargs))
+        await db.insert(counted())
+
+    if count == 0:
+        d.print("\nNo transcripts were imported (the source produced none).\n")
+        return
 
     d.print("\nImport complete. To view transcripts:\n")
     d.print(f"  scout view -T {transcripts_dir}\n")

--- a/tests/cli/test_import_output.py
+++ b/tests/cli/test_import_output.py
@@ -1,0 +1,69 @@
+"""Tests for import command completion messaging in import_command."""
+
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable
+
+import pytest
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_scout._cli.import_command import _run_import
+from inspect_scout._transcript.types import Transcript
+
+
+def _sample_transcript(id: str) -> Transcript:
+    return Transcript(
+        transcript_id=id,
+        source_type="test",
+        source_id="source-001",
+        source_uri=f"test://{id}",
+        metadata={},
+        messages=[ChatMessageUser(content="Test message")],
+        events=[],
+    )
+
+
+def _source_with(
+    transcripts: list[Transcript],
+) -> Callable[..., AsyncIterator[Transcript]]:
+    """Create a source function yielding the given transcripts."""
+
+    async def source(**kwargs: Any) -> AsyncIterator[Transcript]:
+        for transcript in transcripts:
+            yield transcript
+
+    return source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transcripts", "expected", "not_expected"),
+    [
+        pytest.param(
+            [],
+            ["No transcripts were imported"],
+            ["scout view"],
+            id="empty_source",
+        ),
+        pytest.param(
+            [_sample_transcript("t-001")],
+            ["Import complete", "scout view"],
+            ["No transcripts were imported"],
+            id="non_empty_source",
+        ),
+    ],
+)
+async def test_run_import_completion_message(
+    transcripts: list[Transcript],
+    expected: list[str],
+    not_expected: list[str],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    transcripts_dir = str(tmp_path / "transcripts")
+
+    await _run_import(_source_with(transcripts), "test-source", {}, transcripts_dir)
+
+    output = capsys.readouterr().out
+    for fragment in expected:
+        assert fragment in output
+    for fragment in not_expected:
+        assert fragment not in output


### PR DESCRIPTION
## Summary

When I try to import some transcript(s) via e.g. `scout import claude_code ...` which doesn't result in any transcripts being imported (e.g. typo in path/session ID, doesn't exist), the CLI doesn't produce any error or indication that it didn't import anything.

## Old behaviour

`scout import` previously printed "Import complete. To view transcripts:" even when the source yielded zero transcripts, which was misleading (to me, anyway).

## New behaviour

If nothing was imported, it now prints "No transcripts were imported (the source produced none)." and skips the `scout view` hint.

## Notes

- Transcripts are counted by a small wrapper generator as they stream through to `db.insert`, so the bounded-memory streaming insert path is preserved (no buffering of the full import in memory).
- I do not print "{count} imported" - the DB skips existing transcripts, so I wouldn't want to mislead a user.

## Future improvements

It would be nice to have something like "Import complete. Read 6 transcripts. Inserted 2 into database. Skipped 4 (already existed).". Out of scope of this PR.