### PR TITLE
fix: preserve boolean values when expanding uniformly-boolean resultsets

### DIFF
--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -1114,13 +1114,17 @@ def _cast_value_column(df: pd.DataFrame) -> pd.DataFrame:
 
         try:
             if vtype == "boolean":
-                # Handle various string representations of booleans
+                # Handle string representations of booleans (parquet stores
+                # values as strings) as well as actual bools (resultset
+                # expansion parses JSON into native True/False).
                 df["value"] = df["value"].map(
                     {
                         "true": True,
                         "false": False,
                         "True": True,
                         "False": False,
+                        True: True,
+                        False: False,
                         None: None,
                     }
                 )

--- a/tests/test_resultset_expansion.py
+++ b/tests/test_resultset_expansion.py
@@ -63,6 +63,19 @@ def simple_scanner_factory() -> Scanner[Transcript]:
     return scan_transcript
 
 
+@scanner(name="boolean_resultset_scanner", messages="all")
+def boolean_resultset_scanner_factory() -> Scanner[Transcript]:
+    """Scanner that returns a resultset whose values are uniformly boolean."""
+
+    async def scan_transcript(transcript: Transcript) -> list[Result]:
+        return [
+            Result(label="deception", value=True),
+            Result(label="sandbagging", value=False),
+        ]
+
+    return scan_transcript
+
+
 @scanner(name="empty_resultset_scanner", messages="all")
 def empty_resultset_scanner_factory() -> Scanner[Transcript]:
     """Scanner that returns an empty resultset."""
@@ -258,6 +271,32 @@ def test_resultset_with_optional_fields() -> None:
         deception_rows = df[df["label"] == "deception"]
         # Check that answer column exists but may be None
         assert "answer" in deception_rows.columns
+
+
+def test_uniformly_boolean_resultset_values_survive_expansion() -> None:
+    """Regression test: uniformly-boolean resultsets keep True/False values.
+
+    Resultset expansion parses JSON into native Python bools; the boolean
+    cast previously only mapped string representations, silently turning
+    every value into NaN when all expanded values were boolean.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[boolean_resultset_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+            max_processes=1,
+        )
+
+        results = scan_results_df(status.location, scanner="boolean_resultset_scanner")
+        df = results.scanners["boolean_resultset_scanner"]
+
+        assert len(df) == 2
+        assert all(df["value_type"] == "boolean")
+        values = df.set_index("label")["value"]
+        assert values["deception"] is True
+        assert values["sandbagging"] is False
 
 
 def test_multiple_transcripts_with_resultsets() -> None:


### PR DESCRIPTION
(written by Claude, edited by Thomas)

## Problem

Resultsets whose expanded values are uniformly boolean get their values silently destroyed to `NaN` in the pandas path (`scan_results_df` with `rows="results"`).

`_expand_resultset_rows()` parses the resultset JSON with `json.loads`, so each result's value becomes a native Python `True`/`False`. It then calls `_cast_value_column()`, whose boolean branch maps values via `{"true": True, "false": False, "True": True, "False": False, None: None}`. That map was written for the top-level parquet path where values are stored as strings — actual bools match no key, so `Series.map` returns `NaN` for every value.

Repro:

```python
_expand_resultset_rows(pd.DataFrame({
    "value_type": ["resultset"],
    "value": [json.dumps([{"label": "a", "value": True}])],
}))
# value column comes back [nan] with value_type "boolean"
```

The bug only bites when the expanded values are *uniformly* boolean — mixed-type resultsets skip the cast entirely. 

`scan_results_db` is unaffected: `_create_expanded_view_sql` extracts values with `json_extract_string`, yielding strings the map handles downstream.

## Fix

Extend the map with identity entries for real bools (`True: True, False: False` — bool and str keys coexist fine in one dict).

## Notes

- This is a user-visible behavior change: uniformly-boolean resultsets now return real `True`/`False` from `scan_results_df` where they previously returned `NaN`.