### PR TITLE
chore: hide docs/chore/refactor from release notes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -21,15 +21,18 @@
         },
         {
           "type": "refactor",
-          "section": "Code Refactoring"
+          "section": "Code Refactoring",
+          "hidden": true
         },
         {
           "type": "docs",
-          "section": "Documentation"
+          "section": "Documentation",
+          "hidden": true
         },
         {
           "type": "chore",
-          "section": "Miscellaneous"
+          "section": "Miscellaneous",
+          "hidden": true
         },
         {
           "type": "build",


### PR DESCRIPTION
Aligns scout's `changelog-sections` with the org standard: release notes surface user-facing types (`feat`, `fix`, `perf`, `revert`) and hide `docs`/`chore`/`refactor` (`build`/`ci`/`test`/`style` were already hidden).

Removes the spurious **Documentation** entry (the contributing-guide PR #514) from the pending **0.4.44** notes. Once merged, Release Please regenerates the release PR (#513) without that section.

Mirrors the shared-source change in meridianlabs-ai/actions#63. `hidden` affects changelog visibility only — no impact on which PR-title types `pr-title-lint` allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)