### PR TITLE
Fix mypy no-any-return errors and sync OpenAPI schema for inspect_ai reasoning_mode

### DIFF
--- a/src/inspect_scout/_llm_scanner/answer.py
+++ b/src/inspect_scout/_llm_scanner/answer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, Literal, Protocol, Sequence, runtime_checkable
+from typing import Any, Callable, Literal, Protocol, Sequence, runtime_checkable
 
 from inspect_ai._util.pattern import ANSWER_PATTERN_WORD
 from inspect_ai._util.text import (
@@ -30,6 +30,13 @@ from .prompt import (
     STR_ANSWER_FORMAT,
     STR_ANSWER_PROMPT,
 )
+
+
+def _render_template(source: str, **variables: Any) -> str:
+    # Template.__new__ is annotated as returning t.Any (a jinja2 workaround
+    # for its sphinx build), so annotate the instance to keep render() -> str.
+    template: Template = Template(source)
+    return template.render(**variables)
 
 
 def _search_last(pattern: str, string: str, flags: int = 0) -> re.Match[str] | None:
@@ -248,8 +255,8 @@ class _LabelsAnswer(Answer):
             if self.multi_classification
             else LABELS_ANSWER_FORMAT_SINGLE
         )
-        return Template(format_template).render(
-            letters=letters, formatted_choices=formatted_choices
+        return _render_template(
+            format_template, letters=letters, formatted_choices=formatted_choices
         )
 
     def result_for_answer(
@@ -408,14 +415,14 @@ class _StructuredAnswer(Answer):
 
     @property
     def prompt(self) -> str:
-        return Template(self.answer.answer_prompt).render(
-            answer_tool=self.answer.answer_tool
+        return _render_template(
+            self.answer.answer_prompt, answer_tool=self.answer.answer_tool
         )
 
     @property
     def format(self) -> str:
-        return Template(self.answer.answer_format).render(
-            answer_tool=self.answer.answer_tool
+        return _render_template(
+            self.answer.answer_format, answer_tool=self.answer.answer_tool
         )
 
     def result_for_answer(

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-CZa1Uf8p.css
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-CZa1Uf8p.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15b56be86c6edbbd46bac384b26470a4f1b18a8cdae41662657b27ca39037e8f
-size 14646

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-D8JDK-oK.css
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-D8JDK-oK.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:958d98c3ae7b290bbc445e78d0ba9b9fee549c6577d8d3d81671002d29391e33
+size 15657

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-DYU6ZYpc.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-DYU6ZYpc.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e23703025ea1526b7eaa380e151cbb795f28d8ca7e153d5b04fdc4d7c5a7c013
+size 179095

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-Z6OFX-oS.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-Z6OFX-oS.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d86825d47765a7898e6de543ced5209e073fd3e193820dc527f7c28736a669bb
-size 177046

--- a/src/inspect_scout/_view/dist/assets/index-B3s32d30.css
+++ b/src/inspect_scout/_view/dist/assets/index-B3s32d30.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929b55fd11af24d5224e4de51e2cebb1cf6054329ec9830c69138904f96e1dfa
+size 530815

--- a/src/inspect_scout/_view/dist/assets/index-DNP7wM0L.css
+++ b/src/inspect_scout/_view/dist/assets/index-DNP7wM0L.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6af3e22edea1e1b78a744f00538a0c2ff8a19b1004956efaf33ff8cb95695b85
-size 529722

--- a/src/inspect_scout/_view/dist/assets/index-IpVmoq4C.js
+++ b/src/inspect_scout/_view/dist/assets/index-IpVmoq4C.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:204b9191560bde61e1207b33529c17eae07748e1c21a3185ef95b0e67206d9ac
-size 2755817

--- a/src/inspect_scout/_view/dist/assets/index-u8FytxgA.js
+++ b/src/inspect_scout/_view/dist/assets/index-u8FytxgA.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb68ae2a606abcb05934a2bec33b2dab656e4033b958de39bb25149fee17bb66
+size 2762420

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CD07wM5G.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CD07wM5G.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e896ceff16c1e3b28766be8840d0bd03dd402bda1e99d98c3adbb47cf8b0c6d0
-size 22573

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-kYMOFspM.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-kYMOFspM.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac9c16e395b2839b27b7e6fcc70ad25933e154fb89a838e65da63e212df932d4
+size 22569

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-S4QiO_Ju.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-S4QiO_Ju.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81809c2b70a170c24c818ed3a8e61314e0f44de6dade5d8422653624b56a6fa9
-size 2233922

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-v94pi3MF.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-v94pi3MF.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37586d95b9b9edb9cf32cdd7c8f9f79fc389abe98709e818be0b2f3bc69b806
+size 2233836

--- a/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-Dhskupmn.js
+++ b/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-Dhskupmn.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bf147fa24b0df3350a7fedf04f159c48a23db1218d0edf69700995777c78eef
+size 27971

--- a/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-PjiiYgMQ.js
+++ b/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-PjiiYgMQ.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60ac522c0397c3cbe81ebe4646d8298e8406916986d0816298ed16944d9178f2
-size 27972

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e990ba15b9fc08a7812085e2b7522bd007d1dc28ff25a55b7b44513e4e11f7e1
-size 3721
+oid sha256:cc5858e00ac08c89ed8cfb0bcc5513367da2e48dace62ed0cd0875f3171d7f62
+size 3719

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -3001,6 +3001,21 @@
             ],
             "title": "Reasoning History"
           },
+          "reasoning_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "standard",
+                  "pro"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Mode"
+          },
           "reasoning_summary": {
             "anyOf": [
               {
@@ -3489,6 +3504,21 @@
               }
             ],
             "title": "Reasoning History"
+          },
+          "reasoning_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "standard",
+                  "pro"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Mode"
           },
           "reasoning_summary": {
             "anyOf": [


### PR DESCRIPTION
Fixes two breaks on main:

**mypy `no-any-return` errors in `_llm_scanner/answer.py`**

mypy 2.2.0 now propagates the return annotation of `jinja2.Template.__new__` — which jinja2 deliberately types as `t.Any` to work around a sphinx build issue — onto the constructed instance, so `Template(...).render(...)` was typed as returning `Any`. Added a `_render_template(source, **variables) -> str` helper that annotates the instance as `Template` (restoring `render() -> str`) and routed the three call sites through it.

`mypy src examples tests` against `inspect_ai@main`: 0 errors in 428 files.

**OpenAPI schema drift**

`inspect_ai@main` added `reasoning_mode: "standard" | "pro"` to `GenerateConfig`. This PR:
- re-exports `openapi.json` (`scripts/export_openapi_schema.py`)
- bumps the ts-mono submodule to `9ebe230` (meridianlabs-ai/ts-mono#412, now on ts-mono main), which contains the matching regenerated `generated.ts`

Verified locally that `pnpm --filter scout types:generate` at the new pointer produces no diff, so `check-schema-and-types` and `submodule-on-main` should both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEmdhb9t9GyvYJBVcUdstv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEmdhb9t9GyvYJBVcUdstv)_