### PR TITLE
docs: add PR-title and release guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@
 
 - Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it
 - `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. `perf:`/`revert:` also appear in the notes (no bump); `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` are hidden
-- Body lines starting with `type:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
+- Body lines starting with `<type>:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
 - Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@
 - Never edit generated files—`openapi.json` and `generated.ts` are generated; modify source and regenerate
 - During development, run only implicated tests; run the full suite when the work is complete
 
+## Pull Requests
+
+- Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it
+- `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. Everything else (`docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`) is hidden from the notes
+- Body lines starting with `type:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
+- Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines
+
 ## Documentation
 
 Consult documentation when you need deeper context on how subsystems work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 ## Pull Requests
 
 - Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it
-- `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. Everything else (`docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`) is hidden from the notes
+- `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. `perf:`/`revert:` also appear in the notes (no bump); `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` are hidden
 - Body lines starting with `type:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
 - Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines


### PR DESCRIPTION
Adds a **Pull Requests** section to `AGENTS.md` (which `CLAUDE.md` symlinks to, so it covers both). Rationale: agents read `AGENTS.md`/`CLAUDE.md` automatically but don't reliably open `CONTRIBUTING.md` — so the rules that actually bite are inlined:

- Conventional-commit PR titles (squash-merge → title becomes the release-driving commit; linted)
- `feat:`/`fix:` reserved for user-facing changes (they headline notes + bump the version); other types hidden
- Don't start description lines with a `type:` prefix accidentally (they get parsed as extra changelog entries)
- Never hand-edit `CHANGELOG.md` / version / `.release-please-manifest.json`
- Pointer to CONTRIBUTING.md for the rest

This is the template example — if the shape looks right, the same section (minus repo-specific bits) rolls out to the other repos' agent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)