### PR TITLE
Fix MyPy for `inspect_ai@main`: `ConcurrencySemaphore` protocol

### DIFF
--- a/src/inspect_scout/_concurrency/_mp_registry.py
+++ b/src/inspect_scout/_concurrency/_mp_registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterable
+from logging import getLogger
 from multiprocessing.managers import DictProxy, SyncManager
 from multiprocessing.queues import Queue
 from threading import Condition
@@ -28,6 +29,29 @@ from ._mp_semaphore import MPConcurrencySemaphore, PicklableMPSemaphore
 # and won't be evaluated at runtime
 if sys.version_info < (3, 13):
     DictProxy = DictProxy
+
+logger = getLogger(__name__)
+
+
+def _warn_unsupported_features(
+    name: str, adaptive: AdaptiveConcurrency | None, resizable: bool
+) -> None:
+    """Warn when a semaphore is requested with features the MP strategy lacks.
+
+    Cross-process semaphores have a fixed limit: neither adaptive scaling nor
+    live resizing is implemented, so such requests degrade to a fixed-limit
+    semaphore.
+    """
+    if adaptive is not None:
+        logger.warning(
+            f"Semaphore '{name}' requested adaptive concurrency, which is not "
+            "supported in multi-process scans; using a fixed limit instead."
+        )
+    if resizable:
+        logger.warning(
+            f"Semaphore '{name}' requested a resizable limit, which is not "
+            "supported in multi-process scans; using a fixed limit instead."
+        )
 
 
 class ParentSemaphoreRegistry(ConcurrencySemaphoreRegistry):
@@ -92,8 +116,10 @@ class ParentSemaphoreRegistry(ConcurrencySemaphoreRegistry):
             concurrency: Maximum concurrent holders
             key: Unique storage key (defaults to name if None)
             visible: Whether visible in status display
-            adaptive: Adaptive concurrency (if any)
-            resizable: Live-resizable semaphore (not supported cross-process; ignored)
+            adaptive: Adaptive concurrency (not supported cross-process;
+                warns and uses a fixed limit)
+            resizable: Live-resizable semaphore (not supported cross-process;
+                warns and uses a fixed limit)
 
         Returns:
             Wrapped semaphore instance
@@ -102,6 +128,8 @@ class ParentSemaphoreRegistry(ConcurrencySemaphoreRegistry):
         async with self._lock:
             if k in self._semaphores:
                 return self._semaphores[k]
+
+            _warn_unsupported_features(name, adaptive, resizable)
 
             # Create ManagerSemaphore in shared registry
             await self._create_semaphore(name, concurrency)
@@ -191,8 +219,10 @@ class ChildSemaphoreRegistry(ConcurrencySemaphoreRegistry):
             concurrency: Maximum concurrent holders
             key: Unique storage key (defaults to name if None)
             visible: Whether visible in status display
-            adaptive: Adaptive concurrency (if any)
-            resizable: Live-resizable semaphore (not supported cross-process; ignored)
+            adaptive: Adaptive concurrency (not supported cross-process;
+                warns and uses a fixed limit)
+            resizable: Live-resizable semaphore (not supported cross-process;
+                warns and uses a fixed limit)
 
         Returns:
             Wrapped semaphore instance
@@ -201,6 +231,8 @@ class ChildSemaphoreRegistry(ConcurrencySemaphoreRegistry):
         async with self._lock:
             if k in self._wrappers:
                 return self._wrappers[k]
+
+            _warn_unsupported_features(name, adaptive, resizable)
 
             # Request via IPC
             sem = await self._request_semaphore(name, concurrency, visible)

--- a/src/inspect_scout/_concurrency/_mp_registry.py
+++ b/src/inspect_scout/_concurrency/_mp_registry.py
@@ -80,6 +80,7 @@ class ParentSemaphoreRegistry(ConcurrencySemaphoreRegistry):
         key: str | None,
         visible: bool,
         adaptive: AdaptiveConcurrency | None = None,
+        resizable: bool = False,
     ) -> ConcurrencySemaphore:
         """Get or create a cross-process semaphore.
 
@@ -92,6 +93,7 @@ class ParentSemaphoreRegistry(ConcurrencySemaphoreRegistry):
             key: Unique storage key (defaults to name if None)
             visible: Whether visible in status display
             adaptive: Adaptive concurrency (if any)
+            resizable: Live-resizable semaphore (not supported cross-process; ignored)
 
         Returns:
             Wrapped semaphore instance
@@ -176,6 +178,7 @@ class ChildSemaphoreRegistry(ConcurrencySemaphoreRegistry):
         key: str | None,
         visible: bool,
         adaptive: AdaptiveConcurrency | None = None,
+        resizable: bool = False,
     ) -> ConcurrencySemaphore:
         """Get or create a cross-process semaphore via IPC.
 
@@ -189,6 +192,7 @@ class ChildSemaphoreRegistry(ConcurrencySemaphoreRegistry):
             key: Unique storage key (defaults to name if None)
             visible: Whether visible in status display
             adaptive: Adaptive concurrency (if any)
+            resizable: Live-resizable semaphore (not supported cross-process; ignored)
 
         Returns:
             Wrapped semaphore instance

--- a/src/inspect_scout/_concurrency/_mp_semaphore.py
+++ b/src/inspect_scout/_concurrency/_mp_semaphore.py
@@ -4,7 +4,6 @@ from types import TracebackType
 from typing import Any
 
 import anyio
-from inspect_ai.util._concurrency import ConcurrencySemaphore
 
 
 class PicklableMPSemaphore:
@@ -45,8 +44,13 @@ class PicklableMPSemaphore:
         return self._value_proxy.value
 
 
-class MPConcurrencySemaphore(ConcurrencySemaphore, AbstractAsyncContextManager[None]):
+class MPConcurrencySemaphore(AbstractAsyncContextManager[None]):
     """ConcurrencySemaphore implementation wrapping MPSemaphoreLike.
+
+    Satisfies the `ConcurrencySemaphore` protocol structurally rather than by
+    inheritance: the protocol declares `concurrency`/`value`/`in_use` as
+    properties, and inheriting those descriptors would block plain attribute
+    assignment in `__init__`.
 
     Since MPSemaphoreLike is synchronous, this class runs acquire/release operations
     in threads to avoid blocking the async event loop. The class itself serves as the
@@ -76,3 +80,7 @@ class MPConcurrencySemaphore(ConcurrencySemaphore, AbstractAsyncContextManager[N
     @property
     def value(self) -> int:
         return self._sem.get_value()
+
+    @property
+    def in_use(self) -> int:
+        return self.concurrency - self._sem.get_value()

--- a/tests/concurrency/test_mp_registry.py
+++ b/tests/concurrency/test_mp_registry.py
@@ -1,0 +1,64 @@
+"""Tests for cross-process semaphore registry behavior."""
+
+import logging
+import multiprocessing
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from inspect_ai.util import AdaptiveConcurrency
+from inspect_scout._concurrency._mp_registry import ParentSemaphoreRegistry
+
+REGISTRY_LOGGER = "inspect_scout._concurrency._mp_registry"
+
+
+@pytest_asyncio.fixture
+async def parent_registry() -> AsyncIterator[ParentSemaphoreRegistry]:
+    manager = multiprocessing.get_context("spawn").Manager()
+    try:
+        yield ParentSemaphoreRegistry(manager)
+    finally:
+        manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_warns_on_unsupported_resizable(
+    parent_registry: ParentSemaphoreRegistry, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=REGISTRY_LOGGER):
+        sem = await parent_registry.get_or_create(
+            "resizable-sem", 2, None, True, resizable=True
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "resizable" in warnings[0].getMessage()
+    # degrades to a working fixed-limit semaphore
+    assert sem.concurrency == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_warns_on_unsupported_adaptive(
+    parent_registry: ParentSemaphoreRegistry, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=REGISTRY_LOGGER):
+        sem = await parent_registry.get_or_create(
+            "adaptive-sem", 2, None, True, adaptive=AdaptiveConcurrency()
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "adaptive" in warnings[0].getMessage()
+    assert sem.concurrency == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_no_warning_for_fixed_semaphore(
+    parent_registry: ParentSemaphoreRegistry, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=REGISTRY_LOGGER):
+        # created, then returned from cache: neither call should warn
+        await parent_registry.get_or_create("fixed-sem", 2, None, True)
+        await parent_registry.get_or_create("fixed-sem", 2, None, True)
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]

--- a/tests/concurrency/test_mp_registry.py
+++ b/tests/concurrency/test_mp_registry.py
@@ -29,6 +29,10 @@ async def test_get_or_create_warns_on_unsupported_resizable(
         sem = await parent_registry.get_or_create(
             "resizable-sem", 2, None, True, resizable=True
         )
+        # cached retrieval must not warn again
+        await parent_registry.get_or_create(
+            "resizable-sem", 2, None, True, resizable=True
+        )
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 1
@@ -57,8 +61,6 @@ async def test_get_or_create_no_warning_for_fixed_semaphore(
     parent_registry: ParentSemaphoreRegistry, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING, logger=REGISTRY_LOGGER):
-        # created, then returned from cache: neither call should warn
-        await parent_registry.get_or_create("fixed-sem", 2, None, True)
         await parent_registry.get_or_create("fixed-sem", 2, None, True)
 
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]


### PR DESCRIPTION
## Problem

[UKGovernmentBEIS/inspect_ai#4410](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4410) (merged 2026-07-06 14:11 UTC) changed the `ConcurrencySemaphore` protocol:

- `concurrency` is now a read-only property (was a plain mutable attribute)
- a new required `in_use` property (exact count of current holders)
- `ConcurrencySemaphoreRegistry.get_or_create` gained a `resizable: bool = False` parameter

CI in this repo now [fails](https://github.com/meridianlabs-ai/inspect_scout/actions/runs/28803473871/job/85412748559) for MyPy.

Note that we use `inspect_ai` from `main` in CI (but pyproject.toml installs from PyPI).

## Fix

- `MPConcurrencySemaphore` now satisfies the protocol **structurally** instead of nominally inheriting it. The runtime failure was caused by inheriting the protocol's new property descriptors, which block plain attribute assignment in `__init__`; the upstream protocol docstring explicitly notes a plain attribute satisfies the read-only `concurrency` member. The registries' `ConcurrencySemaphore` return types keep the structural conformance checked by mypy.
- Added the `in_use` property (`concurrency - value`, correct for a fixed-limit semaphore per the upstream docstring).
- Both registries accept (and ignore) `resizable`, matching the existing treatment of `adaptive` — live resizing isn't supported cross-process. A warning is emitted if either of these is set.

## Verification

- mypy passes against **both** inspect_ai 0.3.244 (the declared minimum pin) and inspect_ai git main (verified locally by overlaying the new `_concurrency.py` for type-checking; the 5 CI errors reproduced exactly before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)