### PR TITLE
fix: restore multiprocess concurrency against inspect_ai's updated ConcurrencySemaphore protocol (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- Bugfix: Guard against empty eval logs producing invalid SQL
-
 ## 0.4.43 (05 July 2026)
 
 - Store transcript and scan-result event/input columns as compact JSON (`indent=None`), substantially reducing on-disk Parquet size and the bytes streamed to Scout View (e.g. ~700 MiB → ~200 MiB for a large events column).


### PR DESCRIPTION
Catch-up release notes for two fixes already merged for **0.4.44** whose original commits Release Please didn't surface on its own:

- **#498** — its squash title (`Fix MyPy for inspect_ai@main…`) wasn't a Conventional Commit, so RP couldn't parse it. It's a real user-facing fix: the upstream `ConcurrencySemaphore` protocol change caused a runtime failure in `MPConcurrencySemaphore`.
- **#319** — a clean `fix:` commit that RP dropped from generation anyway (it only survived in the hand-maintained `## Unreleased` block).

This PR credits both via conventional-commit lines (the title + the body line below) so they land in the 0.4.44 notes, and removes the stale `## Unreleased` section (Release Please owns the changelog now).

fix: guard against empty eval logs producing invalid SQL (#319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)