### PR TITLE
fix: restore compatibility with inspect-ai 0.3.248 trace CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fastapi>=0.128.1",
     "ijson>=3.2.0",
     "importlib-metadata",
-    "inspect-ai>=0.3.246",
+    "inspect-ai>=0.3.248",
     "inspect-swe>=0.2.56",
     "jinja2>=3.0.0",
     "jsonlines>=3.0.0",

--- a/src/inspect_scout/_cli/trace.py
+++ b/src/inspect_scout/_cli/trace.py
@@ -1,6 +1,6 @@
 import click
 from inspect_ai._cli.trace import (
-    anomolies_command_impl,
+    anomalies_command_impl,
     dump_command_impl,
     http_command_impl,
     list_command_impl,
@@ -57,9 +57,18 @@ def dump_command(trace_file: str | None, filter: str | None) -> None:
     default=False,
     help="Show only failed HTTP requests (non-200 status)",
 )
-def http_command(trace_file: str | None, filter: str | None, failed: bool) -> None:
+@click.option(
+    "--json",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Output as JSON (a `{trace_file, as_of, requests}` envelope).",
+)
+def http_command(
+    trace_file: str | None, filter: str | None, failed: bool, json: bool
+) -> None:
     """View all HTTP requests in the trace log."""
-    http_command_impl(trace_file, filter, failed, scout_trace_dir())
+    http_command_impl(trace_file, filter, failed, json, trace_dir=scout_trace_dir())
 
 
 @trace_command.command("anomalies")
@@ -73,8 +82,17 @@ def http_command(trace_file: str | None, filter: str | None, failed: bool) -> No
     "--all",
     is_flag=True,
     default=False,
-    help="Show all anomolies including errors and timeouts (by default only still running and cancelled actions are shown).",
+    help="Show all anomalies including errors and timeouts (by default only still running and cancelled actions are shown; JSON output always includes all buckets).",
 )
-def anomolies_command(trace_file: str | None, filter: str | None, all: bool) -> None:
+@click.option(
+    "--json",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Output as JSON (a `{trace_file, as_of, running, cancelled, errors, timeouts}` envelope).",
+)
+def anomalies_command(
+    trace_file: str | None, filter: str | None, all: bool, json: bool
+) -> None:
     """Look for anomalies in a trace file (never completed or cancelled actions)."""
-    anomolies_command_impl(trace_file, filter, all, scout_trace_dir())
+    anomalies_command_impl(trace_file, filter, all, json, trace_dir=scout_trace_dir())

--- a/uv.lock
+++ b/uv.lock
@@ -1491,7 +1491,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.246"
+version = "0.3.248"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1536,9 +1536,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/6f/6c4d56a838d77cda79a8beefb60019dc50f9d2d6beb1c5f414dde5db610e/inspect_ai-0.3.246.tar.gz", hash = "sha256:2edebb069318042bca0638de50be666a50e514096a90070ee00aceccf858c84b", size = 49563205, upload-time = "2026-07-10T23:54:07.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/f4/599b4efbc99bfcdd428246da2106aae83358504af4c0f29c46885ec59630/inspect_ai-0.3.248.tar.gz", hash = "sha256:43ca13fffa82db7dbb98f2ecf749b159d2cdca3075571d5c84ca5c7705a73e33", size = 49367201, upload-time = "2026-07-18T01:30:15.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/635fc2d46379eb7da73cd04ec1b23486a113be55c256c5bce8193198f97e/inspect_ai-0.3.246-py3-none-any.whl", hash = "sha256:b010b5759332f8f780757bfcae854fcfe5f71c6387988a14ca6a7b024a4a9e88", size = 37185092, upload-time = "2026-07-10T23:53:59.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/97/470fed5587567973f6fb03aec30aa14d95758e58a413732384aabce7abec/inspect_ai-0.3.248-py3-none-any.whl", hash = "sha256:2a2f742560085af047c3ca20eda76ba89ed423f9935004f5f5376babc912ffe7", size = 36901395, upload-time = "2026-07-18T01:30:06.86Z" },
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'dev'" },
     { name = "ijson", specifier = ">=3.2.0" },
     { name = "importlib-metadata" },
-    { name = "inspect-ai", specifier = ">=0.3.245" },
+    { name = "inspect-ai", specifier = ">=0.3.248" },
     { name = "inspect-swe", specifier = ">=0.2.56" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "jsonlines", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Problem

Every CI run on `main` fails in `py-mypy` and `py-test` since inspect-ai 0.3.248 was released to PyPI (2026-07-18). Upstream changed `inspect_ai/_cli/trace.py` (commits 0ef100d and 63b67f3):

1. Typo-fix rename: `anomolies_command_impl` → `anomalies_command_impl`. Scout imports the old name, so `inspect_scout._cli.trace` raises `ImportError` at import time, breaking collection of 4 CLI test modules.
2. A new `json: bool = False` parameter was inserted before `trace_dir` in `http_command_impl` and `anomalies_command_impl`. Scout passed `scout_trace_dir()` as the 4th positional argument, which now lands in the `json` slot (mypy: `Argument 4 to "http_command_impl" has incompatible type "Path"; expected "bool"`).

## Changes

- Import `anomalies_command_impl` (new spelling) and pass the scout trace dir by keyword (`trace_dir=scout_trace_dir()`) in both calls.
- Surface the new `--json` flag on `scout trace http` and `scout trace anomalies`, matching upstream's flags and help text.
- Rename scout's own `anomolies_command` function and fix the "anomolies" typo in the `--all` help text.
- Bump the `inspect-ai` pin from `>=0.3.246` to `>=0.3.248` — older releases lack the renamed function, so the floor must move with the fix.

## Verification

- `mypy src examples tests`: Success, no issues in 439 source files (both prior errors gone).
- `pytest tests/cli -q`: 102 passed (previously 4 modules failed at collection).
- Smoke-tested `scout trace http --json` and `scout trace anomalies --help` against the local scout trace directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)