### PR TITLE
chore: regenerate release-please config (drop invalid key, restore bare tags)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,63 +1,60 @@
 {
   "release-type": "python",
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features"
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes"
-    },
-    {
-      "type": "perf",
-      "section": "Performance Improvements"
-    },
-    {
-      "type": "revert",
-      "section": "Reverts"
-    },
-    {
-      "type": "refactor",
-      "section": "Code Refactoring",
-      "hidden": true
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": true
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous",
-      "hidden": true
-    },
-    {
-      "type": "build",
-      "section": "Build System",
-      "hidden": true
-    },
-    {
-      "type": "ci",
-      "section": "Continuous Integration",
-      "hidden": true
-    },
-    {
-      "type": "test",
-      "section": "Tests",
-      "hidden": true
-    },
-    {
-      "type": "style",
-      "section": "Styles",
-      "hidden": true
-    }
-  ],
   "packages": {
     ".": {
-      "release-notes-config": {
-        "grouping": true
-      },
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": true
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "style",
+          "section": "Styles",
+          "hidden": true
+        }
+      ],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-v-in-tag": false


### PR DESCRIPTION
Regenerates scout's `.release-please-config.json` from the fixed generator (meridianlabs-ai/actions#64), which drops the invalid `release-notes-config` key that was causing release-please to ignore the per-package options.

**Fixes going forward:**
- `include-v-in-tag: false` should now be honored → next tag is **bare** (`0.4.45`, not `v0.4.45`)
- `docs`/`chore`/`refactor` hidden → notes surface `feat`/`fix`/`perf`/`revert` only

Also reverts the earlier top-level `changelog-sections` experiment back to the canonical per-package form.

**Scout is the verification case:** confirm the bare tag + clean notes on the next real release before we regenerate the other bare repos (viz/swe/petri_dish/petri_bloom). Published `v0.4.44` stays as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)