### PR TITLE
chore(timeline): give utility-fixture parents a tool-calling loop

### DIFF
--- a/tests/transcript/nodes/fixtures/events/utility_single_turn.json
+++ b/tests/transcript/nodes/fixtures/events/utility_single_turn.json
@@ -1,5 +1,5 @@
 {
-  "description": "Agent with 1 ModelEvent and different system prompt is classified as utility",
+  "description": "Agent with 1 ModelEvent and different system prompt is classified as utility The parent runs a tool-calling loop (dispatching to the checker), which utility classification requires: helper spans are only demoted to utility when the parent has an agentic loop for them to be subordinate to.",
   "events": [
     {
       "event": "span_begin",
@@ -26,14 +26,38 @@
       "timestamp": "2024-01-01T00:00:02Z",
       "completed": "2024-01-01T00:00:03Z",
       "input": [
-        {"role": "system", "content": "You are an orchestrator agent."},
-        {"role": "user", "content": "Solve the task."}
+        {
+          "role": "system",
+          "content": "You are an orchestrator agent."
+        },
+        {
+          "role": "user",
+          "content": "Solve the task."
+        }
       ],
       "output": {
         "usage": {
           "input_tokens": 50,
           "output_tokens": 25
-        }
+        },
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call-1",
+                  "function": "safety_checker",
+                  "arguments": {
+                    "input": "validate this plan"
+                  }
+                }
+              ]
+            },
+            "stop_reason": "tool_calls"
+          }
+        ]
       }
     },
     {
@@ -53,8 +77,14 @@
       "timestamp": "2024-01-01T00:00:05Z",
       "completed": "2024-01-01T00:00:06Z",
       "input": [
-        {"role": "system", "content": "You are a safety checker. Validate the output."},
-        {"role": "user", "content": "Check this output."}
+        {
+          "role": "system",
+          "content": "You are a safety checker. Validate the output."
+        },
+        {
+          "role": "user",
+          "content": "Check this output."
+        }
       ],
       "output": {
         "usage": {
@@ -91,7 +121,9 @@
         "source": "span",
         "span_id": "parent-agent"
       },
-      "event_uuids": ["e-001"],
+      "event_uuids": [
+        "e-001"
+      ],
       "utility": false,
       "children": [
         {
@@ -101,7 +133,9 @@
             "source": "span",
             "span_id": "child-agent"
           },
-          "event_uuids": ["e-002"],
+          "event_uuids": [
+            "e-002"
+          ],
           "utility": true,
           "total_tokens": 45
         }

--- a/tests/transcript/nodes/fixtures/events/utility_tool_turn.json
+++ b/tests/transcript/nodes/fixtures/events/utility_tool_turn.json
@@ -1,5 +1,5 @@
 {
-  "description": "Agent with 2 ModelEvents + ToolEvent between, different system prompt is classified as utility",
+  "description": "Agent with 2 ModelEvents + ToolEvent between, different system prompt is classified as utility The parent runs a tool-calling loop (dispatching to the checker), which utility classification requires: helper spans are only demoted to utility when the parent has an agentic loop for them to be subordinate to.",
   "events": [
     {
       "event": "span_begin",
@@ -26,14 +26,38 @@
       "timestamp": "2024-01-01T00:00:02Z",
       "completed": "2024-01-01T00:00:03Z",
       "input": [
-        {"role": "system", "content": "You are an orchestrator agent."},
-        {"role": "user", "content": "Solve the task."}
+        {
+          "role": "system",
+          "content": "You are an orchestrator agent."
+        },
+        {
+          "role": "user",
+          "content": "Solve the task."
+        }
       ],
       "output": {
         "usage": {
           "input_tokens": 50,
           "output_tokens": 25
-        }
+        },
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call-1",
+                  "function": "bash_checker",
+                  "arguments": {
+                    "input": "validate this command"
+                  }
+                }
+              ]
+            },
+            "stop_reason": "tool_calls"
+          }
+        ]
       }
     },
     {
@@ -53,8 +77,14 @@
       "timestamp": "2024-01-01T00:00:05Z",
       "completed": "2024-01-01T00:00:06Z",
       "input": [
-        {"role": "system", "content": "You are a bash checker. Validate bash commands."},
-        {"role": "user", "content": "Check this command."}
+        {
+          "role": "system",
+          "content": "You are a bash checker. Validate bash commands."
+        },
+        {
+          "role": "user",
+          "content": "Check this command."
+        }
       ],
       "output": {
         "usage": {
@@ -80,8 +110,14 @@
       "timestamp": "2024-01-01T00:00:09Z",
       "completed": "2024-01-01T00:00:10Z",
       "input": [
-        {"role": "system", "content": "You are a bash checker. Validate bash commands."},
-        {"role": "user", "content": "Process the result."}
+        {
+          "role": "system",
+          "content": "You are a bash checker. Validate bash commands."
+        },
+        {
+          "role": "user",
+          "content": "Process the result."
+        }
       ],
       "output": {
         "usage": {
@@ -118,7 +154,9 @@
         "source": "span",
         "span_id": "parent-agent"
       },
-      "event_uuids": ["e-001"],
+      "event_uuids": [
+        "e-001"
+      ],
       "utility": false,
       "children": [
         {
@@ -128,7 +166,11 @@
             "source": "span",
             "span_id": "child-agent"
           },
-          "event_uuids": ["e-002", "e-003", "e-004"],
+          "event_uuids": [
+            "e-002",
+            "e-003",
+            "e-004"
+          ],
           "utility": true,
           "total_tokens": 105
         }

--- a/tests/transcript/nodes/test_timeline.py
+++ b/tests/transcript/nodes/test_timeline.py
@@ -31,6 +31,7 @@ from inspect_ai.model import (
     ModelOutput,
     ModelUsage,
 )
+from inspect_ai.tool import ToolCall
 from inspect_scout._transcript.timeline import (
     Timeline,
     TimelineEvent,
@@ -138,7 +139,20 @@ def _create_event(event_type: str, data: dict[str, Any]) -> Event | None:
         choices: list[dict[str, Any]] = []
         for choice_data in choices_data:
             msg_data = choice_data.get("message", {})
-            msg = ChatMessageAssistant(content=msg_data.get("content", ""))
+            tool_calls_data = msg_data.get("tool_calls")
+            msg = ChatMessageAssistant(
+                content=msg_data.get("content", ""),
+                tool_calls=[
+                    ToolCall(
+                        id=tc["id"],
+                        function=tc["function"],
+                        arguments=tc.get("arguments", {}),
+                    )
+                    for tc in tool_calls_data
+                ]
+                if tool_calls_data
+                else None,
+            )
             choices.append(
                 {"message": msg, "stop_reason": choice_data.get("stop_reason", "stop")}
             )


### PR DESCRIPTION
## What

Prepares the two utility-classification fixtures for the upcoming inspect_ai / ts-mono change that gates utility-agent classification on a tool-calling parent loop (a single-turn sub-agent with a different prompt is only demoted to utility when its parent actually runs an agentic loop):

- inspect_ai: https://github.com/UKGovernmentBEIS/inspect_ai/pull/4516
- ts-mono: https://github.com/meridianlabs-ai/ts-mono/pull/425

`utility_single_turn` and `utility_tool_turn` had a parent with no tool calls, so their `utility: true` expectations would fail under the new semantics. Rather than flipping the expectations (which would require a coordinated merge), the parent now dispatches a tool call — the expectations then hold under **both** the current and the new semantics, so this can merge any time before the dependency bumps, with no coordination window:

- old logic (loop irrelevant): child still utility ✓
- new logic (loop required): parent has a loop → child still utility ✓

The Python fixture loader (`_create_event`) now maps `tool_calls` on assistant choices so the parent's tool-calling turn actually reaches `timeline_build`.

## Testing

- Full `tests/transcript/nodes/` suite passes (84 tests) against both the released inspect_ai semantics and the new-branch semantics.
- TS fixture suite passes against the current submodule pointer (old loader/logic, 52 tests) and against the ts-mono PR branch (verified by running these fixtures through it directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
