### PR TITLE
fix: reject scanners whose union types don't cover all filtered message/event types

### DIFF
--- a/src/inspect_scout/_scanner/validate.py
+++ b/src/inspect_scout/_scanner/validate.py
@@ -465,18 +465,19 @@ def _can_handle_all_types(
     return _is_compatible_with_type(scanner_type, required_type)
 
 
+def _is_union_type(type_hint: Any) -> bool:
+    """Check if a type hint is a union, in either spelling.
+
+    Covers ``typing.Union[X, Y]`` and the ``X | Y`` syntax (distinct types
+    before Python 3.14, unified from 3.14 on).
+    """
+    return get_origin(type_hint) is Union or isinstance(type_hint, UnionType)
+
+
 def _get_union_members(type_hint: Any) -> set[Type[Any]] | None:
     """Get the member types of a Union, or None if not a Union."""
-    origin = get_origin(type_hint)
-
-    # Handle Union from typing module
-    if origin is Union:
+    if _is_union_type(type_hint):
         return set(get_args(type_hint))
-
-    # Handle Python 3.10+ union syntax (X | Y)
-    if isinstance(type_hint, UnionType):
-        return set(get_args(type_hint))
-
     return None
 
 
@@ -516,10 +517,7 @@ def _is_compatible_with_type(scanner_type: Any, target_type: Any) -> bool:
 
         # Unions never match on origin alone (every union's origin is Union,
         # so a partial union would wrongly match a full one)
-        if (
-            _get_union_members(target_type) is not None
-            or _get_union_members(scanner_type) is not None
-        ):
+        if _is_union_type(scanner_type) or _is_union_type(target_type):
             return _union_covers_union(scanner_type, target_type)
 
         # Try to check subclass relationship

--- a/src/inspect_scout/_scanner/validate.py
+++ b/src/inspect_scout/_scanner/validate.py
@@ -480,6 +480,22 @@ def _get_union_members(type_hint: Any) -> set[Type[Any]] | None:
     return None
 
 
+def _union_covers_union(scanner_type: Any, target_type: Any) -> bool:
+    """Check if a union scanner type covers every member of a union target.
+
+    A partial union (e.g. two of ChatMessage's four members) does not cover
+    the full union. Returns False if either type is not a union.
+    """
+    scanner_members = _get_union_members(scanner_type)
+    target_members = _get_union_members(target_type)
+    if scanner_members is None or target_members is None:
+        return False
+    return all(
+        any(_is_compatible_with_type(s, t) for s in scanner_members)
+        for t in target_members
+    )
+
+
 def _is_compatible_with_type(scanner_type: Any, target_type: Any) -> bool:
     """
     Check if scanner_type is compatible with target_type.
@@ -497,6 +513,14 @@ def _is_compatible_with_type(scanner_type: Any, target_type: Any) -> bool:
         # Direct equality
         if scanner_type == target_type:
             return True
+
+        # Unions never match on origin alone (every union's origin is Union,
+        # so a partial union would wrongly match a full one)
+        if (
+            _get_union_members(target_type) is not None
+            or _get_union_members(scanner_type) is not None
+        ):
+            return _union_covers_union(scanner_type, target_type)
 
         # Try to check subclass relationship
         # This works for normal classes

--- a/tests/scanner/test_validation.py
+++ b/tests/scanner/test_validation.py
@@ -1,7 +1,7 @@
 """Tests for runtime type validation in the scanner module."""
 
 from collections.abc import AsyncIterator, Callable
-from typing import Any
+from typing import Any, Union
 
 import pytest
 from inspect_ai._util.registry import registry_info
@@ -17,6 +17,7 @@ from inspect_ai.model._chat_message import (
 )
 from inspect_scout._scanner.result import Result
 from inspect_scout._scanner.scanner import SCANNER_CONFIG, Scanner, scanner
+from inspect_scout._scanner.validate import _is_compatible_with_type
 from inspect_scout._transcript.types import Transcript
 
 # Valid scanner tests
@@ -523,3 +524,100 @@ def test_message_validation_matrix(
                 return scan
 
             test_scanner()
+
+
+# Union-spelling regression tests
+#
+# A union type can be written two ways: the pipe form (``X | Y``) and the
+# typing form (``Union[X, Y]``). Before Python 3.14 these had different origins
+# (``types.UnionType`` vs ``typing.Union``); 3.14 unified them into one type.
+# The existing union tests above only exercise the pipe form, so they never
+# covered the typing form — which was mishandled on every Python version. These
+# tests pin the behaviour across both spellings.
+
+_PARTIAL_UNION_PIPE: Any = ChatMessageSystem | ChatMessageUser
+_PARTIAL_UNION_TYPING: Any = Union[ChatMessageSystem, ChatMessageUser]
+_FULL_UNION_PIPE: Any = (
+    ChatMessageSystem | ChatMessageUser | ChatMessageAssistant | ChatMessageTool
+)
+_FULL_UNION_TYPING: Any = Union[
+    ChatMessageSystem, ChatMessageUser, ChatMessageAssistant, ChatMessageTool
+]
+
+
+@pytest.mark.parametrize(
+    "scanner_type",
+    [
+        pytest.param(_PARTIAL_UNION_PIPE, id="pipe"),
+        pytest.param(_PARTIAL_UNION_TYPING, id="typing-union"),
+    ],
+)
+def test_partial_union_rejected_both_spellings(scanner_type: Any) -> None:
+    """A partial union can't satisfy a filter requiring more types.
+
+    Holds whichever way the union is written (pipe or typing.Union).
+    """
+    with pytest.raises(TypeError, match="must be able to handle all types"):
+
+        @scanner(messages=["system", "user", "assistant"])
+        def test_scanner() -> Scanner[scanner_type]:  # pyright: ignore[reportInvalidTypeForm]
+            async def scan(message: scanner_type) -> Result:
+                return Result(value={"bad": True})
+
+            return scan
+
+        test_scanner()
+
+
+def test_full_union_typing_spelling_accepts_all() -> None:
+    """A full union written with typing.Union satisfies messages='all'.
+
+    Guards against a fix that over-rejects by treating every union as a subset.
+    """
+
+    @scanner(messages="all")
+    def test_scanner() -> Scanner[
+        Union[
+            ChatMessageSystem,
+            ChatMessageUser,
+            ChatMessageAssistant,
+            ChatMessageTool,
+        ]
+    ]:
+        async def scan(
+            message: Union[
+                ChatMessageSystem,
+                ChatMessageUser,
+                ChatMessageAssistant,
+                ChatMessageTool,
+            ],
+        ) -> Result:
+            return Result(value={"ok": True})
+
+        return scan
+
+    scanner_instance = test_scanner()
+    assert registry_info(scanner_instance).metadata[SCANNER_CONFIG]
+
+
+@pytest.mark.parametrize(
+    "scanner_type,target,expected",
+    [
+        # A partial union is not the base union, however it is spelled.
+        pytest.param(_PARTIAL_UNION_PIPE, ChatMessage, False, id="partial-pipe"),
+        pytest.param(_PARTIAL_UNION_TYPING, ChatMessage, False, id="partial-typing"),
+        # A full union is equivalent to the base union.
+        pytest.param(_FULL_UNION_PIPE, ChatMessage, True, id="full-pipe"),
+        pytest.param(_FULL_UNION_TYPING, ChatMessage, True, id="full-typing"),
+        # The base alias is trivially compatible with itself.
+        pytest.param(ChatMessage, ChatMessage, True, id="alias"),
+    ],
+)
+def test_is_compatible_with_type_union_semantics(
+    scanner_type: Any, target: Any, expected: bool
+) -> None:
+    """A union counts as the base type only when it covers every member.
+
+    Equivalently, only when it equals the base union — never for a strict subset.
+    """
+    assert _is_compatible_with_type(scanner_type, target) is expected


### PR DESCRIPTION
## Summary

`_is_compatible_with_type` had an origin-equality fallback that treated *any* union as compatible with a union target — e.g. a scanner typed `ChatMessageSystem | ChatMessageUser` passed validation as `ChatMessage`. A union now satisfies a union target only when it covers every target member.

The old check compared union origins, never union members, so partial unions written as `typing.Union[X, Y]` passed validation on every Python version. Pipe-spelled unions (`X | Y`) were broken before 3.14 too, just in the opposite direction: their origin (`types.UnionType`) never matched `typing.Union`, so any pipe union not exactly equal to the target was rejected outright — even when its members covered it. Python 3.14 unified the two spellings, flipping the pipe form from over-rejection to over-acceptance, which is how this surfaced (see #531).

## ⚠️ Change in behaviour

This tightens validation: scanners with partial-union types that previously passed validation **incorrectly** will now be rejected at registration with a `TypeError`. Those scanners were already receiving message types they didn't declare — the new error is surfacing a real mismatch, but existing code may need its type annotations (or filters) fixed.

This is unlikely to affect many users, so we're not classifying this as a breaking change. Here is an example of a scanner which would be implicated in this change:

```py
from typing import Union

from inspect_ai.model import ChatMessageSystem, ChatMessageUser
from inspect_scout import Result, Scanner, scanner


@scanner(messages=["system", "user", "assistant"])
def broken() -> Scanner[Union[ChatMessageSystem, ChatMessageUser]]:  # <- missing assistant, should fail
    async def scan(message: Union[ChatMessageSystem, ChatMessageUser]) -> Result:
        return Result(value=True)

    return scan


broken()  # before: registers fine; after: TypeError "must be able to handle all types"
```