### PR TITLE
ci: enable Meridian agents via shared workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,39 @@
+# Copy to .github/workflows/claude-review.yml in any Meridian repo to add the
+# read-only reviewer. Auto-reviews PRs when they open (drafts are skipped
+# until marked ready for review) and on demand via an @review comment.
+# Independent of the dev agent (claude.yml) — different trigger, different
+# (lower) permissions.
+#
+# Caveat: auto-review-on-open (the pull_request trigger) only fires where this
+# file exists on the PR's BASE branch — GitHub resolves pull_request-family
+# workflows from the PR's branches, not the default branch. On a pristine-base
+# mirror like the inspect_ai fork, PRs target a base that lacks this workflow,
+# so pull_request never fires; only the @review comment path works there, and
+# auto-review is instead driven by the dev agent posting @review on PR open.
+
+name: Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    # Run on PR events (skipping drafts — they get reviewed via
+    # ready_for_review when marked ready), or on a PR comment containing
+    # @review. An explicit @review still works on a draft. `@review` does not
+    # collide with the dev agent's `@claude` trigger.
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft != true) ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@review'))
+    uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,171 @@
+# Copy this file to .github/workflows/claude.yml in any Meridian repo
+# (or run scripts/enable-claude.sh <org/repo> to open a PR that adds it).
+#
+# Requires only that the Claude GitHub App is installed on the repo
+# (org-level install covers this). Auth uses Workload Identity Federation —
+# no secrets needed, but `id-token: write` below is required for the OIDC
+# exchange.
+
+name: Claude
+
+# Trigger-resolution caveat: GitHub runs issue_comment / issues workflows from
+# the DEFAULT branch, but pull_request_review_comment / pull_request_review
+# (the pull_request family) from the PR's OWN branches. So the latter two only
+# fire where this file exists on the PR's base/head branch. On a pristine-base
+# mirror like the inspect_ai fork — where the Claude workflows live only on the
+# default branch and PRs target an upstream-mirror base that lacks them — those
+# two never fire; only top-level @claude comments (issue_comment) and the
+# `claude` label (issues) work. Drop the two review triggers in that setup so
+# the surface matches reality (the fork's deployed stub does).
+#
+# `issue_comment: edited` is included so that ADDING @claude/@auto to an
+# existing comment (a common way people invoke the agent after the fact) fires
+# the workflow — GitHub only delivers the edited action when it's subscribed
+# here. The job `if:` below guards it to edits that newly introduce the phrase
+# (via github.event.changes.body.from), so re-editing a comment that already
+# mentioned the agent does NOT re-trigger it.
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  claude:
+    # Cheap gate to avoid spending runner minutes on unrelated events; the
+    # action does its own authoritative trigger check. Two phrases summon the
+    # one-shot dev agent: @claude and @i-am-marvin (the machine account — a real
+    # user, so the mention resolves to it and pings nothing else). They do the
+    # same thing; the action's trigger_phrase is single-valued, so
+    # `with.trigger_phrase` below resolves which phrase the *event's own text*
+    # contains (comment body for a comment, review body for a review, issue
+    # body/title for an issue — the same source the action checks) and this gate
+    # fires if that text has either phrase.
+    #
+    # Machine-account guard: github.actor != 'i-am-marvin' over the whole gate,
+    # so a comment/review/issue authored by the machine account can't self-
+    # trigger the dev agent and loop (its own output — and the fork guidance —
+    # can contain @claude/@i-am-marvin). Hoisted rather than per-source: the
+    # sources are OR'd, so guarding only the comment branch is bypassable by a
+    # phrase left in the enclosing issue body/title.
+    #
+    # Sources are scoped to the event that carries them (github.event.action /
+    # event_name), so a comment event is judged by the comment alone — a stale
+    # @claude in the enclosing issue can't fire a runner-spin for an unrelated
+    # comment, nor mask an alias typed in the comment.
+    #
+    # On an edited comment (the only `edited` action we subscribe to), fire only
+    # when the edit newly introduced a phrase — comparing against the pre-edit
+    # body — so re-editing a comment that already mentioned one does not
+    # re-trigger. Known limitation: contains() is a substring test, looser than
+    # the action's word-boundary trigger; a pre-edit body holding a phrase only
+    # as a NON-triggering substring (in backticks, or a token like foo@claude)
+    # blocks the edit path. Acceptable for a cheap gate (no regex in workflow
+    # expressions); the action remains the authoritative check on what fires.
+    if: |
+      github.actor != 'i-am-marvin' && (
+        ( github.event.action == 'edited'
+          && ( contains(github.event.comment.body, '@claude')
+            || contains(github.event.comment.body, '@i-am-marvin') )
+          && !( contains(github.event.changes.body.from, '@claude')
+            || contains(github.event.changes.body.from, '@i-am-marvin') ) ) ||
+        ( github.event.action == 'created' && (
+            contains(github.event.comment.body, '@claude') ||
+            contains(github.event.comment.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event.action == 'submitted' && (
+            contains(github.event.review.body, '@claude') ||
+            contains(github.event.review.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event_name == 'issues' && (
+            contains(github.event.issue.body, '@claude') ||
+            contains(github.event.issue.body, '@i-am-marvin') ||
+            contains(github.event.issue.title, '@claude') ||
+            contains(github.event.issue.title, '@i-am-marvin') ||
+            github.event.label.name == 'claude'
+        ) )
+      )
+    uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    # Pass the machine-account PAT (MARVIN_TOKEN, an org secret) through to the
+    # reusable workflow so agent-opened PRs trigger CI and @review. Passed
+    # explicitly — NOT via `secrets: inherit` — so this repo's other secrets
+    # aren't exposed to an external workflow pinned to a mutable @main ref
+    # (least privilege; the reusable workflow consumes only this one secret).
+    # An absent MARVIN_TOKEN resolves to empty: the agent still runs, just with
+    # issue-triggered PR creation degraded (see the reusable workflow's
+    # secrets.MARVIN_TOKEN and design/auto-agent.md).
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    with:
+      # trigger_phrase is single-valued, so resolve it from the SAME source the
+      # action will check for this event (comment > review > issue), not from a
+      # union of all sources — otherwise a stale @claude in an enclosing issue
+      # would mask an @i-am-marvin typed in a comment, resolving @claude and
+      # then no-op'ing (the action only checks the comment body on a comment
+      # event). Within a source, default @claude and only switch to
+      # @i-am-marvin when that's what's present; the trailing @claude covers the
+      # `claude` label event and is a harmless fallback.
+      # Caveat: this pick is substring-based (workflow expressions have no
+      # regex), so it also SELECTS which phrase the action then re-checks with
+      # word boundaries. In the contrived case where the other phrase appears
+      # only as a NON-triggering substring (backticked, or glued into a token
+      # like foo@i-am-marvin) a genuine trigger can be mis-resolved and no-op,
+      # not merely cost gate minutes. Accepted: the collision needs someone to,
+      # in one comment, write one phrase for real and the other as a bare
+      # substring — and both phrases route to the same dev agent anyway.
+      trigger_phrase: >-
+        ${{
+        github.event.comment && (contains(github.event.comment.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        github.event.review && (contains(github.event.review.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        (contains(github.event.issue.body, '@i-am-marvin') || contains(github.event.issue.title, '@i-am-marvin')) && '@i-am-marvin' ||
+        '@claude'
+        }}
+
+  # @auto kickoff (distinct from the one-shot `claude` above). An `auto` label or
+  # `@auto` mention drives the issue autonomously: the dev agent opens a PR, the
+  # PR inherits the `auto` label (so the loop in claude-auto.yml engages), and it
+  # runs to a human handoff. Same reusable dev workflow, different trigger — the
+  # action's trigger_phrase/label_trigger are single-valued, so `auto` needs its
+  # own invocation. Needs MARVIN_TOKEN (the PR must trigger CI/@review).
+  claude-auto:
+    # See the `claude` job's `if:` — same edited-comment guard, so adding @auto
+    # to an existing comment kicks off the autonomous loop but re-editing a
+    # comment that already mentioned @auto does not re-fire it (which could
+    # otherwise open a duplicate PR). Same machine-account guard too: @auto is
+    # the loop-prone trigger, so keep the machine account from kicking it off
+    # (nothing in the designed loop relies on marvin posting @auto).
+    if: |
+      github.actor != 'i-am-marvin' && (
+        ( github.event.action == 'edited'
+          && contains(github.event.comment.body, '@auto')
+          && !contains(github.event.changes.body.from, '@auto') ) ||
+        ( github.event.action != 'edited' && (
+            contains(github.event.comment.body, '@auto') ||
+            contains(github.event.review.body, '@auto') ||
+            contains(github.event.issue.body, '@auto') ||
+            contains(github.event.issue.title, '@auto') ||
+            github.event.label.name == 'auto'
+        ) )
+      )
+    uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    with:
+      trigger_phrase: "@auto"
+      label_trigger: "auto"


### PR DESCRIPTION
Adds workflow stubs from [meridianlabs-ai/agents](https://github.com/meridianlabs-ai/agents): claude.yml,claude-review.yml.

Once merged:
- **Dev agent** — mention `@claude` in an issue or PR comment, or add the `claude` label to an issue.
- **Reviewer** — auto-reviews PRs on open; or comment `@review` on a PR.