### PR TITLE
ci: test against Python 3.10 and 3.14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        # rationale: test the supported floor and the latest release
+        python-version: &python-versions ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Lint with Ruff
@@ -29,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: *python-versions
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -60,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: *python-versions
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -90,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: *python-versions
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Run the CI test matrix on the supported floor (3.10) and the latest release (3.14), instead of 3.10/3.11. Motivation: https://github.com/meridianlabs-ai/inspect_scout/pull/486#issuecomment-4846004034 and internal discussion on standardising on floor + latest.

**Depends on #530 (merged)** — 3.14 unified the two union spellings, which exposes the validation bug fixed there; CI on this PR will fail until that lands.