### PR TITLE
test: move changelog-sections to top level (hide docs/chore/refactor)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,60 +1,60 @@
 {
   "release-type": "python",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    }
+  ],
   "packages": {
     ".": {
-      "changelog-sections": [
-        {
-          "type": "feat",
-          "section": "Features"
-        },
-        {
-          "type": "fix",
-          "section": "Bug Fixes"
-        },
-        {
-          "type": "perf",
-          "section": "Performance Improvements"
-        },
-        {
-          "type": "revert",
-          "section": "Reverts"
-        },
-        {
-          "type": "refactor",
-          "section": "Code Refactoring",
-          "hidden": true
-        },
-        {
-          "type": "docs",
-          "section": "Documentation",
-          "hidden": true
-        },
-        {
-          "type": "chore",
-          "section": "Miscellaneous",
-          "hidden": true
-        },
-        {
-          "type": "build",
-          "section": "Build System",
-          "hidden": true
-        },
-        {
-          "type": "ci",
-          "section": "Continuous Integration",
-          "hidden": true
-        },
-        {
-          "type": "test",
-          "section": "Tests",
-          "hidden": true
-        },
-        {
-          "type": "style",
-          "section": "Styles",
-          "hidden": true
-        }
-      ],
       "release-notes-config": {
         "grouping": true
       },


### PR DESCRIPTION
Per-package `changelog-sections` isn't being honored by Release Please — `docs` stayed visible in the 0.4.44 notes despite `hidden: true`, even after a from-scratch regeneration. This moves `changelog-sections` to the **top level** of the manifest config to test whether that's the level RP actually reads (mirroring how `include-v-in-tag` is the inverse — per-package only).

If merging this makes the **Documentation** section disappear from the release PR notes, top-level is the correct home and we fix the shared generator (`actions`) the same way.

`include-v-in-tag` etc. stay per-package (unchanged). `hidden` affects changelog visibility only — no impact on `pr-title-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)