### PR TITLE
ci: auto-pin inspect_ai to the shipped release on the release PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          # Track inspect_ai main everywhere EXCEPT the release PR, where we
+          # validate against the pinned/shipped version pulled in via .[dev] below.
+          if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
+            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          fi
           python -m pip install .[dev]
       - name: Run mypy
         run: |
@@ -73,7 +77,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          # Track inspect_ai main everywhere EXCEPT the release PR, where we
+          # validate against the pinned/shipped version pulled in via .[dev] below.
+          if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
+            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          fi
           python -m pip install .[dev]
       - name: Run tests
         run: pytest
@@ -92,7 +100,11 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          # Track inspect_ai main everywhere EXCEPT the release PR, where we
+          # validate against the pinned/shipped version pulled in via . below.
+          if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
+            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          fi
           python -m pip install build
       - name: Build package
         run: python -m build
@@ -122,7 +134,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          # Track inspect_ai main everywhere EXCEPT the release PR, where we
+          # validate against the pinned/shipped version pulled in via . below.
+          if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
+            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+          fi
           python -m pip install .
 
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release-pin-deps.yml
+++ b/.github/workflows/release-pin-deps.yml
@@ -1,0 +1,74 @@
+name: Pin inspect_ai for release
+
+# On the Release Please release PR, rewrite the `inspect_ai` dependency from a
+# moving git ref (`inspect-ai @ git+...@main`) to the currently-shipped PyPI
+# version (`inspect-ai>=<version>`). Dev on `main` tracks inspect_ai's `main`;
+# a *published* scout must depend on a *released* inspect_ai (PyPI rejects
+# direct-reference deps, and a git ref is not reproducible).
+#
+# This is the companion to release-dep-guard.yml: the guard *blocks* a release
+# PR that still carries a git ref; this workflow *fixes* it automatically. If
+# scout genuinely needs an unreleased inspect_ai, pinning to the shipped
+# version makes the release PR's build/tests fail loudly — which is the signal
+# to cut an inspect_ai release first.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pin:
+    # Only touch the Release Please release PR.
+    if: ${{ github.head_ref == 'release-please--branches--main' }}
+    runs-on: ubuntu-latest
+    steps:
+      # App token so the pin commit re-triggers the PR's checks (guard + build).
+      # A commit pushed with the default GITHUB_TOKEN would not trigger them.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Rewrite inspect_ai git ref to the shipped PyPI version
+        run: |
+          python3 - <<'PY'
+          import json, re, sys, urllib.request
+
+          with urllib.request.urlopen("https://pypi.org/pypi/inspect-ai/json", timeout=30) as r:
+              version = json.load(r)["info"]["version"]
+          if not version:
+              print("::error::Could not resolve a released inspect-ai version from PyPI")
+              sys.exit(1)
+
+          path = "pyproject.toml"
+          src = open(path).read()
+          # Match `inspect-ai @ git+...` (or inspect_ai) inside a TOML string.
+          pat = re.compile(r'"inspect[-_]ai\s*@\s*git\+[^"]*"')
+          new = pat.sub(f'"inspect-ai>={version}"', src)
+          if new == src:
+              print(f"No inspect_ai git ref to pin (already released-versioned). Latest PyPI: {version}")
+          else:
+              open(path, "w").write(new)
+              print(f"Pinned inspect_ai to >={version}")
+          PY
+
+      - name: Commit the pin if pyproject changed
+        run: |
+          if git diff --quiet -- pyproject.toml; then
+            echo "No change to commit."
+            exit 0
+          fi
+          git config user.name "meridian-release-bot[bot]"
+          git config user.email "meridian-release-bot[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: pin inspect_ai to the shipped release for publishing"
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
## What

Companion to the release dependency guard (#509). Two changes, both scoped to the Release Please release PR (`head_ref == release-please--branches--main`):

1. **New workflow `release-pin-deps.yml`** — on the release PR, rewrites the `inspect_ai` dependency in `pyproject.toml` from the moving git ref (`inspect-ai @ git+...@main`) to the currently-shipped PyPI version (`inspect-ai>=<version>`), then commits the pin back to the release branch. Uses the release-bot App token so the pin commit re-triggers the PR's checks (guard + build). Idempotent — if there's no git ref, it no-ops.

2. **`build.yaml`** — on the release PR only, skips the `pip install git+...@main` step so the build/tests validate against the *pinned/shipped* inspect_ai (pulled in via `.[dev]`/`.`). Everywhere else (main, normal PRs) continues to track inspect_ai main.

## Why

A published scout cannot depend on a moving git ref — PyPI rejects direct-reference deps and a git ref isn't reproducible. The [guard](../pull/509) *blocks* a release PR that still carries a git ref; this PR *fixes* it automatically and then proves the shipped version actually works.

If scout genuinely needs an unreleased inspect_ai, pinning to the shipped version makes the release PR's build fail loudly — which is the correct signal to cut an inspect_ai release first, rather than silently shipping against main.

## Flow on a release PR

1. Release Please opens the PR (pyproject still points at `@main`) → guard goes red.
2. `release-pin-deps` runs → pins to `inspect-ai>=<shipped>` → commits.
3. Pin commit re-triggers checks: guard now green; build validates against the shipped version.
4. If the shipped version is incompatible, build fails → ship inspect_ai first.

## Notes

- Latest shipped inspect_ai at time of writing: `0.3.246`.
- Only `inspect_ai` is auto-pinned; any *other* git-ref dep will still (correctly) trip the guard and require manual attention.