### PR TITLE
perf: index eval logs concurrently on a thread pool (~6x faster for S3 log directories)

### DIFF
--- a/src/inspect_scout/_transcript/caching.py
+++ b/src/inspect_scout/_transcript/caching.py
@@ -2,7 +2,7 @@ import io
 import json
 import warnings
 from collections.abc import Callable, Generator
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import partial
 from os import PathLike
@@ -125,6 +125,7 @@ def samples_df_with_caching(
         # reads, cache the reads still in flight, then re-raise.
         miss_df_by_path: dict[str, pd.DataFrame] = {}
         first_error: Exception | None = None
+        futures: dict[Future[pd.DataFrame], tuple[str, str]] = {}
         if cache_misses:
             with ThreadPoolExecutor(
                 max_workers=min(max_workers, len(cache_misses))
@@ -134,19 +135,28 @@ def samples_df_with_caching(
                     for path, etag in cache_misses
                 }
                 for future in as_completed(futures):
-                    if future.cancelled():
-                        continue
                     path, etag = futures[future]
                     try:
                         df = future.result()
                     except Exception as ex:
-                        if first_error is None:
-                            first_error = ex
-                            executor.shutdown(wait=False, cancel_futures=True)
-                        continue
+                        # as_completed never yields futures that
+                        # shutdown(cancel_futures=True) drained from the
+                        # queue, so stop iterating and harvest the reads
+                        # still in flight below.
+                        first_error = ex
+                        executor.shutdown(wait=True, cancel_futures=True)
+                        break
                     _put_cached_df(kvstore, path, etag, df)
                     miss_df_by_path[path] = df
         if first_error is not None:
+            # cache the in-flight reads that completed after the failure
+            for future, (path, etag) in futures.items():
+                if path in miss_df_by_path or future.cancelled():
+                    continue
+                try:
+                    _put_cached_df(kvstore, path, etag, future.result())
+                except Exception:
+                    pass
             raise first_error
         miss_dfs = [miss_df_by_path[path] for path, _ in cache_misses]
 

--- a/src/inspect_scout/_transcript/caching.py
+++ b/src/inspect_scout/_transcript/caching.py
@@ -2,18 +2,21 @@ import io
 import json
 import warnings
 from collections.abc import Callable, Generator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai._util.file import FileInfo, filesystem
+from inspect_ai._util.file import FileInfo, FileSystem, filesystem
 from inspect_ai._util.kvstore import KVStore, inspect_kvstore
 from inspect_ai.log._file import EvalLogInfo, log_files_from_ls
 
 from .types import LogPaths
 
 DEFAULT_MAX_CACHE_ENTRIES = 5000
+DEFAULT_READER_CHUNK_SIZE = 32
+DEFAULT_RESOLVE_MAX_WORKERS = 8
 _CACHE_VERSION = 10
 _CACHE_VERSION_KEY = "__cache_version__"
 
@@ -75,21 +78,28 @@ def _get_cached_dfs(
 
 
 def samples_df_with_caching(
-    reader: Callable[[str], pd.DataFrame],
+    reader: Callable[[list[str]], list[pd.DataFrame]],
     logs: LogPaths,
     cache_store: str = "scout_transcript_info_cache",
+    chunk_size: int = DEFAULT_READER_CHUNK_SIZE,
 ) -> pd.DataFrame:
     """Read transcript sample info from the logs with caching.
 
     Caching behavior:
-    - Calls reader(path) per file (with caching by etag or mtime:size)
+    - Calls reader with chunks of up to chunk_size cache-miss paths; passing
+      multiple paths per call allows the reader to read them concurrently
+      (per-file results are cached by etag or mtime:size)
+    - Caches each chunk before reading the next, so a failure part way
+      through preserves the chunks already read
     - Concatenates all results into single DataFrame
     - Falls back to direct reader call on any cache errors
 
     Args:
-        reader: Function taking a path, returning DataFrame
+        reader: Function taking a list of paths, returning one DataFrame per
+            path in the same order
         logs: Log paths to read
         cache_store: KVStore name for cache storage
+        chunk_size: Maximum number of cache-miss paths per reader call
 
     Returns:
         DataFrame with transcript data
@@ -103,10 +113,20 @@ def samples_df_with_caching(
     ) as kvstore:
         cache_hits, cache_misses = _get_cached_dfs(kvstore, paths_and_etags)
 
-        # Read and cache the dataframes for all of the cache misses.
-        miss_dfs = [reader(path) for path, _ in cache_misses]
-        for (path, etag), df in zip(cache_misses, miss_dfs, strict=True):
-            _put_cached_df(kvstore, path, etag, df)
+        # Read and cache the dataframes for all of the cache misses, one
+        # chunk at a time (each chunk is cached before the next is read).
+        miss_dfs: list[pd.DataFrame] = []
+        for start in range(0, len(cache_misses), chunk_size):
+            chunk = cache_misses[start : start + chunk_size]
+            chunk_dfs = reader([path for path, _ in chunk])
+            if len(chunk_dfs) != len(chunk):
+                raise ValueError(
+                    f"reader returned {len(chunk_dfs)} DataFrames for "
+                    f"{len(chunk)} log paths"
+                )
+            for (path, etag), df in zip(chunk, chunk_dfs, strict=True):
+                _put_cached_df(kvstore, path, etag, df)
+            miss_dfs.extend(chunk_dfs)
 
     all_dfs = [df for df in cache_hits + miss_dfs if not df.empty]
     if not all_dfs:
@@ -116,7 +136,9 @@ def samples_df_with_caching(
         return pd.concat(all_dfs, ignore_index=True)
 
 
-def _resolve_logs(logs: LogPaths) -> list[tuple[str, str]]:
+def _resolve_logs(
+    logs: LogPaths, max_workers: int = DEFAULT_RESOLVE_MAX_WORKERS
+) -> list[tuple[str, str]]:
     """Resolve log paths to list of (path, etag) tuples.
 
     Similar to inspect_ai's resolve_logs(), but also returns etag for each log file.
@@ -127,6 +149,7 @@ def _resolve_logs(logs: LogPaths) -> list[tuple[str, str]]:
 
     Args:
         logs: Log paths to resolve (can be files, directories, or EvalLogInfo objects)
+        max_workers: Maximum number of threads used to fetch file info
 
     Returns:
         List of (path, etag) tuples where etag is either from filesystem or mtime:size fallback
@@ -142,11 +165,29 @@ def _resolve_logs(logs: LogPaths) -> list[tuple[str, str]]:
         for log in logs_list
     ]
 
+    # Create filesystems on the calling thread (fsspec filesystem-instance
+    # construction/caching is not thread-safe), then fetch file info
+    # concurrently -- one round trip per path on remote filesystems.
+    filesystems = [filesystem(log_str) for log_str in logs_str]
+
+    def fetch_info(fs: FileSystem, path: str) -> FileInfo:
+        return fs.info(path)
+
+    if len(logs_str) > 1:
+        with ThreadPoolExecutor(
+            max_workers=min(max_workers, len(logs_str))
+        ) as executor:
+            # map preserves input order and raises the earliest-ordered failure
+            infos = list(executor.map(fetch_info, filesystems, logs_str))
+    else:
+        infos = [
+            fetch_info(fs, log_str)
+            for fs, log_str in zip(filesystems, logs_str, strict=True)
+        ]
+
     # Expand directories
     file_infos: list[FileInfo] = []
-    for log_str in logs_str:
-        fs = filesystem(log_str)
-        info = fs.info(log_str)
+    for fs, info in zip(filesystems, infos, strict=True):
         if info.type == "directory":
             file_infos.extend(
                 [fi for fi in fs.ls(info.name, recursive=True) if fi.type == "file"]

--- a/src/inspect_scout/_transcript/caching.py
+++ b/src/inspect_scout/_transcript/caching.py
@@ -2,21 +2,23 @@ import io
 import json
 import warnings
 from collections.abc import Callable, Generator
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
+from functools import partial
 from os import PathLike
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai._util.file import FileInfo, FileSystem, filesystem
+from inspect_ai._util._async import run_coroutine, tg_collect
+from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_ai._util.file import FileInfo
 from inspect_ai._util.kvstore import KVStore, inspect_kvstore
 from inspect_ai.log._file import EvalLogInfo, log_files_from_ls
 
 from .types import LogPaths
 
 DEFAULT_MAX_CACHE_ENTRIES = 5000
-DEFAULT_READER_CHUNK_SIZE = 32
-DEFAULT_RESOLVE_MAX_WORKERS = 8
+DEFAULT_READER_MAX_WORKERS = 16
 _CACHE_VERSION = 10
 _CACHE_VERSION_KEY = "__cache_version__"
 
@@ -78,28 +80,32 @@ def _get_cached_dfs(
 
 
 def samples_df_with_caching(
-    reader: Callable[[list[str]], list[pd.DataFrame]],
+    reader: Callable[[str], pd.DataFrame],
     logs: LogPaths,
     cache_store: str = "scout_transcript_info_cache",
-    chunk_size: int = DEFAULT_READER_CHUNK_SIZE,
+    max_workers: int = DEFAULT_READER_MAX_WORKERS,
 ) -> pd.DataFrame:
     """Read transcript sample info from the logs with caching.
 
     Caching behavior:
-    - Calls reader with chunks of up to chunk_size cache-miss paths; passing
-      multiple paths per call allows the reader to read them concurrently
-      (per-file results are cached by etag or mtime:size)
-    - Caches each chunk before reading the next, so a failure part way
-      through preserves the chunks already read
+    - Calls reader(path) per file (with caching by etag or mtime:size),
+      reading cache misses concurrently on a thread pool
+    - Each file is cached as soon as its read completes, so a failure part
+      way through preserves the files already read
     - Concatenates all results into single DataFrame
     - Falls back to direct reader call on any cache errors
 
+    Reads are one file per reader call (rather than one multi-file call)
+    because inspect_ai's samples_df de-duplicates samples by uuid across
+    all logs it is given: eval-set retry logs carry forward completed
+    samples with identical uuids, so two such logs read in one call would
+    each get a partial result. Per-file calls make de-duplication a no-op.
+
     Args:
-        reader: Function taking a list of paths, returning one DataFrame per
-            path in the same order
+        reader: Function taking a path, returning DataFrame
         logs: Log paths to read
         cache_store: KVStore name for cache storage
-        chunk_size: Maximum number of cache-miss paths per reader call
+        max_workers: Maximum number of threads used to read cache misses
 
     Returns:
         DataFrame with transcript data
@@ -113,20 +119,36 @@ def samples_df_with_caching(
     ) as kvstore:
         cache_hits, cache_misses = _get_cached_dfs(kvstore, paths_and_etags)
 
-        # Read and cache the dataframes for all of the cache misses, one
-        # chunk at a time (each chunk is cached before the next is read).
-        miss_dfs: list[pd.DataFrame] = []
-        for start in range(0, len(cache_misses), chunk_size):
-            chunk = cache_misses[start : start + chunk_size]
-            chunk_dfs = reader([path for path, _ in chunk])
-            if len(chunk_dfs) != len(chunk):
-                raise ValueError(
-                    f"reader returned {len(chunk_dfs)} DataFrames for "
-                    f"{len(chunk)} log paths"
-                )
-            for (path, etag), df in zip(chunk, chunk_dfs, strict=True):
-                _put_cached_df(kvstore, path, etag, df)
-            miss_dfs.extend(chunk_dfs)
+        # Read the cache misses concurrently, caching each file as its read
+        # completes (on this thread -- the kvstore connection is not shared
+        # with reader threads). On the first failure stop submitting new
+        # reads, cache the reads still in flight, then re-raise.
+        miss_df_by_path: dict[str, pd.DataFrame] = {}
+        first_error: Exception | None = None
+        if cache_misses:
+            with ThreadPoolExecutor(
+                max_workers=min(max_workers, len(cache_misses))
+            ) as executor:
+                futures = {
+                    executor.submit(reader, path): (path, etag)
+                    for path, etag in cache_misses
+                }
+                for future in as_completed(futures):
+                    if future.cancelled():
+                        continue
+                    path, etag = futures[future]
+                    try:
+                        df = future.result()
+                    except Exception as ex:
+                        if first_error is None:
+                            first_error = ex
+                            executor.shutdown(wait=False, cancel_futures=True)
+                        continue
+                    _put_cached_df(kvstore, path, etag, df)
+                    miss_df_by_path[path] = df
+        if first_error is not None:
+            raise first_error
+        miss_dfs = [miss_df_by_path[path] for path, _ in cache_misses]
 
     all_dfs = [df for df in cache_hits + miss_dfs if not df.empty]
     if not all_dfs:
@@ -136,9 +158,7 @@ def samples_df_with_caching(
         return pd.concat(all_dfs, ignore_index=True)
 
 
-def _resolve_logs(
-    logs: LogPaths, max_workers: int = DEFAULT_RESOLVE_MAX_WORKERS
-) -> list[tuple[str, str]]:
+def _resolve_logs(logs: LogPaths) -> list[tuple[str, str]]:
     """Resolve log paths to list of (path, etag) tuples.
 
     Similar to inspect_ai's resolve_logs(), but also returns etag for each log file.
@@ -149,7 +169,6 @@ def _resolve_logs(
 
     Args:
         logs: Log paths to resolve (can be files, directories, or EvalLogInfo objects)
-        max_workers: Maximum number of threads used to fetch file info
 
     Returns:
         List of (path, etag) tuples where etag is either from filesystem or mtime:size fallback
@@ -165,35 +184,7 @@ def _resolve_logs(
         for log in logs_list
     ]
 
-    # Create filesystems on the calling thread (fsspec filesystem-instance
-    # construction/caching is not thread-safe), then fetch file info
-    # concurrently -- one round trip per path on remote filesystems.
-    filesystems = [filesystem(log_str) for log_str in logs_str]
-
-    def fetch_info(fs: FileSystem, path: str) -> FileInfo:
-        return fs.info(path)
-
-    if len(logs_str) > 1:
-        with ThreadPoolExecutor(
-            max_workers=min(max_workers, len(logs_str))
-        ) as executor:
-            # map preserves input order and raises the earliest-ordered failure
-            infos = list(executor.map(fetch_info, filesystems, logs_str))
-    else:
-        infos = [
-            fetch_info(fs, log_str)
-            for fs, log_str in zip(filesystems, logs_str, strict=True)
-        ]
-
-    # Expand directories
-    file_infos: list[FileInfo] = []
-    for fs, info in zip(filesystems, infos, strict=True):
-        if info.type == "directory":
-            file_infos.extend(
-                [fi for fi in fs.ls(info.name, recursive=True) if fi.type == "file"]
-            )
-        else:
-            file_infos.append(info)
+    file_infos = run_coroutine(_expand_logs(logs_str))
 
     # Create dict mapping log file name to etag (or fallback to mtime:size)
     etag_map = {fi.name: fi.etag or f"{fi.mtime}:{fi.size}" for fi in file_infos}
@@ -201,6 +192,34 @@ def _resolve_logs(
     eval_log_infos = log_files_from_ls(file_infos, sort=False)
 
     return [(log_file.name, etag_map[log_file.name]) for log_file in eval_log_infos]
+
+
+async def _expand_logs(paths: list[str]) -> list[FileInfo]:
+    """Fetch FileInfo (including etag) for each path, expanding directories.
+
+    All paths are processed concurrently on a shared AsyncFilesystem client:
+    one listing sweep per directory input (which yields file info from the
+    listing itself, with no per-file stat calls) and one stat per file input.
+    """
+    async with AsyncFilesystem() as fs:
+        expanded = await tg_collect([partial(_expand_log, fs, path) for path in paths])
+    return [fi for fis in expanded for fi in fis]
+
+
+async def _expand_log(fs: AsyncFilesystem, path: str) -> list[FileInfo]:
+    async def list_files() -> list[FileInfo]:
+        return [fi async for fi in fs.iter_files(path, recursive=True, detail=True)]
+
+    try:
+        info = await fs.info(path)
+    except Exception:
+        # S3 has no directory objects, so info() raises for directory
+        # prefixes; a path that lists as a non-empty directory is one.
+        # Anything else (missing path, bad credentials) re-raises.
+        if files := await list_files():
+            return files
+        raise
+    return await list_files() if info.type == "directory" else [info]
 
 
 def _get_cached_df(

--- a/src/inspect_scout/_transcript/caching.py
+++ b/src/inspect_scout/_transcript/caching.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pandas as pd
 from inspect_ai._util._async import run_coroutine, tg_collect
 from inspect_ai._util.asyncfiles import AsyncFilesystem
-from inspect_ai._util.file import FileInfo
+from inspect_ai._util.file import FileInfo, filesystem
 from inspect_ai._util.kvstore import KVStore, inspect_kvstore
 from inspect_ai.log._file import EvalLogInfo, log_files_from_ls
 
@@ -127,6 +127,15 @@ def samples_df_with_caching(
         first_error: Exception | None = None
         futures: dict[Future[pd.DataFrame], tuple[str, str]] = {}
         if cache_misses:
+            # fsspec filesystem-instance construction/caching is not
+            # thread-safe, and readers construct filesystems internally,
+            # so instantiate each protocol's filesystem on this thread
+            # before the reader threads can race to create it
+            for path in {
+                _path_protocol(path): path for path, _ in cache_misses
+            }.values():
+                filesystem(path)
+
             with ThreadPoolExecutor(
                 max_workers=min(max_workers, len(cache_misses))
             ) as executor:
@@ -166,6 +175,10 @@ def samples_df_with_caching(
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
         return pd.concat(all_dfs, ignore_index=True)
+
+
+def _path_protocol(path: str) -> str:
+    return path.split("://", 1)[0] if "://" in path else "file"
 
 
 def _resolve_logs(logs: LogPaths) -> list[tuple[str, str]]:

--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -17,7 +17,6 @@ from typing import (
 
 import pandas as pd
 from inspect_ai._util.asyncfiles import AsyncFilesystem
-from inspect_ai._util.path import native_path
 from inspect_ai._util.zip_common import ZipEntry
 from inspect_ai.analysis._dataframe.columns import Column
 from inspect_ai.analysis._dataframe.evals.columns import (
@@ -677,45 +676,13 @@ def _index_logs(logs: Logs) -> pd.DataFrame:
 
     with display().text_progress("Indexing", True) as progress:
 
-        def read_samples(paths: list[str]) -> list[pd.DataFrame]:
-            with trace_action(
-                logger, "Scout Eval Log Index", f"Indexing {len(paths)} log(s)"
-            ):
-                dfs = _read_samples_per_log(paths)
-                for path in paths:
-                    progress.update(path)
-                return dfs
+        def read_samples(path: str) -> pd.DataFrame:
+            with trace_action(logger, "Scout Eval Log Index", f"Indexing {path}"):
+                df = _read_samples([path])
+            progress.update(path)
+            return df
 
         return samples_df_with_caching(read_samples, logs)
-
-
-def _read_samples_per_log(paths: list[str]) -> list[pd.DataFrame]:
-    """Read per-log sample DataFrames, concurrently across log files.
-
-    All paths are read in a single inspect_ai call (which fetches log headers
-    and sample summaries concurrently) and the combined result is split back
-    into one DataFrame per path.
-
-    Args:
-        paths: Paths to eval log files
-
-    Returns:
-        One DataFrame per path, in input order.
-    """
-    combined = _read_samples(paths)
-    dfs = _split_df_by_log(combined, paths)
-
-    # An empty split can mean the log genuinely has no samples, or that the
-    # batch contained a duplicate of the same eval (inspect_ai de-duplicates
-    # evals within a call, attributing all samples to one file). Re-read
-    # empties individually so per-file results (which get cached) never lose
-    # samples to batch composition.
-    if len(paths) > 1:
-        for i, df in enumerate(dfs):
-            if df.empty:
-                dfs[i] = _read_samples([paths[i]])
-
-    return dfs
 
 
 def _read_samples(paths: list[str]) -> pd.DataFrame:
@@ -749,39 +716,6 @@ def _read_samples(paths: list[str]) -> pd.DataFrame:
     if not df.empty:
         df["transcript_id"] = df["sample_id"]
     return df
-
-
-def _split_df_by_log(df: pd.DataFrame, paths: list[str]) -> list[pd.DataFrame]:
-    """Split a combined multi-log samples DataFrame into per-log DataFrames.
-
-    Args:
-        df: Combined DataFrame with a "log" column
-        paths: Log file paths, in the order the per-log frames are returned
-
-    Returns:
-        One DataFrame per path (empty where a path contributed no rows).
-
-    Raises:
-        RuntimeError: If the DataFrame contains rows whose "log" value matches
-            none of the paths (they would otherwise be silently dropped).
-    """
-    if df.empty:
-        return [df.iloc[0:0] for _ in paths]
-
-    groups: dict[str, pd.DataFrame] = {
-        str(log): group.reset_index(drop=True)
-        for log, group in df.groupby("log", sort=False)
-    }
-    # the "log" column holds native paths (e.g. file:// prefix stripped),
-    # so match requested paths by their native form
-    empty = df.iloc[0:0]
-    dfs = [groups.pop(native_path(path), empty) for path in paths]
-    if groups:
-        raise RuntimeError(
-            "Indexing returned samples for unrequested log file(s): "
-            f"{sorted(groups.keys())}"
-        )
-    return dfs
 
 
 def _compute_cache_key_from_logs(logs: Logs) -> str:

--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -17,6 +17,7 @@ from typing import (
 
 import pandas as pd
 from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_ai._util.path import native_path
 from inspect_ai._util.zip_common import ZipEntry
 from inspect_ai.analysis._dataframe.columns import Column
 from inspect_ai.analysis._dataframe.evals.columns import (
@@ -676,33 +677,111 @@ def _index_logs(logs: Logs) -> pd.DataFrame:
 
     with display().text_progress("Indexing", True) as progress:
 
-        def read_samples(path: str) -> pd.DataFrame:
-            with trace_action(logger, "Scout Eval Log Index", f"Indexing {path}"):
-                # This cast is wonky, but the public function, samples_df, uses overloads
-                # to make the return type be a DataFrame when strict=True. Since we're
-                # calling the helper method, we'll just have to cast it.
-                progress.update(path)
-                df = cast(
-                    pd.DataFrame,
-                    _read_samples_df_serial(
-                        [path],
-                        TranscriptColumns,
-                        full=False,
-                        strict=True,
-                        progress=False,
-                    ),
-                )
-
-                # The transcript_id uses the computed sample_id
-                # value, which will properly handle old eval log
-                # that are missing uuids for samples (so we use the value
-                # from the synthesized sample_id column rather than the `id`
-                # prop from the sample itself.
-                if not df.empty:
-                    df["transcript_id"] = df["sample_id"]
-                return df
+        def read_samples(paths: list[str]) -> list[pd.DataFrame]:
+            with trace_action(
+                logger, "Scout Eval Log Index", f"Indexing {len(paths)} log(s)"
+            ):
+                dfs = _read_samples_per_log(paths)
+                for path in paths:
+                    progress.update(path)
+                return dfs
 
         return samples_df_with_caching(read_samples, logs)
+
+
+def _read_samples_per_log(paths: list[str]) -> list[pd.DataFrame]:
+    """Read per-log sample DataFrames, concurrently across log files.
+
+    All paths are read in a single inspect_ai call (which fetches log headers
+    and sample summaries concurrently) and the combined result is split back
+    into one DataFrame per path.
+
+    Args:
+        paths: Paths to eval log files
+
+    Returns:
+        One DataFrame per path, in input order.
+    """
+    combined = _read_samples(paths)
+    dfs = _split_df_by_log(combined, paths)
+
+    # An empty split can mean the log genuinely has no samples, or that the
+    # batch contained a duplicate of the same eval (inspect_ai de-duplicates
+    # evals within a call, attributing all samples to one file). Re-read
+    # empties individually so per-file results (which get cached) never lose
+    # samples to batch composition.
+    if len(paths) > 1:
+        for i, df in enumerate(dfs):
+            if df.empty:
+                dfs[i] = _read_samples([paths[i]])
+
+    return dfs
+
+
+def _read_samples(paths: list[str]) -> pd.DataFrame:
+    """Read a combined samples DataFrame for the given eval logs.
+
+    Args:
+        paths: Paths to eval log files
+
+    Returns:
+        DataFrame with one row per sample from all logs
+    """
+    # This cast is wonky, but the public function, samples_df, uses overloads
+    # to make the return type be a DataFrame when strict=True. Since we're
+    # calling the helper method, we'll just have to cast it.
+    df = cast(
+        pd.DataFrame,
+        _read_samples_df_serial(
+            paths,
+            TranscriptColumns,
+            full=False,
+            strict=True,
+            progress=False,
+        ),
+    )
+
+    # The transcript_id uses the computed sample_id
+    # value, which will properly handle old eval log
+    # that are missing uuids for samples (so we use the value
+    # from the synthesized sample_id column rather than the `id`
+    # prop from the sample itself.
+    if not df.empty:
+        df["transcript_id"] = df["sample_id"]
+    return df
+
+
+def _split_df_by_log(df: pd.DataFrame, paths: list[str]) -> list[pd.DataFrame]:
+    """Split a combined multi-log samples DataFrame into per-log DataFrames.
+
+    Args:
+        df: Combined DataFrame with a "log" column
+        paths: Log file paths, in the order the per-log frames are returned
+
+    Returns:
+        One DataFrame per path (empty where a path contributed no rows).
+
+    Raises:
+        RuntimeError: If the DataFrame contains rows whose "log" value matches
+            none of the paths (they would otherwise be silently dropped).
+    """
+    if df.empty:
+        return [df.iloc[0:0] for _ in paths]
+
+    groups: dict[str, pd.DataFrame] = {
+        str(log): group.reset_index(drop=True)
+        for log, group in df.groupby("log", sort=False)
+    }
+    # the "log" column holds native paths (e.g. file:// prefix stripped),
+    # so match requested paths by their native form
+    empty = df.iloc[0:0]
+    dfs = [groups.pop(native_path(path), empty) for path in paths]
+    if groups:
+        raise RuntimeError(
+            "Indexing returned samples for unrequested log file(s): "
+            f"{sorted(groups.keys())}"
+        )
+    return dfs
 
 
 def _compute_cache_key_from_logs(logs: Logs) -> str:

--- a/tests/scanner/test_df_integration.py
+++ b/tests/scanner/test_df_integration.py
@@ -28,11 +28,11 @@ REFERENCE_WORKING_TIME = 1.006
 async def test_integration() -> None:
     """Cache roundtrip preserves realistic DataFrame with pyarrow dtypes."""
 
-    def _sample_reader(paths: list[str]) -> list[pd.DataFrame]:
-        return [samples_df([path], TranscriptColumns) for path in paths]
+    def _sample_reader(path: str) -> pd.DataFrame:
+        return samples_df([path], TranscriptColumns)
 
     with temp_kvstore() as kvstore_name:
-        df_1 = _sample_reader([LOG_1.as_posix()])[0]
+        df_1 = _sample_reader(LOG_1.as_posix())
 
         # Put LOG_1 into the cache
         all_misses = samples_df_with_caching(_sample_reader, LOG_1, kvstore_name)

--- a/tests/scanner/test_df_integration.py
+++ b/tests/scanner/test_df_integration.py
@@ -28,11 +28,11 @@ REFERENCE_WORKING_TIME = 1.006
 async def test_integration() -> None:
     """Cache roundtrip preserves realistic DataFrame with pyarrow dtypes."""
 
-    def _sample_reader(path: str) -> pd.DataFrame:
-        return samples_df([path], TranscriptColumns)
+    def _sample_reader(paths: list[str]) -> list[pd.DataFrame]:
+        return [samples_df([path], TranscriptColumns) for path in paths]
 
     with temp_kvstore() as kvstore_name:
-        df_1 = _sample_reader(LOG_1.as_posix())
+        df_1 = _sample_reader([LOG_1.as_posix()])[0]
 
         # Put LOG_1 into the cache
         all_misses = samples_df_with_caching(_sample_reader, LOG_1, kvstore_name)

--- a/tests/transcript/test_caching.py
+++ b/tests/transcript/test_caching.py
@@ -165,8 +165,9 @@ def mock_filesystem() -> Iterator[Mock]:
             "inspect_scout._transcript.caching.log_files_from_ls",
             side_effect=mock_log_files_from_ls,
         ),
+        patch("inspect_scout._transcript.caching.filesystem") as filesystem_mock,
     ):
-        yield Mock()
+        yield filesystem_mock
 
 
 def _paths_read(mock: Mock) -> list[str]:
@@ -338,6 +339,27 @@ def test_samples_df_with_caching_failure_preserves_completed_reads(
     assert paths[2] in read_paths
     assert sorted(read_paths) == sorted(set(paths) - set(succeeded))
     assert sorted(result["id"].tolist()) == sorted(paths)
+
+
+def test_samples_df_with_caching_warms_filesystems_before_reads(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """Each protocol's fsspec instance is constructed before reader threads run.
+
+    fsspec filesystem-instance construction/caching is not thread-safe,
+    so readers must never race to create one.
+    """
+    paths = ["s3://bucket/log1.json", "s3://bucket/log2.json", "/local/log3.json"]
+
+    def reader(path: str) -> pd.DataFrame:
+        assert mock_filesystem.call_count == 2  # warmed before any read started
+        return pd.DataFrame({"id": [path]})
+
+    samples_df_with_caching(reader, paths)
+    warmed = {call.args[0] for call in mock_filesystem.call_args_list}
+    assert len(warmed) == 2
+    assert any(path.startswith("s3://bucket/") for path in warmed)
+    assert "/local/log3.json" in warmed
 
 
 def test_samples_df_with_caching_failure_with_queued_reads_raises(

--- a/tests/transcript/test_caching.py
+++ b/tests/transcript/test_caching.py
@@ -2,7 +2,7 @@
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, AsyncIterator, Iterator
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -96,58 +96,70 @@ def mock_kvstore() -> Iterator[Mock]:
         yield mock
 
 
+def create_file_info(
+    path: str, file_type: str = "file", etag: str | None = None
+) -> FileInfo:
+    """Helper to create FileInfo with all required fields."""
+    return FileInfo(
+        name=path,
+        size=1024,
+        type=file_type,
+        mtime=1234567890.0,
+        etag=etag,
+    )
+
+
+class MockAsyncFilesystem:
+    """AsyncFilesystem stand-in: paths ending in "/" are directories, S3 files get etags."""
+
+    async def __aenter__(self) -> "MockAsyncFilesystem":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    async def info(self, path: str) -> FileInfo:
+        # Directories return directory type
+        if path.endswith("/"):
+            return create_file_info(path, "directory", None)
+        # S3 files get etags, local files don't
+        if path.startswith("s3://"):
+            etag = f"etag_{hash(path) % 10000}"
+            return create_file_info(path, "file", etag)
+        return create_file_info(path, "file", None)
+
+    async def iter_files(
+        self,
+        path: str,
+        pattern: str = "*",
+        *,
+        recursive: bool = False,
+        detail: bool = False,
+    ) -> AsyncIterator[FileInfo]:
+        # Return list of files for directory listings
+        if path.rstrip("/") == "s3://bucket/dir":
+            yield create_file_info("s3://bucket/dir/log1.json", "file", "etag_1")
+            yield create_file_info("s3://bucket/dir/log2.json", "file", "etag_2")
+
+
+def mock_log_files_from_ls(
+    file_infos: list[FileInfo], sort: bool = True
+) -> list[EvalLogInfo]:
+    """Mock log_files_from_ls to convert FileInfo to EvalLogInfo."""
+    return [
+        create_evalloginfo(fi.name)
+        for fi in file_infos
+        if fi.type == "file" and fi.name.endswith(".json")
+    ]
+
+
 @pytest.fixture
 def mock_filesystem() -> Iterator[Mock]:
-    """Mock filesystem that returns FileInfo with/without etag."""
-
-    def create_file_info(
-        path: str, file_type: str = "file", etag: str | None = None
-    ) -> FileInfo:
-        return FileInfo(
-            name=path,
-            size=1024,
-            type=file_type,
-            mtime=1234567890.0,
-            etag=etag,
-        )
-
-    class MockFilesystem:
-        def __init__(self, path: str):
-            self.path = path
-
-        def info(self, path: str) -> FileInfo:
-            # Directories return directory type
-            if path.endswith("/"):
-                return create_file_info(path, "directory", None)
-            # S3 files get etags, local files don't
-            if path.startswith("s3://"):
-                etag = f"etag_{hash(path) % 10000}"
-                return create_file_info(path, "file", etag)
-            return create_file_info(path, "file", None)
-
-        def ls(self, path: str, recursive: bool = False) -> list[FileInfo]:
-            # Return list of files for directory listings
-            if path == "s3://bucket/dir/":
-                return [
-                    create_file_info("s3://bucket/dir/log1.json", "file", "etag_1"),
-                    create_file_info("s3://bucket/dir/log2.json", "file", "etag_2"),
-                ]
-            return []
-
-    def mock_log_files_from_ls(
-        file_infos: list[FileInfo], sort: bool = True
-    ) -> list[EvalLogInfo]:
-        """Mock log_files_from_ls to convert FileInfo to EvalLogInfo."""
-        return [
-            create_evalloginfo(fi.name)
-            for fi in file_infos
-            if fi.type == "file" and fi.name.endswith(".json")
-        ]
-
+    """Mock AsyncFilesystem that returns FileInfo with/without etag."""
     with (
         patch(
-            "inspect_scout._transcript.caching.filesystem",
-            side_effect=MockFilesystem,
+            "inspect_scout._transcript.caching.AsyncFilesystem",
+            MockAsyncFilesystem,
         ),
         patch(
             "inspect_scout._transcript.caching.log_files_from_ls",
@@ -158,8 +170,8 @@ def mock_filesystem() -> Iterator[Mock]:
 
 
 def _paths_read(mock: Mock) -> list[str]:
-    """All paths passed to a batch reader mock, across calls, in order."""
-    return [path for call in mock.call_args_list for path in call.args[0]]
+    """All paths passed to a reader mock, across calls, in order."""
+    return [call.args[0] for call in mock.call_args_list]
 
 
 @pytest.fixture
@@ -167,21 +179,16 @@ def mock_reader() -> Mock:
     """Mock reader function that tracks calls and returns DataFrames."""
     path_counter = {"count": 0}
 
-    def reader_impl(paths: list[str]) -> list[pd.DataFrame]:
-        dfs: list[pd.DataFrame] = []
-        for _ in paths:
-            path_num = path_counter["count"]
-            path_counter["count"] += 1
-            dfs.append(
-                pd.DataFrame(
-                    {
-                        "eval_id": [f"eval_{path_num}"],
-                        "id": [f"sample_{path_num}"],
-                        "score": [0.5 + path_num * 0.1],
-                    }
-                )
-            )
-        return dfs
+    def reader_impl(path: str) -> pd.DataFrame:
+        path_num = path_counter["count"]
+        path_counter["count"] += 1
+        return pd.DataFrame(
+            {
+                "eval_id": [f"eval_{path_num}"],
+                "id": [f"sample_{path_num}"],
+                "score": [0.5 + path_num * 0.1],
+            }
+        )
 
     return Mock(side_effect=reader_impl)
 
@@ -237,18 +244,13 @@ def test_samples_df_with_caching_invalidates_on_etag_change(
     assert len(_paths_read(mock_reader)) == 1
 
     # Simulate etag change
-    def new_mock_fs(path: str) -> Any:
-        fs = Mock()
-        fs.info.return_value = FileInfo(
-            name=path,
-            size=1024,
-            type="file",
-            mtime=1234567890.0,
-            etag="new_etag_changed",
-        )
-        return fs
+    class ChangedEtagFilesystem(MockAsyncFilesystem):
+        async def info(self, path: str) -> FileInfo:
+            return create_file_info(path, "file", "new_etag_changed")
 
-    with patch("inspect_scout._transcript.caching.filesystem", side_effect=new_mock_fs):
+    with patch(
+        "inspect_scout._transcript.caching.AsyncFilesystem", ChangedEtagFilesystem
+    ):
         samples_df_with_caching(mock_reader, "s3://bucket/log.json")
         assert len(_paths_read(mock_reader)) == 2
 
@@ -257,7 +259,7 @@ def test_samples_df_with_caching_dataframe_roundtrip(
     mock_kvstore: Mock, mock_filesystem: Mock, sample_df: pd.DataFrame
 ) -> None:
     """Cached DataFrame preserves data through JSON serialization."""
-    reader = Mock(return_value=[sample_df])
+    reader = Mock(return_value=sample_df)
 
     result1 = samples_df_with_caching(reader, "s3://bucket/log.json")
     result2 = samples_df_with_caching(reader, "s3://bucket/log.json")
@@ -288,34 +290,19 @@ def test_samples_df_with_caching_directory_input(
     assert len(result) == 2
 
 
-def test_samples_df_with_caching_chunks_misses(
-    mock_kvstore: Mock, mock_filesystem: Mock
-) -> None:
-    """Cache misses are read in chunks of up to chunk_size, in input order."""
-    paths = [f"s3://bucket/log{i}.json" for i in range(5)]
-    chunks: list[list[str]] = []
-
-    def reader(chunk: list[str]) -> list[pd.DataFrame]:
-        chunks.append(list(chunk))
-        return [pd.DataFrame({"id": [path]}) for path in chunk]
-
-    result = samples_df_with_caching(reader, paths, chunk_size=2)
-    assert chunks == [paths[0:2], paths[2:4], paths[4:5]]
-    assert result["id"].tolist() == paths
-
-
 def test_samples_df_with_caching_caches_per_path(
     mock_kvstore: Mock, mock_filesystem: Mock
 ) -> None:
-    """Each path in a chunk gets its own cache entry, aligned with its data."""
+    """Each path gets its own cache entry, aligned with its data, in input order."""
     paths = [f"s3://bucket/log{i}.json" for i in range(4)]
 
-    def reader(chunk: list[str]) -> list[pd.DataFrame]:
-        return [pd.DataFrame({"id": [path]}) for path in chunk]
+    def reader(path: str) -> pd.DataFrame:
+        return pd.DataFrame({"id": [path]})
 
-    samples_df_with_caching(reader, paths, chunk_size=2)
+    result = samples_df_with_caching(reader, paths)
+    assert result["id"].tolist() == paths
 
-    def fail_reader(chunk: list[str]) -> list[pd.DataFrame]:
+    def fail_reader(path: str) -> pd.DataFrame:
         raise AssertionError("all paths should be cache hits")
 
     for path in paths:
@@ -323,73 +310,55 @@ def test_samples_df_with_caching_caches_per_path(
         assert cached["id"].tolist() == [path]
 
 
-def test_samples_df_with_caching_reader_count_mismatch(
+def test_samples_df_with_caching_failure_preserves_completed_reads(
     mock_kvstore: Mock, mock_filesystem: Mock
 ) -> None:
-    """Reader returning the wrong number of DataFrames raises."""
-
-    def bad_reader(chunk: list[str]) -> list[pd.DataFrame]:
-        return [pd.DataFrame({"id": [chunk[0]]})]
-
-    with pytest.raises(ValueError, match="DataFrames"):
-        samples_df_with_caching(
-            bad_reader, ["s3://bucket/log1.json", "s3://bucket/log2.json"]
-        )
-
-
-def test_samples_df_with_caching_failure_preserves_prior_chunks(
-    mock_kvstore: Mock, mock_filesystem: Mock
-) -> None:
-    """A failure part way through preserves cache entries from earlier chunks."""
+    """A failing read preserves cache entries for reads that succeeded."""
     paths = [f"s3://bucket/log{i}.json" for i in range(4)]
 
-    def failing_reader(chunk: list[str]) -> list[pd.DataFrame]:
-        if paths[2] in chunk:
+    def failing_reader(path: str) -> pd.DataFrame:
+        if path == paths[2]:
             raise ValueError("boom")
-        return [pd.DataFrame({"id": [path]}) for path in chunk]
+        return pd.DataFrame({"id": [path]})
 
     with pytest.raises(ValueError, match="boom"):
-        samples_df_with_caching(failing_reader, paths, chunk_size=2)
+        samples_df_with_caching(failing_reader, paths)
 
     read_paths: list[str] = []
 
-    def reader(chunk: list[str]) -> list[pd.DataFrame]:
-        read_paths.extend(chunk)
-        return [pd.DataFrame({"id": [path]}) for path in chunk]
+    def reader(path: str) -> pd.DataFrame:
+        read_paths.append(path)
+        return pd.DataFrame({"id": [path]})
 
-    result = samples_df_with_caching(reader, paths, chunk_size=2)
-    assert read_paths == paths[2:4]  # first chunk came from the cache
+    result = samples_df_with_caching(reader, paths)
+    assert read_paths == [paths[2]]  # the other paths came from the cache
     assert sorted(result["id"].tolist()) == sorted(paths)
 
 
 def test_resolve_logs_concurrent_info_preserves_association(
     mock_kvstore: Mock,
 ) -> None:
-    """Concurrent fs.info fetches keep each etag associated with its path."""
-    import time
+    """Concurrent info fetches keep each etag associated with its path."""
+    import anyio
 
     paths = [f"s3://bucket/log{i}.json" for i in range(4)]
     # earlier paths take longer, so completion order inverts input order
     delays = {path: 0.02 * (len(paths) - i) for i, path in enumerate(paths)}
     etags = {path: f"etag-{i}" for i, path in enumerate(paths)}
 
-    def make_fs(path: str) -> Any:
-        fs = Mock()
+    class DelayedInfoFilesystem(MockAsyncFilesystem):
+        async def info(self, path: str) -> FileInfo:
+            await anyio.sleep(delays[path])
+            return create_file_info(path, "file", etags[path])
 
-        def info(p: str) -> FileInfo:
-            time.sleep(delays[p])
-            return FileInfo(
-                name=p, size=1024, type="file", mtime=1234567890.0, etag=etags[p]
-            )
-
-        fs.info = info
-        return fs
-
-    def reader(chunk: list[str]) -> list[pd.DataFrame]:
-        return [pd.DataFrame({"id": [path]}) for path in chunk]
+    def reader(path: str) -> pd.DataFrame:
+        return pd.DataFrame({"id": [path]})
 
     with (
-        patch("inspect_scout._transcript.caching.filesystem", side_effect=make_fs),
+        patch(
+            "inspect_scout._transcript.caching.AsyncFilesystem",
+            DelayedInfoFilesystem,
+        ),
         patch(
             "inspect_scout._transcript.caching.log_files_from_ls",
             side_effect=lambda file_infos, sort: [
@@ -404,12 +373,64 @@ def test_resolve_logs_concurrent_info_preserves_association(
         etags[paths[1]] = "etag-changed"
         read_paths: list[str] = []
 
-        def reader2(chunk: list[str]) -> list[pd.DataFrame]:
-            read_paths.extend(chunk)
-            return [pd.DataFrame({"id": [path]}) for path in chunk]
+        def reader2(path: str) -> pd.DataFrame:
+            read_paths.append(path)
+            return pd.DataFrame({"id": [path]})
 
         samples_df_with_caching(reader2, paths)
         assert read_paths == [paths[1]]
+
+
+def test_resolve_logs_s3_directory_prefix(
+    mock_kvstore: Mock, mock_reader: Mock
+) -> None:
+    """A directory prefix where info() raises (S3) expands via a listing sweep."""
+
+    class S3PrefixFilesystem(MockAsyncFilesystem):
+        async def info(self, path: str) -> FileInfo:
+            raise FileNotFoundError(path)
+
+    with (
+        patch("inspect_scout._transcript.caching.AsyncFilesystem", S3PrefixFilesystem),
+        patch(
+            "inspect_scout._transcript.caching.log_files_from_ls",
+            side_effect=mock_log_files_from_ls,
+        ),
+    ):
+        result = samples_df_with_caching(mock_reader, "s3://bucket/dir")
+        assert sorted(_paths_read(mock_reader)) == [
+            "s3://bucket/dir/log1.json",
+            "s3://bucket/dir/log2.json",
+        ]
+        assert len(result) == 2
+
+
+def test_resolve_logs_missing_path_raises(mock_kvstore: Mock) -> None:
+    """A path where info() raises and nothing lists re-raises the info error."""
+
+    class MissingPathFilesystem(MockAsyncFilesystem):
+        async def info(self, path: str) -> FileInfo:
+            raise FileNotFoundError(path)
+
+        async def iter_files(
+            self,
+            path: str,
+            pattern: str = "*",
+            *,
+            recursive: bool = False,
+            detail: bool = False,
+        ) -> AsyncIterator[FileInfo]:
+            return
+            yield
+
+    def fail_reader(path: str) -> pd.DataFrame:
+        raise AssertionError("reader should not be called")
+
+    with patch(
+        "inspect_scout._transcript.caching.AsyncFilesystem", MissingPathFilesystem
+    ):
+        with pytest.raises(FileNotFoundError):
+            samples_df_with_caching(fail_reader, "s3://bucket/nope.json")
 
 
 def test_cache_version_invalidation(
@@ -445,7 +466,7 @@ def test_cache_version_invalidation(
 def test_dataframe_cache_roundtrip(mock_filesystem: Mock) -> None:
     """Cache roundtrip preserves realistic DataFrame with pyarrow dtypes."""
     fresh = samples_df([LOGS_DIR.as_posix()], TranscriptColumns)
-    reader = Mock(return_value=[fresh])
+    reader = Mock(return_value=fresh)
 
     first = samples_df_with_caching(reader, "s3://bucket/log.json")
     second = samples_df_with_caching(reader, "s3://bucket/log.json")

--- a/tests/transcript/test_caching.py
+++ b/tests/transcript/test_caching.py
@@ -315,10 +315,12 @@ def test_samples_df_with_caching_failure_preserves_completed_reads(
 ) -> None:
     """A failing read preserves cache entries for reads that succeeded."""
     paths = [f"s3://bucket/log{i}.json" for i in range(4)]
+    succeeded: list[str] = []
 
     def failing_reader(path: str) -> pd.DataFrame:
         if path == paths[2]:
             raise ValueError("boom")
+        succeeded.append(path)
         return pd.DataFrame({"id": [path]})
 
     with pytest.raises(ValueError, match="boom"):
@@ -330,9 +332,32 @@ def test_samples_df_with_caching_failure_preserves_completed_reads(
         read_paths.append(path)
         return pd.DataFrame({"id": [path]})
 
+    # only the failed path and any reads cancelled while still queued are
+    # re-read; every read that succeeded came from the cache
     result = samples_df_with_caching(reader, paths)
-    assert read_paths == [paths[2]]  # the other paths came from the cache
+    assert paths[2] in read_paths
+    assert sorted(read_paths) == sorted(set(paths) - set(succeeded))
     assert sorted(result["id"].tolist()) == sorted(paths)
+
+
+def test_samples_df_with_caching_failure_with_queued_reads_raises(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """A failure while reads are still queued raises instead of deadlocking.
+
+    With one worker, the remaining paths are still queued when the first
+    read fails; their futures get cancelled without ever being picked up
+    by a worker, and as_completed never yields such futures.
+    """
+    paths = [f"s3://bucket/log{i}.json" for i in range(4)]
+
+    def failing_reader(path: str) -> pd.DataFrame:
+        if path == paths[0]:
+            raise ValueError("boom")
+        return pd.DataFrame({"id": [path]})
+
+    with pytest.raises(ValueError, match="boom"):
+        samples_df_with_caching(failing_reader, paths, max_workers=1)
 
 
 def test_resolve_logs_concurrent_info_preserves_association(

--- a/tests/transcript/test_caching.py
+++ b/tests/transcript/test_caching.py
@@ -157,27 +157,37 @@ def mock_filesystem() -> Iterator[Mock]:
         yield Mock()
 
 
+def _paths_read(mock: Mock) -> list[str]:
+    """All paths passed to a batch reader mock, across calls, in order."""
+    return [path for call in mock.call_args_list for path in call.args[0]]
+
+
 @pytest.fixture
 def mock_reader() -> Mock:
     """Mock reader function that tracks calls and returns DataFrames."""
-    call_counter = {"count": 0}
+    path_counter = {"count": 0}
 
-    def reader_impl(path: str) -> pd.DataFrame:
-        call_num = call_counter["count"]
-        call_counter["count"] += 1
-        return pd.DataFrame(
-            {
-                "eval_id": [f"eval_{call_num}"],
-                "id": [f"sample_{call_num}"],
-                "score": [0.5 + call_num * 0.1],
-            }
-        )
+    def reader_impl(paths: list[str]) -> list[pd.DataFrame]:
+        dfs: list[pd.DataFrame] = []
+        for _ in paths:
+            path_num = path_counter["count"]
+            path_counter["count"] += 1
+            dfs.append(
+                pd.DataFrame(
+                    {
+                        "eval_id": [f"eval_{path_num}"],
+                        "id": [f"sample_{path_num}"],
+                        "score": [0.5 + path_num * 0.1],
+                    }
+                )
+            )
+        return dfs
 
     return Mock(side_effect=reader_impl)
 
 
 @pytest.mark.parametrize(
-    "logs_input,expected_calls,expected_rows",
+    "logs_input,expected_paths,expected_rows",
     [
         ("s3://bucket/log.json", 1, 1),
         (["s3://bucket/log1.json", "s3://bucket/log2.json"], 2, 2),
@@ -189,12 +199,12 @@ def test_samples_df_with_caching_reads_and_concatenates(
     mock_filesystem: Mock,
     mock_reader: Mock,
     logs_input: Any,
-    expected_calls: int,
+    expected_paths: int,
     expected_rows: int,
 ) -> None:
     """Reads logs and concatenates into single DataFrame."""
     result = samples_df_with_caching(mock_reader, logs_input)
-    assert mock_reader.call_count == expected_calls
+    assert len(_paths_read(mock_reader)) == expected_paths
     assert len(result) == expected_rows
 
 
@@ -212,10 +222,10 @@ def test_samples_df_with_caching_uses_cache_on_second_read(
 ) -> None:
     """Second read with same etag uses cache, doesn't call reader."""
     result1 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
 
     result2 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
     pd.testing.assert_frame_equal(result1, result2, check_dtype=False)
 
 
@@ -224,7 +234,7 @@ def test_samples_df_with_caching_invalidates_on_etag_change(
 ) -> None:
     """Etag change invalidates cache and triggers re-read."""
     samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
 
     # Simulate etag change
     def new_mock_fs(path: str) -> Any:
@@ -240,14 +250,14 @@ def test_samples_df_with_caching_invalidates_on_etag_change(
 
     with patch("inspect_scout._transcript.caching.filesystem", side_effect=new_mock_fs):
         samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-        assert mock_reader.call_count == 2
+        assert len(_paths_read(mock_reader)) == 2
 
 
 def test_samples_df_with_caching_dataframe_roundtrip(
     mock_kvstore: Mock, mock_filesystem: Mock, sample_df: pd.DataFrame
 ) -> None:
     """Cached DataFrame preserves data through JSON serialization."""
-    reader = Mock(return_value=sample_df)
+    reader = Mock(return_value=[sample_df])
 
     result1 = samples_df_with_caching(reader, "s3://bucket/log.json")
     result2 = samples_df_with_caching(reader, "s3://bucket/log.json")
@@ -262,10 +272,10 @@ def test_samples_df_with_caching_files_without_etag(
 ) -> None:
     """Files without native etag use mtime:size fallback for caching."""
     result1 = samples_df_with_caching(mock_reader, "/local/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
 
     result2 = samples_df_with_caching(mock_reader, "/local/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
     pd.testing.assert_frame_equal(result1, result2, check_dtype=False)
 
 
@@ -274,8 +284,132 @@ def test_samples_df_with_caching_directory_input(
 ) -> None:
     """Directory input expands to multiple files."""
     result = samples_df_with_caching(mock_reader, "s3://bucket/dir/")
-    assert mock_reader.call_count == 2
+    assert len(_paths_read(mock_reader)) == 2
     assert len(result) == 2
+
+
+def test_samples_df_with_caching_chunks_misses(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """Cache misses are read in chunks of up to chunk_size, in input order."""
+    paths = [f"s3://bucket/log{i}.json" for i in range(5)]
+    chunks: list[list[str]] = []
+
+    def reader(chunk: list[str]) -> list[pd.DataFrame]:
+        chunks.append(list(chunk))
+        return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+    result = samples_df_with_caching(reader, paths, chunk_size=2)
+    assert chunks == [paths[0:2], paths[2:4], paths[4:5]]
+    assert result["id"].tolist() == paths
+
+
+def test_samples_df_with_caching_caches_per_path(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """Each path in a chunk gets its own cache entry, aligned with its data."""
+    paths = [f"s3://bucket/log{i}.json" for i in range(4)]
+
+    def reader(chunk: list[str]) -> list[pd.DataFrame]:
+        return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+    samples_df_with_caching(reader, paths, chunk_size=2)
+
+    def fail_reader(chunk: list[str]) -> list[pd.DataFrame]:
+        raise AssertionError("all paths should be cache hits")
+
+    for path in paths:
+        cached = samples_df_with_caching(fail_reader, path)
+        assert cached["id"].tolist() == [path]
+
+
+def test_samples_df_with_caching_reader_count_mismatch(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """Reader returning the wrong number of DataFrames raises."""
+
+    def bad_reader(chunk: list[str]) -> list[pd.DataFrame]:
+        return [pd.DataFrame({"id": [chunk[0]]})]
+
+    with pytest.raises(ValueError, match="DataFrames"):
+        samples_df_with_caching(
+            bad_reader, ["s3://bucket/log1.json", "s3://bucket/log2.json"]
+        )
+
+
+def test_samples_df_with_caching_failure_preserves_prior_chunks(
+    mock_kvstore: Mock, mock_filesystem: Mock
+) -> None:
+    """A failure part way through preserves cache entries from earlier chunks."""
+    paths = [f"s3://bucket/log{i}.json" for i in range(4)]
+
+    def failing_reader(chunk: list[str]) -> list[pd.DataFrame]:
+        if paths[2] in chunk:
+            raise ValueError("boom")
+        return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+    with pytest.raises(ValueError, match="boom"):
+        samples_df_with_caching(failing_reader, paths, chunk_size=2)
+
+    read_paths: list[str] = []
+
+    def reader(chunk: list[str]) -> list[pd.DataFrame]:
+        read_paths.extend(chunk)
+        return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+    result = samples_df_with_caching(reader, paths, chunk_size=2)
+    assert read_paths == paths[2:4]  # first chunk came from the cache
+    assert sorted(result["id"].tolist()) == sorted(paths)
+
+
+def test_resolve_logs_concurrent_info_preserves_association(
+    mock_kvstore: Mock,
+) -> None:
+    """Concurrent fs.info fetches keep each etag associated with its path."""
+    import time
+
+    paths = [f"s3://bucket/log{i}.json" for i in range(4)]
+    # earlier paths take longer, so completion order inverts input order
+    delays = {path: 0.02 * (len(paths) - i) for i, path in enumerate(paths)}
+    etags = {path: f"etag-{i}" for i, path in enumerate(paths)}
+
+    def make_fs(path: str) -> Any:
+        fs = Mock()
+
+        def info(p: str) -> FileInfo:
+            time.sleep(delays[p])
+            return FileInfo(
+                name=p, size=1024, type="file", mtime=1234567890.0, etag=etags[p]
+            )
+
+        fs.info = info
+        return fs
+
+    def reader(chunk: list[str]) -> list[pd.DataFrame]:
+        return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+    with (
+        patch("inspect_scout._transcript.caching.filesystem", side_effect=make_fs),
+        patch(
+            "inspect_scout._transcript.caching.log_files_from_ls",
+            side_effect=lambda file_infos, sort: [
+                create_evalloginfo(fi.name) for fi in file_infos
+            ],
+        ),
+    ):
+        result = samples_df_with_caching(reader, paths)
+        assert result["id"].tolist() == paths
+
+        # invalidate a single path's etag: exactly that path is re-read
+        etags[paths[1]] = "etag-changed"
+        read_paths: list[str] = []
+
+        def reader2(chunk: list[str]) -> list[pd.DataFrame]:
+            read_paths.extend(chunk)
+            return [pd.DataFrame({"id": [path]}) for path in chunk]
+
+        samples_df_with_caching(reader2, paths)
+        assert read_paths == [paths[1]]
 
 
 def test_cache_version_invalidation(
@@ -286,11 +420,11 @@ def test_cache_version_invalidation(
 
     # First call populates cache with current version
     result1 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
 
     # Second call uses cache (same version)
     result2 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-    assert mock_reader.call_count == 1
+    assert len(_paths_read(mock_reader)) == 1
     pd.testing.assert_frame_equal(result1, result2, check_dtype=False)
 
     # Simulate version change by patching _CACHE_VERSION
@@ -300,18 +434,18 @@ def test_cache_version_invalidation(
     ):
         # Third call triggers cache invalidation and re-read
         result3 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-        assert mock_reader.call_count == 2
+        assert len(_paths_read(mock_reader)) == 2
 
         # Fourth call uses cache again (with new version)
         result4 = samples_df_with_caching(mock_reader, "s3://bucket/log.json")
-        assert mock_reader.call_count == 2
+        assert len(_paths_read(mock_reader)) == 2
         pd.testing.assert_frame_equal(result3, result4, check_dtype=False)
 
 
 def test_dataframe_cache_roundtrip(mock_filesystem: Mock) -> None:
     """Cache roundtrip preserves realistic DataFrame with pyarrow dtypes."""
     fresh = samples_df([LOGS_DIR.as_posix()], TranscriptColumns)
-    reader = Mock(return_value=fresh)
+    reader = Mock(return_value=[fresh])
 
     first = samples_df_with_caching(reader, "s3://bucket/log.json")
     second = samples_df_with_caching(reader, "s3://bucket/log.json")

--- a/tests/transcript/test_eval_log_indexing.py
+++ b/tests/transcript/test_eval_log_indexing.py
@@ -1,111 +1,15 @@
-"""Tests for concurrent multi-log indexing in eval_log.py."""
+"""Tests for eval log sample reading in eval_log.py."""
 
-import shutil
 from pathlib import Path
 
-import pandas as pd
-import pytest
-from inspect_ai.analysis import samples_df
-from inspect_scout._transcript.eval_log import (
-    TranscriptColumns,
-    _read_samples_per_log,
-    _split_df_by_log,
-)
+from inspect_scout._transcript.eval_log import _read_samples
 
 LOGS_DIR = Path(__file__).parent.parent / "recorder" / "logs"
 LOG_1 = LOGS_DIR / "2025-09-23T08-09-58-04-00_popularity_DN2wbX2ZvACsBpjwptzBRo.eval"
-LOG_2 = (
-    LOGS_DIR / "2025-09-23T08-09-58-04-00_security-guide_LuxZJVwvymC3S3SyoJczxB.eval"
-)
 
 
-def test_read_samples_per_log_matches_individual_reads() -> None:
-    """A multi-path read yields the same per-log frames as individual reads."""
-    paths = [LOG_1.as_posix(), LOG_2.as_posix()]
-
-    batched = _read_samples_per_log(paths)
-    individual = [_read_samples_per_log([path])[0] for path in paths]
-
-    assert len(batched) == len(paths)
-    for batched_df, individual_df in zip(batched, individual, strict=True):
-        # a batched frame may carry extra all-null columns contributed by
-        # other logs in the batch (e.g. score_* columns of another task);
-        # for the log's own columns the content must match
-        extra = [c for c in batched_df.columns if c not in individual_df.columns]
-        assert all(batched_df[c].isna().all() for c in extra)
-        pd.testing.assert_frame_equal(
-            batched_df[list(individual_df.columns)],
-            individual_df,
-            check_dtype=False,
-        )
-
-
-def test_read_samples_per_log_sets_transcript_id() -> None:
-    """Each per-log frame carries transcript_id derived from sample_id."""
-    dfs = _read_samples_per_log([LOG_1.as_posix(), LOG_2.as_posix()])
-    for df in dfs:
-        assert not df.empty
-        assert df["transcript_id"].tolist() == df["sample_id"].tolist()
-
-
-def test_read_samples_per_log_duplicate_logs(tmp_path: Path) -> None:
-    """Copies of the same eval log each yield their full set of samples.
-
-    inspect_ai de-duplicates evals within a multi-path call, so without the
-    re-read safeguard the duplicate file would come back empty (and poison
-    the per-file cache with an empty entry).
-    """
-    copy_1 = tmp_path / "copy_1.eval"
-    copy_2 = tmp_path / "copy_2.eval"
-    shutil.copy(LOG_1, copy_1)
-    shutil.copy(LOG_1, copy_2)
-
-    reference = samples_df([LOG_1.as_posix()], TranscriptColumns)
-    dfs = _read_samples_per_log([copy_1.as_posix(), copy_2.as_posix()])
-
-    assert len(dfs) == 2
-    for df in dfs:
-        assert len(df) == len(reference)
-        assert sorted(df["sample_id"].tolist()) == sorted(
-            reference["sample_id"].tolist()
-        )
-
-
-def test_split_df_by_log_partitions_rows() -> None:
-    """Rows are partitioned by their log value, in the order of paths."""
-    df = pd.DataFrame(
-        {
-            "log": ["/logs/log_b", "/logs/log_a", "/logs/log_b", "/logs/log_a"],
-            "sample_id": ["s1", "s2", "s3", "s4"],
-        }
-    )
-
-    dfs = _split_df_by_log(df, ["/logs/log_a", "/logs/log_b", "/logs/log_c"])
-
-    assert dfs[0]["sample_id"].tolist() == ["s2", "s4"]
-    assert dfs[1]["sample_id"].tolist() == ["s1", "s3"]
-    assert dfs[2].empty
-    assert list(dfs[2].columns) == ["log", "sample_id"]
-
-
-def test_split_df_by_log_matches_native_paths() -> None:
-    """Requested file:// paths match log values in native (stripped) form."""
-    df = pd.DataFrame({"log": ["/logs/log_a"], "sample_id": ["s1"]})
-    dfs = _split_df_by_log(df, ["file:///logs/log_a"])
-    assert dfs[0]["sample_id"].tolist() == ["s1"]
-
-
-def test_split_df_by_log_empty_df() -> None:
-    """An empty DataFrame splits into empty frames, one per path."""
-    dfs = _split_df_by_log(pd.DataFrame(), ["/logs/log_a", "/logs/log_b"])
-    assert len(dfs) == 2
-    assert all(df.empty for df in dfs)
-
-
-def test_split_df_by_log_unrequested_log_raises() -> None:
-    """Rows for a log that was not requested raise instead of being dropped."""
-    df = pd.DataFrame(
-        {"log": ["/logs/log_a", "/logs/log_x"], "sample_id": ["s1", "s2"]}
-    )
-    with pytest.raises(RuntimeError, match="log_x"):
-        _split_df_by_log(df, ["/logs/log_a"])
+def test_read_samples_sets_transcript_id() -> None:
+    """The samples frame carries transcript_id derived from sample_id."""
+    df = _read_samples([LOG_1.as_posix()])
+    assert not df.empty
+    assert df["transcript_id"].tolist() == df["sample_id"].tolist()

--- a/tests/transcript/test_eval_log_indexing.py
+++ b/tests/transcript/test_eval_log_indexing.py
@@ -1,0 +1,111 @@
+"""Tests for concurrent multi-log indexing in eval_log.py."""
+
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from inspect_ai.analysis import samples_df
+from inspect_scout._transcript.eval_log import (
+    TranscriptColumns,
+    _read_samples_per_log,
+    _split_df_by_log,
+)
+
+LOGS_DIR = Path(__file__).parent.parent / "recorder" / "logs"
+LOG_1 = LOGS_DIR / "2025-09-23T08-09-58-04-00_popularity_DN2wbX2ZvACsBpjwptzBRo.eval"
+LOG_2 = (
+    LOGS_DIR / "2025-09-23T08-09-58-04-00_security-guide_LuxZJVwvymC3S3SyoJczxB.eval"
+)
+
+
+def test_read_samples_per_log_matches_individual_reads() -> None:
+    """A multi-path read yields the same per-log frames as individual reads."""
+    paths = [LOG_1.as_posix(), LOG_2.as_posix()]
+
+    batched = _read_samples_per_log(paths)
+    individual = [_read_samples_per_log([path])[0] for path in paths]
+
+    assert len(batched) == len(paths)
+    for batched_df, individual_df in zip(batched, individual, strict=True):
+        # a batched frame may carry extra all-null columns contributed by
+        # other logs in the batch (e.g. score_* columns of another task);
+        # for the log's own columns the content must match
+        extra = [c for c in batched_df.columns if c not in individual_df.columns]
+        assert all(batched_df[c].isna().all() for c in extra)
+        pd.testing.assert_frame_equal(
+            batched_df[list(individual_df.columns)],
+            individual_df,
+            check_dtype=False,
+        )
+
+
+def test_read_samples_per_log_sets_transcript_id() -> None:
+    """Each per-log frame carries transcript_id derived from sample_id."""
+    dfs = _read_samples_per_log([LOG_1.as_posix(), LOG_2.as_posix()])
+    for df in dfs:
+        assert not df.empty
+        assert df["transcript_id"].tolist() == df["sample_id"].tolist()
+
+
+def test_read_samples_per_log_duplicate_logs(tmp_path: Path) -> None:
+    """Copies of the same eval log each yield their full set of samples.
+
+    inspect_ai de-duplicates evals within a multi-path call, so without the
+    re-read safeguard the duplicate file would come back empty (and poison
+    the per-file cache with an empty entry).
+    """
+    copy_1 = tmp_path / "copy_1.eval"
+    copy_2 = tmp_path / "copy_2.eval"
+    shutil.copy(LOG_1, copy_1)
+    shutil.copy(LOG_1, copy_2)
+
+    reference = samples_df([LOG_1.as_posix()], TranscriptColumns)
+    dfs = _read_samples_per_log([copy_1.as_posix(), copy_2.as_posix()])
+
+    assert len(dfs) == 2
+    for df in dfs:
+        assert len(df) == len(reference)
+        assert sorted(df["sample_id"].tolist()) == sorted(
+            reference["sample_id"].tolist()
+        )
+
+
+def test_split_df_by_log_partitions_rows() -> None:
+    """Rows are partitioned by their log value, in the order of paths."""
+    df = pd.DataFrame(
+        {
+            "log": ["/logs/log_b", "/logs/log_a", "/logs/log_b", "/logs/log_a"],
+            "sample_id": ["s1", "s2", "s3", "s4"],
+        }
+    )
+
+    dfs = _split_df_by_log(df, ["/logs/log_a", "/logs/log_b", "/logs/log_c"])
+
+    assert dfs[0]["sample_id"].tolist() == ["s2", "s4"]
+    assert dfs[1]["sample_id"].tolist() == ["s1", "s3"]
+    assert dfs[2].empty
+    assert list(dfs[2].columns) == ["log", "sample_id"]
+
+
+def test_split_df_by_log_matches_native_paths() -> None:
+    """Requested file:// paths match log values in native (stripped) form."""
+    df = pd.DataFrame({"log": ["/logs/log_a"], "sample_id": ["s1"]})
+    dfs = _split_df_by_log(df, ["file:///logs/log_a"])
+    assert dfs[0]["sample_id"].tolist() == ["s1"]
+
+
+def test_split_df_by_log_empty_df() -> None:
+    """An empty DataFrame splits into empty frames, one per path."""
+    dfs = _split_df_by_log(pd.DataFrame(), ["/logs/log_a", "/logs/log_b"])
+    assert len(dfs) == 2
+    assert all(df.empty for df in dfs)
+
+
+def test_split_df_by_log_unrequested_log_raises() -> None:
+    """Rows for a log that was not requested raise instead of being dropped."""
+    df = pd.DataFrame(
+        {"log": ["/logs/log_a", "/logs/log_x"], "sample_id": ["s1", "s2"]}
+    )
+    with pytest.raises(RuntimeError, match="log_x"):
+        _split_df_by_log(df, ["/logs/log_a"])


### PR DESCRIPTION
## Summary
Indexing previously read each eval log with a separate serial call, so jobs over hundreds of S3-hosted logs spent most of their time in per-file round trips (#475). This PR makes the two phases of indexing concurrent:

- **Log resolution** (`_resolve_logs`): paths are expanded and etags fetched concurrently on a shared warm `AsyncFilesystem` client. This builds directly on the recent inspect_ai change ([inspect_ai#3684](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3684) and follow-on work) that gave `iter_files`/`iter_dirs` a `detail=True` mode returning the `FileInfo` the listing previously threw on the floor — made for exactly this use: a directory input now costs one listing sweep yielding file names *and* etags from `list_objects_v2` metadata, with no per-file stat calls or new fsspec call sites. A file input costs one async `info()`.
- **Sample reads**: cache misses are read concurrently on a thread pool (16 workers by default), one file per `samples_df` call, with each file cached (keyed by etag) as soon as its read completes — so a failure part way through preserves the files already read.

## Why one file per reader call (not batching)

An earlier iteration of this PR batched 32 paths into single multi-log `samples_df` calls. That was abandoned: `samples_df` de-duplicates samples by uuid across all logs it is given, and eval-set retry logs carry completed samples forward with identical uuids — so two retry logs for the same task read in one call each get a partial (and silently wrong) result, which then gets cached by etag. Found empirically on `s3://meridian-test-data/logs`: one retry log dropped from 1000 rows to 158 depending on which files shared a batch. Per-file calls make the de-duplication a no-op and match the semantics of the serial implementation exactly, at equivalent speed and with far less code (no combined-frame splitting, no re-read safeguards, no batch composition rules).

## Key Changes

**`caching.py`**
- `samples_df_with_caching` reads cache misses via `ThreadPoolExecutor` (default 16 workers, `max_workers` param); reader signature stays `Callable[[str], pd.DataFrame]`
- Each file is cached on completion (kvstore stays on the calling thread); on first failure it stops submitting new reads, caches in-flight successes, then re-raises
- `_resolve_logs` uses `run_coroutine`/`tg_collect` with a shared `AsyncFilesystem`: directories expand via a single `iter_files(recursive=True, detail=True)` sweep, files via concurrent `info()`. S3 has no directory objects so `info()` raises for prefixes; a path that lists non-empty is treated as a directory, anything else re-raises

**`eval_log.py`**
- `_index_logs` reader takes a single path; `trace_action` wraps each file read

**Tests**
- Mock `AsyncFilesystem` (async `info`/`iter_files`) replaces the fsspec mocks
- New coverage: S3 directory-prefix expansion, missing-path error propagation, concurrent etag→path association, failure preserving completed reads

## Performance Measurement

Cold-cache indexing of `s3://meridian-test-data/logs` (~336 objects → 295 eval logs). Method: fresh process, `scout_transcript_info_cache.db` deleted before each run, wall time of `_index_logs("s3://meridian-test-data/logs")`.

| Version | Wall time | Samples indexed |
|---------|-----------|-----------------|
| `origin/main` (serial, one file per call) | 1062 s (~17.7 min) | 14,052 |
| This PR (concurrent per-file reads, 16 threads) | 169 s (~2.8 min) — **~6× faster** | 14,052 |

Per-file cache contents verified byte-identical to the serial implementation across all 295 files (including the eval-set retry pair that the batched design corrupted). Wall time on this workload varied roughly ±25% across runs (S3 read throughput), so treat the speedup as approximate.

## Possible Follow-ups

- Each per-file `samples_df` call warms its own S3 client (~0.5–1 s, overlapped across threads). A process-shared warm client in inspect_ai (or `samples_df` accepting an `AsyncFilesystem`) would shave this.
- `_resolve_logs`'s etag logic could migrate into inspect_ai's `resolve_logs()`.

https://claude.ai/code/session_01ThJmjTpPzpe4M798ScGu1W

