### PR TITLE
ci: keep schema-sync check on inspect_ai main, not the shipped version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,11 +134,14 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          # Track inspect_ai main everywhere EXCEPT the release PR, where we
-          # validate against the pinned/shipped version pulled in via . below.
-          if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
-            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
-          fi
+          # This job checks that the committed schema/type artifacts are in sync
+          # with the Python source — a regeneration-hygiene check, NOT a
+          # shipped-compatibility gate. The committed artifacts are generated
+          # against inspect_ai main, so this must always run against main; using
+          # the pinned/shipped version on the release PR would flag false drift
+          # for inspect_ai fields not yet released. (Shipped-version compatibility
+          # is covered by py-test / py-build / py-mypy.)
+          python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
           python -m pip install .
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## What

Follow-up to the auto-pin work (#510). On the Release Please release PR, `#510` made **all four** Python build jobs install the shipped inspect_ai instead of main. That's right for three of them but wrong for `check-schema-and-types`, which this PR reverts to always installing inspect_ai **main**.

## Why

There are two different kinds of check here:

| Check | Purpose | Which inspect_ai? |
|---|---|---|
| `py-test` / `py-build` / `py-mypy` | Does scout actually **work** against the version it will ship pinned to? | **shipped** (keep the swap) |
| `check-schema-and-types` | Did the dev **regenerate** the committed `openapi.json` / `generated.ts` after changing source? | **main** (revert) |

`check-schema-and-types` regenerates the committed artifacts from source and diffs. Those artifacts are generated against inspect_ai `main`. Running it against the *shipped* version makes it regenerate a **different** schema and report false structural drift for any inspect_ai field that exists on `main` but isn't released yet.

Concretely, on release PR #511 this blocked the release over a `role` field that's in inspect_ai `main` but not in the shipped `0.3.246` — even though `py-test`/`py-build`/`py-mypy` **all pass** against `0.3.246`, i.e. scout 0.4.44 is genuinely compatible with the shipped inspect_ai. That was a false blocker, not a real incompatibility.

## Effect

Release PRs now block only when scout truly doesn't work against the shipped inspect_ai (via the compat gates). Schema-artifact freshness is still enforced everywhere, against the version those artifacts track (main).