### PR TITLE
ci: guard against releasing with a git-ref dependency

### DIFF
--- a/.github/workflows/release-dep-guard.yml
+++ b/.github/workflows/release-dep-guard.yml
@@ -1,0 +1,42 @@
+name: Release dependency guard
+
+# Block *releases* that still point a runtime dependency at a git ref (e.g.
+# `inspect_ai @ git+...@main`). Dev PRs may legitimately use inspect_ai's main
+# branch, so this only gates the Release Please release PR — a package must be
+# pinned to a *released* version before it ships (PyPI rejects direct-reference
+# deps, and a git ref is not reproducible).
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-git-deps:
+    # Only gate the Release Please release PR.
+    if: ${{ github.head_ref == 'release-please--branches--main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Fail if any dependency points at a git ref
+        run: |
+          python3 - <<'PY'
+          import tomllib, sys
+          proj = tomllib.load(open("pyproject.toml", "rb")).get("project", {})
+          deps = list(proj.get("dependencies", []))
+          for extra in proj.get("optional-dependencies", {}).values():
+              deps += extra
+          bad = [d for d in deps if "git+" in d or "@ git" in d]
+          if bad:
+              print("::error::Release blocked — pin these to a released version before releasing "
+                    "(a published package cannot depend on a moving git ref):")
+              for b in bad:
+                  print(f"  - {b}")
+              sys.exit(1)
+          print("OK — no git-ref dependencies in project metadata")
+          PY


### PR DESCRIPTION
Fast safety net for the inspect_ai-dependency issue: **never release scout while `pyproject.toml` points a dependency at a git ref** (e.g. `inspect_ai @ git+…@main`, which scout's `dependencies` line is toggled to during dev when it needs unreleased inspect_ai).

## What it does
A check that runs **only on the Release Please release PR** (`head == release-please--branches--main`) and **fails if any `[project]` (or optional) dependency contains a git ref**. Dev PRs are unaffected — they can point at inspect_ai `main` freely; we only block the *release*.

Rationale: PyPI rejects direct-reference deps, and a git ref isn't reproducible — so a release in that state would fail (or ship something unpinnable).

## Note — scout is in this state right now
`main` currently has `inspect-ai @ git+…/inspect_ai@main`, so once this merges, the current/next `0.4.44` release PR will show this check **red** — correctly blocking the release until the dependency is pinned to a released inspect_ai.

## To hard-block (recommended)
Add **`no-git-deps`** to the `main` ruleset's **required status checks** so a red guard actually prevents merging the release PR (otherwise it's an advisory red check the code-owner reviewer must heed).

## Follow-up (per our plan)
Next PR: **auto-pin** inspect_ai to the latest shipped version on the release PR + **validate scout against that shipped version** (so it breaks when scout needs an unreleased inspect_ai). This guard is the fast backstop; the auto-pin is the ergonomic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)