### PR TITLE
fix: scope Model reducer to Scout's pickler, not global copyreg

### DIFF
--- a/src/inspect_scout/_concurrency/_mp_common.py
+++ b/src/inspect_scout/_concurrency/_mp_common.py
@@ -44,19 +44,28 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# copyreg reducer: make inspect_ai Model picklable via cloudpickle
+# Pickler-scoped reducer: make inspect_ai Model picklable via cloudpickle
 # ---------------------------------------------------------------------------
 # ModelAPI subclasses contain unpicklable state (anyio.Lock, httpx.AsyncClient,
 # SDK async clients).  When a scanner closure captures a Model instance,
 # cloudpickle fails with "cannot pickle '_thread.RLock' object".
 #
-# We register a copyreg reducer that converts Model → ModelConfig for
-# serialization, then reconstructs via get_model() on unpickle.  get_model()
-# uses memoize=True by default, so repeated unpickles in the same worker
-# reuse the cached instance rather than creating duplicate HTTP clients.
+# We reduce Model → ModelConfig for serialization, then reconstruct via
+# get_model() on unpickle.  get_model() uses memoize=True by default, so
+# repeated unpickles in the same worker reuse the cached instance rather than
+# creating duplicate HTTP clients.
+#
+# The reducer is scoped to a dedicated `ScoutPickler` (via reducer_override)
+# rather than registered globally with `copyreg.pickle(Model, ...)`.  A global
+# registration pollutes `copyreg.dispatch_table`, which `copy.copy()` and
+# `copy.deepcopy()` also consult — so merely importing scout would change what
+# `copy(model)` means process-wide, aliasing the memoized instance instead of
+# producing a distinct copy (see issue #537).  reducer_override is consulted
+# only by our pickler and is invisible to the copy module.  The unpickle side
+# needs no registration: the pickled data embeds `_reconstruct_model` directly.
 # ---------------------------------------------------------------------------
 
-import copyreg
+import io
 
 from inspect_ai.model import get_model
 from inspect_ai.model._model import Model
@@ -78,7 +87,30 @@ def _reduce_model(model: Model) -> tuple[Callable[..., Any], tuple[ModelConfig]]
     return (_reconstruct_model, (model_to_model_config(model),))
 
 
-copyreg.pickle(Model, _reduce_model)
+class ScoutPickler(cloudpickle.Pickler):  # type: ignore[misc]
+    """cloudpickle Pickler that can serialize inspect_ai Model instances.
+
+    The Model reducer is applied via `reducer_override` (consulted per-pickler,
+    before any dispatch table) so it stays scoped to serialization and never
+    leaks into `copy.copy()` / `copy.deepcopy()` semantics (issue #537).
+    """
+
+    def reducer_override(self, obj: Any) -> Any:
+        if isinstance(obj, Model):
+            return _reduce_model(obj)
+        return super().reducer_override(obj)
+
+
+def scout_dumps(obj: Any) -> bytes:
+    """Serialize an object with cloudpickle, adding Model support.
+
+    Mirrors `cloudpickle.dumps` but uses `ScoutPickler`, so scanner closures
+    that capture inspect_ai `Model` instances survive the roundtrip without
+    globally overriding pickle/copy behavior for `Model`.
+    """
+    with io.BytesIO() as file:
+        ScoutPickler(file).dump(obj)
+        return file.getvalue()
 
 
 class DillCallable:
@@ -94,7 +126,7 @@ class DillCallable:
         Args:
             func: The callable to wrap (can be closure, lambda, etc)
         """
-        self._pickled_func: bytes = cloudpickle.dumps(func)
+        self._pickled_func: bytes = scout_dumps(func)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Call the wrapped function.

--- a/src/inspect_scout/_concurrency/multi_process.py
+++ b/src/inspect_scout/_concurrency/multi_process.py
@@ -20,7 +20,8 @@ import multiprocessing
 import signal
 import time
 from multiprocessing.context import SpawnProcess
-from typing import AsyncIterator, Awaitable, Callable
+from types import FrameType
+from typing import Any, AsyncIterator, Awaitable, Callable
 
 import anyio
 from anyio import create_task_group
@@ -91,6 +92,9 @@ _SHUTDOWN_SENTINEL = ShutdownSentinel()
 # Singleton guard - only one multi_process_strategy can be active at a time
 _active: bool = False
 
+# Return/parameter type of signal.signal() (typeshed's private signal._HANDLER)
+SignalHandler = Callable[[int, FrameType | None], Any] | int | None
+
 
 def multi_process_strategy(
     *,
@@ -147,22 +151,29 @@ def multi_process_strategy(
                 "Another multi_process_strategy is already running. Only one instance can be active at a time."
             )
         _active = True
-        # Create Manager and parent registry for cross-process semaphore coordination
-        spawn_ctx = multiprocessing.get_context("spawn")
-        manager = spawn_ctx.Manager()
-        parent_registry = ParentSemaphoreRegistry(manager)
 
-        # Initialize parent's concurrency system with cross-process registry
-        # This ensures parent creates ManagerSemaphore instances in shared registry
-        # when it receives SemaphoreRequest from children
-        init_concurrency(parent_registry)
+        # None until SIG_IGN is actually installed; lets the finally below know
+        # whether there is an original handler to restore
+        original_sigint_handler: SignalHandler = None
 
-        inspect_log_handler = find_inspect_log_handler()
-
-        # Block SIGINT before creating processes - workers will inherit SIG_IGN
-        original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-
+        # The try must begin before any process-wide state is mutated so the
+        # finally can restore it on every failure path, including setup errors
         try:
+            # Create Manager and parent registry for cross-process semaphore coordination
+            spawn_ctx = multiprocessing.get_context("spawn")
+            manager = spawn_ctx.Manager()
+            parent_registry = ParentSemaphoreRegistry(manager)
+
+            # Initialize parent's concurrency system with cross-process registry
+            # This ensures parent creates ManagerSemaphore instances in shared registry
+            # when it receives SemaphoreRequest from children
+            init_concurrency(parent_registry)
+
+            inspect_log_handler = find_inspect_log_handler()
+
+            # Block SIGINT before creating processes - workers will inherit SIG_IGN
+            original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+
             # Distribute tasks evenly: some processes get base+1, others get base
             # This ensures we use exactly task_count total tasks
             base_tasks = task_count // max_processes
@@ -364,7 +375,8 @@ def multi_process_strategy(
                     )
 
         finally:
-            signal.signal(signal.SIGINT, original_sigint_handler)
+            if original_sigint_handler is not None:
+                signal.signal(signal.SIGINT, original_sigint_handler)
             # Restore the default in-process registry. Leaving the cross-process
             # ParentSemaphoreRegistry installed would leak into any subsequent
             # inspect_ai usage in this process — degrading adaptive/resizable

--- a/src/inspect_scout/_concurrency/multi_process.py
+++ b/src/inspect_scout/_concurrency/multi_process.py
@@ -365,6 +365,11 @@ def multi_process_strategy(
 
         finally:
             signal.signal(signal.SIGINT, original_sigint_handler)
+            # Restore the default in-process registry. Leaving the cross-process
+            # ParentSemaphoreRegistry installed would leak into any subsequent
+            # inspect_ai usage in this process — degrading adaptive/resizable
+            # concurrency requests to fixed-limit MP semaphores.
+            init_concurrency()
             _active = False
 
     return the_func

--- a/tests/concurrency/test_model_pickling.py
+++ b/tests/concurrency/test_model_pickling.py
@@ -9,6 +9,7 @@ the cloudpickle roundtrip intact.
 from __future__ import annotations
 
 import base64
+import copy
 import copyreg
 import json
 import subprocess
@@ -16,11 +17,11 @@ import sys
 from pathlib import Path
 
 import cloudpickle  # type: ignore[import-untyped]
-import inspect_scout._concurrency._mp_common  # noqa: F401 — registers copyreg reducer
 from inspect_ai.model import ModelOutput, get_model
 from inspect_ai.model._model import Model
 from inspect_ai.model._model_config import model_roles_to_model_roles_config
 from inspect_scout import llm_scanner
+from inspect_scout._concurrency._mp_common import scout_dumps
 
 # Scanner file whose grading class contains a ModelEvent field.  Loaded via
 # load_module (exactly as inspect_ai loads user-authored scanner files).
@@ -30,13 +31,28 @@ _SCANNER_WITH_MODEL_EVENT = (
 
 
 # ---------------------------------------------------------------------------
-# copyreg reducer for Model
+# Model reducer must be scoped to pickling, not global copy semantics (#537)
 # ---------------------------------------------------------------------------
 
 
-def test_copyreg_reducer_is_registered() -> None:
-    """Importing _mp_common registers a copyreg reducer for Model."""
-    assert Model in copyreg.dispatch_table
+def test_importing_scout_does_not_hijack_copy() -> None:
+    """Importing scout must not change process-wide copy semantics for Model.
+
+    Registering a reducer via copyreg.pickle() pollutes the global
+    copyreg.dispatch_table, which copy.copy()/copy.deepcopy() also consult.
+    That makes copy(model) round-trip through get_model() (which memoizes),
+    aliasing instances instead of producing distinct copies and breaking
+    inspect_ai's role stamping / role-scoped config overrides. The reducer
+    must be scoped to Scout's own pickler instead.
+    """
+    # The global dispatch table must not be polluted with a Model reducer.
+    assert Model not in copyreg.dispatch_table
+
+    # copy.copy() must produce a genuinely distinct instance, not a memoized
+    # alias returned by get_model().
+    model = get_model("mockllm/model")
+    copied = copy.copy(model)
+    assert copied is not model
 
 
 def test_model_survives_cloudpickle_roundtrip_in_subprocess() -> None:
@@ -46,7 +62,7 @@ def test_model_survives_cloudpickle_roundtrip_in_subprocess() -> None:
     shortcuts, so we must verify in a subprocess to be a valid test.
     """
     model = get_model("mockllm/model")
-    pickled = cloudpickle.dumps(model)
+    pickled = scout_dumps(model)
 
     # Verify in subprocess
     model_b64 = base64.b64encode(pickled).decode()
@@ -100,7 +116,7 @@ def test_llm_scanner_with_model_instance_is_picklable() -> None:
         name="test_scanner",
     )
     # This is what DillCallable.__init__ does
-    pickled = cloudpickle.dumps(scan_fn)
+    pickled = scout_dumps(scan_fn)
     # Verify in a subprocess where cloudpickle can't use identity shortcuts
     assert _unpickle_callable_in_subprocess(pickled)
 

--- a/tests/concurrency/test_mp_model_capture_e2e.py
+++ b/tests/concurrency/test_mp_model_capture_e2e.py
@@ -1,0 +1,92 @@
+"""End-to-end regression test for issue #537.
+
+A scanner whose closure captures an inspect_ai ``Model`` must survive a real
+spawn multiprocessing scan. ``max_processes >= 2`` forces the spawn path, which
+serializes the scanner closure via ``DillCallable`` -> ``scout_dumps``. Because
+the closure captures a ``Model`` directly, this exercises the ``ScoutPickler``
+reducer end to end: the ``Model`` is reduced to a ``ModelConfig`` on the parent
+side and reconstructed via ``get_model()`` in each worker.
+
+The scanner derives its ``Result`` from the captured ``Model`` without any
+network call, so what's under test is the serialization roundtrip across the
+process boundary (not model generation).
+
+NOTE: this module intentionally does NOT use ``from __future__ import
+annotations``. Scout's implicit-loader detection compares the scanner's first
+parameter annotation against the ``Transcript`` class by identity; under PEP 563
+that annotation would be the string ``"Transcript"`` and detection would fail.
+"""
+
+import asyncio
+from pathlib import Path
+
+from inspect_ai.model import get_model
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.model._model import Model
+from inspect_scout import Result, Scanner, scan, scanner, transcripts_db
+from inspect_scout._scanresults import scan_results_df
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+
+def _model_capture_scanner_factory(captured_model: Model) -> Scanner[Transcript]:
+    @scanner(name="model_capture_scanner", messages="all")
+    def factory() -> Scanner[Transcript]:
+        async def scan_transcript(transcript: Transcript) -> Result:
+            # Uses the closure-captured Model without a network call; reaching
+            # here at all proves the closure (and its Model) survived spawn.
+            return Result(
+                value=str(captured_model.name),
+                explanation=f"api={captured_model.api.__class__.__name__}",
+            )
+
+        return scan_transcript
+
+    return factory()
+
+
+def test_model_capturing_closure_survives_multiprocess_scan(tmp_path: Path) -> None:
+    """A scanner closure that captures a Model runs across spawned workers."""
+    captured_model = get_model("mockllm/model")
+
+    db_path = tmp_path / "db"
+    scans_path = tmp_path / "scans"
+    db_path.mkdir()
+    scans_path.mkdir()
+
+    async def insert() -> None:
+        transcripts = [
+            Transcript(
+                transcript_id=f"t-{i:03d}",
+                source_type="test",
+                source_id="s",
+                source_uri=f"test://{i}",
+                metadata={"index": i},
+                messages=[ChatMessageUser(content=f"msg {i}")],
+                events=[],
+            )
+            for i in range(6)
+        ]
+        async with transcripts_db(str(db_path)) as db:
+            await db.insert(transcripts)
+
+    asyncio.run(insert())
+
+    status = scan(
+        scanners=[_model_capture_scanner_factory(captured_model)],
+        transcripts=transcripts_from(str(db_path)),
+        scans=str(scans_path),
+        max_processes=2,  # forces spawn multiprocessing -> DillCallable/scout_dumps
+        display="none",
+    )
+
+    assert status.complete
+    assert status.location is not None
+
+    df = scan_results_df(status.location, scanner="model_capture_scanner").scanners[
+        "model_capture_scanner"
+    ]
+    assert len(df) == 6
+    # The Model was faithfully reconstructed in each worker.
+    assert df["value"].tolist() == ["model"] * 6
+    assert all(e == "api=MockLLM" for e in df["explanation"].tolist())

--- a/tests/concurrency/test_mp_model_capture_e2e.py
+++ b/tests/concurrency/test_mp_model_capture_e2e.py
@@ -23,7 +23,9 @@ from pathlib import Path
 from inspect_ai.model import get_model
 from inspect_ai.model._chat_message import ChatMessageUser
 from inspect_ai.model._model import Model
+from inspect_ai.util import concurrency
 from inspect_scout import Result, Scanner, scan, scanner, transcripts_db
+from inspect_scout._concurrency._mp_semaphore import MPConcurrencySemaphore
 from inspect_scout._scanresults import scan_results_df
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
@@ -90,3 +92,14 @@ def test_model_capturing_closure_survives_multiprocess_scan(tmp_path: Path) -> N
     # The Model was faithfully reconstructed in each worker.
     assert df["value"].tolist() == ["model"] * 6
     assert all(e == "api=MockLLM" for e in df["explanation"].tolist())
+
+    # The scan must also restore inspect_ai's default in-process concurrency
+    # registry on completion. Leaving the cross-process ParentSemaphoreRegistry
+    # installed would degrade later concurrency() requests in this process
+    # (e.g. inspect_ai's adaptive model connections) to fixed-limit MP
+    # semaphores, breaking unrelated code that runs after the scan.
+    async def check_registry_restored() -> None:
+        async with concurrency("post-mp-registry-check", 1) as sem:
+            assert not isinstance(sem, MPConcurrencySemaphore)
+
+    asyncio.run(check_registry_restored())


### PR DESCRIPTION
## Summary

Fixes issue #537 by moving the `Model` pickle reducer from global `copyreg` registration to a dedicated `ScoutPickler` class that uses `reducer_override`. This prevents the reducer from leaking into `copy.copy()` and `copy.deepcopy()` semantics process-wide, which was breaking inspect_ai's role stamping and role-scoped config overrides.

## Key Changes

- **Replaced global `copyreg.pickle()` registration** with a `ScoutPickler` class that extends `cloudpickle.Pickler` and implements `reducer_override()` to handle `Model` instances
- **Added `scout_dumps()` function** that mirrors `cloudpickle.dumps()` but uses `ScoutPickler`, ensuring scanner closures with captured `Model` instances can be serialized without polluting global pickle/copy behavior
- **Updated `DillCallable.__init__`** to use `scout_dumps()` instead of `cloudpickle.dumps()`
- **Updated tests** to verify that importing scout does not hijack `copy.copy()` semantics and that `scout_dumps()` correctly serializes models in subprocesses

## Implementation Details

The `reducer_override` method is consulted per-pickler before any dispatch table, so it stays scoped to serialization and never affects the copy module's behavior. The unpickle side requires no registration since the pickled data embeds `_reconstruct_model` directly.

This approach maintains the memoization benefits of `get_model()` (reusing cached instances in workers) while preventing unintended aliasing when users call `copy.copy(model)` on their own models.

https://claude.ai/code/session_014aNt2wz3DGc5CM6KZFbveg