### PR TITLE
ci: allow hotfix releases via workflow_dispatch target-branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
+        type: string
+        default: main
 
 jobs:
   release-please:
@@ -15,4 +21,5 @@ jobs:
       # workflows, each with its own environment gate — so each posts its own
       # approval ping from there (deep-linking to the paused run), not here.
       approval-ping: false
+      target-branch: ${{ inputs.target-branch }}
     secrets: inherit


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `target-branch` input and passes it through to the reusable `release-please-python.yml@v1` workflow. This is backward compatible—on push, `inputs` is null so the value is empty and the reusable workflow falls back to its default branch. It enables maintenance-branch hotfix releases (e.g. `hotfix/1.4.x`) via manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)