### PR TITLE
Add `/transcripts/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,10 +212,11 @@ __marimo__/
 # Dynamic version
 src/inspect_scout/_version.py
 
-# Inspect logs and scans
+# Inspect logs, scans and transcripts
 /logs/
 /logs-*/
 /scans/
+/transcripts/
 
 # Scout local configuration (developer-only, not checked in)
 scout.local.yaml


### PR DESCRIPTION
In the same way that Inspect [has](https://github.com/UKGovernmentBEIS/inspect_ai/blob/d5c7dce05712606cf44a02a53912ca586977e697/.gitignore#L172) `/logs/` in its `.gitignore`, I thought we should ignore our default transcripts output dir `/transcripts/`. It doesn't belong in source control and it gets created by default for any `scout import` command which doesn't specify a target folder.