### PR TITLE
ci: scheduled auto-repin of inspect_ai on the release PR

### DIFF
--- a/.github/workflows/release-pin-deps.yml
+++ b/.github/workflows/release-pin-deps.yml
@@ -1,44 +1,83 @@
 name: Pin inspect_ai for release
 
-# On the Release Please release PR, rewrite the `inspect_ai` dependency from a
-# moving git ref (`inspect-ai @ git+...@main`) to the currently-shipped PyPI
-# version (`inspect-ai>=<version>`). Dev on `main` tracks inspect_ai's `main`;
-# a *published* scout must depend on a *released* inspect_ai (PyPI rejects
-# direct-reference deps, and a git ref is not reproducible).
+# On the Release Please release PR, keep the `inspect_ai` dependency pinned to
+# the currently-shipped PyPI version:
+#   - rewrite a moving git ref (`inspect-ai @ git+...@main`) to
+#     `inspect-ai>=<latest>` — dev on `main` tracks inspect_ai's `main`, but a
+#     *published* scout must depend on a *released* inspect_ai (PyPI rejects
+#     direct-reference deps, and a git ref is not reproducible);
+#   - bump a stale floor (`inspect-ai>=OLD`) to the latest shipped version, so
+#     the declared minimum matches what the release build actually validated
+#     against (pip resolves the latest, so a stale floor could ship untested).
+#
+# Runs on release-PR events AND on a schedule: publishing a new inspect_ai to
+# PyPI produces no event in this repo, so the schedule is what turns "inspect
+# shipped the fix we need" into "the release PR re-pins and goes green" without
+# a human nudge. The scheduled path no-ops unless a release PR is open.
 #
 # This is the companion to release-dep-guard.yml: the guard *blocks* a release
 # PR that still carries a git ref; this workflow *fixes* it automatically. If
 # scout genuinely needs an unreleased inspect_ai, pinning to the shipped
 # version makes the release PR's build/tests fail loudly — which is the signal
-# to cut an inspect_ai release first.
+# to cut an inspect_ai release first (and this schedule picks it up once cut).
 
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "23 */2 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: release-pin-deps
+  cancel-in-progress: false
+
 jobs:
   pin:
-    # Only touch the Release Please release PR.
-    if: ${{ github.head_ref == 'release-please--branches--main' }}
+    # PR events: only the Release Please release PR. Schedule/dispatch: always
+    # start; the first step exits quietly when no release PR is open.
+    if: ${{ github.event_name != 'pull_request' || github.head_ref == 'release-please--branches--main' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check an open release PR exists (scheduled runs)
+        id: relpr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          n=$(gh pr list --repo "${{ github.repository }}" \
+                --head release-please--branches--main --state open \
+                --json number --jq 'length')
+          if [ "$n" -gt 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open release PR; nothing to pin."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # App token so the pin commit re-triggers the PR's checks (guard + build).
       # A commit pushed with the default GITHUB_TOKEN would not trigger them.
       - uses: actions/create-github-app-token@v2
+        if: steps.relpr.outputs.found == 'true'
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
+        if: steps.relpr.outputs.found == 'true'
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'release-please--branches--main' }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Rewrite inspect_ai git ref to the shipped PyPI version
+      - name: Pin/bump inspect_ai to the shipped PyPI version
+        if: steps.relpr.outputs.found == 'true'
         run: |
           python3 - <<'PY'
           import json, re, sys, urllib.request
@@ -49,19 +88,39 @@ jobs:
               print("::error::Could not resolve a released inspect-ai version from PyPI")
               sys.exit(1)
 
+          def vtuple(v):
+              try:
+                  return tuple(int(p) for p in v.split("."))
+              except ValueError:
+                  return None
+
           path = "pyproject.toml"
           src = open(path).read()
-          # Match `inspect-ai @ git+...` (or inspect_ai) inside a TOML string.
-          pat = re.compile(r'"inspect[-_]ai\s*@\s*git\+[^"]*"')
-          new = pat.sub(f'"inspect-ai>={version}"', src)
-          if new == src:
-              print(f"No inspect_ai git ref to pin (already released-versioned). Latest PyPI: {version}")
+
+          git_pat = re.compile(r'"inspect[-_]ai\s*@\s*git\+[^"]*"')
+          floor_pat = re.compile(r'"inspect[-_]ai>=([0-9.]+)"')
+
+          if git_pat.search(src):
+              new = git_pat.sub(f'"inspect-ai>={version}"', src)
+              action = f"Pinned inspect_ai git ref to >={version}"
           else:
+              m = floor_pat.search(src)
+              new, action = src, None
+              if m:
+                  cur, latest = vtuple(m.group(1)), vtuple(version)
+                  if cur and latest and latest > cur:
+                      new = floor_pat.sub(f'"inspect-ai>={version}"', src)
+                      action = f"Bumped inspect_ai floor {m.group(1)} -> {version}"
+
+          if action:
               open(path, "w").write(new)
-              print(f"Pinned inspect_ai to >={version}")
+              print(action)
+          else:
+              print(f"inspect_ai pin already current (latest PyPI: {version})")
           PY
 
       - name: Commit the pin if pyproject changed
+        if: steps.relpr.outputs.found == 'true'
         run: |
           if git diff --quiet -- pyproject.toml; then
             echo "No change to commit."
@@ -71,4 +130,4 @@ jobs:
           git config user.email "meridian-release-bot[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore: pin inspect_ai to the shipped release for publishing"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:release-please--branches--main


### PR DESCRIPTION
## Problem

When scout's release PR needs an unreleased inspect_ai, it sits red until inspect ships — and inspect shipping to PyPI produces **no event in this repo**, so nothing re-runs the pin or the checks. Today that takes a manual nudge (re-run the pin job or merge something to main).

## Change

Extends `release-pin-deps.yml` with `schedule` (every 2 hours) + `workflow_dispatch` triggers:

- Scheduled runs **no-op quietly unless a release PR is open**.
- When one is open, checkout its branch and re-pin against PyPI's latest inspect-ai; if anything changed, commit with the App token so the guard/build re-run automatically. Net effect: *inspect ships → scout's release PR goes green within ~2 hours, zero clicks.*
- The pin logic also now **bumps stale floors** (`inspect-ai>=OLD` → `>=latest`), not just git refs. This closes a latent hole: pip resolves the *latest* version regardless of the floor, so once inspect shipped, a re-run build could go green while the release still declared a minimum that was never actually validated — breaking users who hold the older inspect. The floor now always matches what the build tested against.

The pull_request path is unchanged in behavior (git-ref rewrite on release-PR regen), and the floor-bump logic is covered by six local test cases (git-ref pin, stale-floor bump, current floor no-op, never-downgrade, numeric-not-lexical compare, other-deps untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)