### PR TITLE
fix: absence-implied true-negative validation rows suppressed by labels on other transcripts

### DIFF
--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -215,21 +215,13 @@ def _handle_label_validation(
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Handle label-based validation for expanded resultset rows.
 
-    Label validation is computed at scan time per scanner invocation (see
-    `_validate_labels()`), so its presentation is scoped the same way: each
-    resultset row is checked against its own `validation_target`.
-
     This function:
     1. Propagates per-label validation results to individual expanded rows
-    2. Creates synthetic rows for expected-absent labels (negative expected
-       value) with no result in their own resultset row, making true
-       negatives visible in the DataFrame
+    2. Creates synthetic rows for missing labels (where expected value is negative)
 
     Args:
-        expanded: DataFrame of expanded result rows (carrying
-            `_RESULTSET_INDEX`); may be empty
-        resultset_rows: Original resultset rows before expansion (carrying
-            `_RESULTSET_INDEX`)
+        expanded: DataFrame of expanded result rows
+        resultset_rows: Original resultset rows before expansion
 
     Returns:
         Tuple of (expanded DataFrame with validation, synthetic rows DataFrame)

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -193,140 +193,132 @@ def remove_scan_results(scan_location: str) -> None:
         scan_path.rmdir(recursive=True)
 
 
+_RESULTSET_INDEX = "_resultset_index"
+"""Temporary column tying expanded rows back to their originating resultset row."""
+
+
+def _parse_json_dict(value: Any) -> dict[str, Any] | None:
+    """Parse a value as a JSON object, returning None if it isn't one."""
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _handle_label_validation(
     expanded: pd.DataFrame, resultset_rows: pd.DataFrame
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Handle label-based validation for expanded resultset rows.
 
+    Label validation is computed at scan time per scanner invocation (see
+    `_validate_labels()`), so its presentation is scoped the same way: each
+    resultset row is checked against its own `validation_target`.
+
     This function:
     1. Propagates per-label validation results to individual expanded rows
-    2. Creates synthetic rows for missing labels (where expected value is negative)
+    2. Creates synthetic rows for expected-absent labels (negative expected
+       value) with no result in their own resultset row, making true
+       negatives visible in the DataFrame
 
     Args:
-        expanded: DataFrame of expanded result rows
-        resultset_rows: Original resultset rows before expansion
+        expanded: DataFrame of expanded result rows (carrying
+            `_RESULTSET_INDEX`); may be empty
+        resultset_rows: Original resultset rows before expansion (carrying
+            `_RESULTSET_INDEX`)
 
     Returns:
         Tuple of (expanded DataFrame with validation, synthetic rows DataFrame)
     """
     # Check if we have validation columns
     if (
-        "validation_target" not in expanded.columns
-        or "validation_result" not in expanded.columns
+        "validation_target" not in resultset_rows.columns
+        or "validation_result" not in resultset_rows.columns
     ):
         return expanded, pd.DataFrame()
 
-    # Check if validation is label-based (both target and result should be JSON dicts)
-    # Get a sample validation_target to check
-    sample_target = (
-        expanded["validation_target"].iloc[0] if not expanded.empty else None
-    )
-    if sample_target is None or not isinstance(sample_target, str):
-        return expanded, pd.DataFrame()
-
-    # Try to parse as JSON dict
-    try:
-        parsed_target = json.loads(sample_target)
-        if not isinstance(parsed_target, dict):
-            # Not label-based validation
-            return expanded, pd.DataFrame()
-    except (json.JSONDecodeError, TypeError):
-        return expanded, pd.DataFrame()
-
-    # Parse validation results (should also be a dict)
-    sample_result = (
-        expanded["validation_result"].iloc[0] if not expanded.empty else None
-    )
-    try:
-        parsed_results = (
-            json.loads(sample_result)
-            if isinstance(sample_result, str)
-            else sample_result
-        )
-        if not isinstance(parsed_results, dict):
-            return expanded, pd.DataFrame()
-    except (json.JSONDecodeError, TypeError):
-        return expanded, pd.DataFrame()
-
-    # This is label-based validation! Propagate per-label results
-    def assign_label_validation(row: pd.Series) -> pd.Series:
+    # Propagate per-label results to rows whose own validation is label-based
+    # (i.e. their validation_target is a JSON dict keyed by label)
+    def assign_label_validation(row: "pd.Series[Any]") -> "pd.Series[Any]":
         """Assign validation result based on the row's label."""
         label = row.get("label")
         if pd.isna(label):
             return row
 
-        # Parse validation results for this row
-        val_result_str = row.get("validation_result")
-        if pd.isna(val_result_str):
+        if _parse_json_dict(row.get("validation_target")) is None:
             return row
 
-        try:
-            val_results_dict = (
-                json.loads(val_result_str)
-                if isinstance(val_result_str, str)
-                else val_result_str
-            )
-            if isinstance(val_results_dict, dict) and label in val_results_dict:
-                # Replace overall validation_result with this label's specific result
-                row["validation_result"] = val_results_dict[label]
-        except (json.JSONDecodeError, TypeError, KeyError):
-            pass
+        val_results_dict = _parse_json_dict(row.get("validation_result"))
+        if val_results_dict is not None and label in val_results_dict:
+            # Replace overall validation_result with this label's specific result
+            row["validation_result"] = val_results_dict[label]
 
         return row
 
-    expanded = expanded.apply(assign_label_validation, axis=1)
+    if not expanded.empty:
+        expanded = expanded.apply(assign_label_validation, axis=1)
 
-    # Create synthetic rows for missing labels
-    # Get all labels present in expanded rows
-    present_labels = set(expanded["label"].dropna().unique())
+    # Labels present in each resultset row's own expansion
+    present_labels: dict[Any, set[str]] = {}
+    if not expanded.empty and "label" in expanded.columns:
+        for resultset_index, labels in expanded.groupby(_RESULTSET_INDEX)["label"]:
+            present_labels[resultset_index] = set(labels.dropna().unique())
 
-    # Get expected labels from validation_target
-    expected_labels = set(parsed_target.keys())
-
-    # Missing labels = expected but not present
-    missing_labels = expected_labels - present_labels
-
-    # Create synthetic rows for missing labels with negative expected values
-    synthetic_rows_list = []
-    for label in missing_labels:
-        expected_value = parsed_target[label]
-        # Only create synthetic row if expected value is negative
-        negative_values = (False, None, "NONE", "none", 0, "")
-        if expected_value not in negative_values:
+    # Create synthetic rows for each resultset row's missing labels with
+    # negative expected values
+    synthetic_rows_list: list["pd.Series[Any]"] = []
+    for _, resultset_row in resultset_rows.iterrows():
+        parsed_target = _parse_json_dict(resultset_row.get("validation_target"))
+        if parsed_target is None:
+            # Not label-based validation for this row
             continue
+        parsed_results = _parse_json_dict(resultset_row.get("validation_result")) or {}
 
-        # Get a template row from the first resultset row
-        if resultset_rows.empty:
-            continue
-        template_row = resultset_rows.iloc[0].copy()
+        present = present_labels.get(resultset_row[_RESULTSET_INDEX], set())
+        missing_labels = set(parsed_target.keys()) - present
 
-        # Set result-specific fields for the synthetic row
-        template_row["label"] = label
-        template_row["value"] = expected_value
-        template_row["value_type"] = (
-            "boolean" if isinstance(expected_value, bool) else "null"
-        )
-        template_row["answer"] = None
-        template_row["explanation"] = None
-        template_row["metadata"] = json.dumps({})
-        template_row["message_references"] = "[]"
-        template_row["event_references"] = "[]"
-        template_row["uuid"] = None  # Will be assigned by system if needed
+        for label in sorted(missing_labels):
+            expected_value = parsed_target[label]
+            # Only create synthetic row if expected value is negative
+            negative_values = (False, None, "NONE", "none", 0, "")
+            if expected_value not in negative_values:
+                continue
 
-        # Set validation result for this synthetic row
-        template_row["validation_result"] = parsed_results.get(label, None)
-        # Note: validation_target, validation_predicate, validation_split are
-        # preserved from template_row (same for all results from the same case)
+            # Template the synthetic row on this row (its own transcript/case)
+            template_row = resultset_row.copy()
 
-        template_row["scan_error"] = None
-        template_row["scan_error_traceback"] = None
-        template_row["scan_error_type"] = None
+            # Set result-specific fields for the synthetic row
+            template_row["label"] = label
+            template_row["value"] = expected_value
+            template_row["value_type"] = (
+                "boolean" if isinstance(expected_value, bool) else "null"
+            )
+            template_row["answer"] = None
+            template_row["explanation"] = None
+            template_row["metadata"] = json.dumps({})
+            template_row["message_references"] = "[]"
+            template_row["event_references"] = "[]"
+            template_row["uuid"] = None  # Will be assigned by system if needed
 
-        # NULL out scan execution fields
-        template_row["scan_total_tokens"] = None
-        template_row["scan_model_usage"] = None
+            # Set validation result for this synthetic row
+            template_row["validation_result"] = parsed_results.get(label, None)
+            # Note: validation_target, validation_predicate, validation_split
+            # are preserved from template_row (same for all results from the
+            # same case)
 
-        synthetic_rows_list.append(template_row)
+            template_row["scan_error"] = None
+            template_row["scan_error_traceback"] = None
+            template_row["scan_error_type"] = None
+
+            # NULL out scan execution fields
+            template_row["scan_total_tokens"] = None
+            template_row["scan_model_usage"] = None
+
+            synthetic_rows_list.append(template_row)
 
     synthetic_rows = (
         pd.DataFrame(synthetic_rows_list) if synthetic_rows_list else pd.DataFrame()
@@ -395,6 +387,10 @@ def _expand_resultset_rows(df: pd.DataFrame) -> pd.DataFrame:
     resultset_rows = df[resultset_mask].copy()
     other_rows = df[~resultset_mask].copy()
 
+    # Tag each resultset row so expanded rows can be tied back to it (label
+    # validation is scoped per resultset row)
+    resultset_rows[_RESULTSET_INDEX] = range(len(resultset_rows))
+
     # Parse JSON strings in value column to lists
     resultset_rows["value"] = resultset_rows["value"].apply(
         lambda x: json.loads(x) if isinstance(x, str) and x else []
@@ -407,8 +403,13 @@ def _expand_resultset_rows(df: pd.DataFrame) -> pd.DataFrame:
     expanded = expanded[expanded["value"].notna()]
 
     if expanded.empty:
-        # No actual results to expand, just return other rows
-        return other_rows.reset_index(drop=True)
+        # No actual results to expand, but synthetic missing-label rows may
+        # still apply (e.g. empty resultsets with negative label expectations)
+        _, synthetic_rows = _handle_label_validation(expanded, resultset_rows)
+        if synthetic_rows.empty:
+            return other_rows.reset_index(drop=True)
+        synthetic_rows = synthetic_rows.drop(columns=[_RESULTSET_INDEX])
+        return _concat_aligned([other_rows, synthetic_rows])
 
     # Normalize the Result objects into columns
     # Each Result has: uuid, label, value, type, answer, explanation, metadata
@@ -545,9 +546,19 @@ def _expand_resultset_rows(df: pd.DataFrame) -> pd.DataFrame:
     # Handle label-based validation: propagate per-label results and add synthetic rows
     expanded, synthetic_rows = _handle_label_validation(expanded, resultset_rows)
 
+    # Drop the resultset index now that label validation is done
+    expanded = expanded.drop(columns=[_RESULTSET_INDEX])
+    if not synthetic_rows.empty:
+        synthetic_rows = synthetic_rows.drop(columns=[_RESULTSET_INDEX])
+
     # Combine with other rows (including synthetic rows)
+    return _concat_aligned([other_rows, expanded, synthetic_rows])
+
+
+def _concat_aligned(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate DataFrames after aligning columns and dtypes."""
     # Filter out empty DataFrames
-    all_rows = [df for df in [other_rows, expanded, synthetic_rows] if not df.empty]
+    all_rows = [df for df in frames if not df.empty]
 
     if not all_rows:
         # All dataframes are empty, return an empty dataframe with the right structure

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -234,25 +234,28 @@ def _handle_label_validation(
         return expanded, pd.DataFrame()
 
     # Propagate per-label results to rows whose own validation is label-based
-    # (i.e. their validation_target is a JSON dict keyed by label)
-    def assign_label_validation(row: "pd.Series[Any]") -> "pd.Series[Any]":
-        """Assign validation result based on the row's label."""
+    # (i.e. their validation_target is a JSON dict keyed by label). Only the
+    # validation_result column is modified (a whole-row apply would let pandas
+    # re-infer dtypes of untouched columns, e.g. object -> bool).
+    def assign_label_validation(row: "pd.Series[Any]") -> Any:
+        """Validation result for this row based on its label."""
+        result = row["validation_result"]
         label = row.get("label")
         if pd.isna(label):
-            return row
+            return result
 
         if _parse_json_dict(row.get("validation_target")) is None:
-            return row
+            return result
 
-        val_results_dict = _parse_json_dict(row.get("validation_result"))
+        val_results_dict = _parse_json_dict(result)
         if val_results_dict is not None and label in val_results_dict:
             # Replace overall validation_result with this label's specific result
-            row["validation_result"] = val_results_dict[label]
+            return val_results_dict[label]
 
-        return row
+        return result
 
     if not expanded.empty:
-        expanded = expanded.apply(assign_label_validation, axis=1)
+        expanded["validation_result"] = expanded.apply(assign_label_validation, axis=1)
 
     # Labels present in each resultset row's own expansion
     present_labels: dict[Any, set[str]] = {}

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -268,7 +268,12 @@ def _handle_label_validation(
         if parsed_target is None:
             # Not label-based validation for this row
             continue
-        parsed_results = _parse_json_dict(resultset_row.get("validation_result")) or {}
+        parsed_results = _parse_json_dict(resultset_row.get("validation_result"))
+        if parsed_results is None:
+            # Label validation always stores a dict result at scan time; if
+            # it's absent (e.g. the scan errored), don't synthesize rows for
+            # verdicts that were never computed
+            continue
 
         present = present_labels.get(resultset_row[_RESULTSET_INDEX], set())
         missing_labels = set(parsed_target.keys()) - present

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -15,6 +15,7 @@ from ._recorder.recorder import (
     ScanResultsDF,
     Status,
 )
+from ._validation.validate import is_positive_value
 
 
 def scan_status(scan_location: str) -> Status:
@@ -284,8 +285,7 @@ def _handle_label_validation(
         for label in sorted(missing_labels):
             expected_value = parsed_target[label]
             # Only create synthetic row if expected value is negative
-            negative_values = (False, None, "NONE", "none", 0, "")
-            if expected_value not in negative_values:
+            if is_positive_value(expected_value):
                 continue
 
             # Template the synthetic row on this row (its own transcript/case)

--- a/tests/test_label_validation.py
+++ b/tests/test_label_validation.py
@@ -196,6 +196,50 @@ class TestLabelValidationExpansion:
         assert by_label["deception"] == True  # noqa: E712
         assert by_label["phishing"] == False  # noqa: E712
 
+    def test_one_row_per_transcript_label_pair(self) -> None:
+        """Regression test for whole-frame scoping (worked example in PR #545).
+
+        t1 truly contains deception (scanner finds it: true positive) and no
+        phishing (scanner stays silent: true negative). t2 is clean but the
+        scanner reports phishing (false positive) and stays silent on
+        deception (true negative). The DataFrame must surface all four
+        judgments as rows -- the whole-frame present_labels computation
+        yielded zero synthetic rows here because each label appeared
+        somewhere in the frame.
+        """
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [{"label": "deception", "value": "found"}],
+                    "target": {"deception": True, "phishing": False},
+                    "result": {"deception": True, "phishing": True},
+                },
+                {
+                    "transcript_id": "t2",
+                    "results": [{"label": "phishing", "value": "found"}],
+                    "target": {"deception": False, "phishing": False},
+                    "result": {"deception": True, "phishing": False},
+                },
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        rows = {
+            (row["transcript_id"], row["label"]): (
+                row["value"],
+                row["validation_result"],
+            )
+            for _, row in expanded.iterrows()
+        }
+        assert rows == {
+            ("t1", "deception"): ("found", True),  # true positive
+            ("t1", "phishing"): (False, True),  # synthetic true negative
+            ("t2", "phishing"): ("found", False),  # false positive
+            ("t2", "deception"): (False, True),  # synthetic true negative
+        }
+
     def test_synthetic_rows_scoped_per_resultset_row(self) -> None:
         """A label in one transcript doesn't suppress another's synthetic row."""
         target = {"deception": True, "phishing": False}

--- a/tests/test_label_validation.py
+++ b/tests/test_label_validation.py
@@ -1,12 +1,15 @@
 """Tests for label-based validation of resultsets."""
 
+import json
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import pytest
 from inspect_ai.model import ChatMessageUser
 from inspect_scout import Result, Scanner, scanner
+from inspect_scout._scanresults import _expand_resultset_rows
 from inspect_scout._transcript.types import Transcript
 from inspect_scout._validation.validate import _validate_labels, is_positive_value
 from inspect_scout._validation.validation import validation_set
@@ -138,32 +141,198 @@ def test_label_validation_basic() -> None:
     assert case.target is None
 
 
-# The following integration tests are simplified to avoid complexity
-# The core functionality is validated by the parsing tests above
+# ============================================================================
+# Tests for label validation presentation in results DataFrames
+# (_expand_resultset_rows / _handle_label_validation)
+# ============================================================================
 
 
-@pytest.mark.skip(reason="Integration test - simplified to unit tests for now")
-def test_label_validation_propagation() -> None:
-    """Test that validation results are propagated to individual expanded rows."""
-    pass
+def _resultset_df(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    """Build a scanner-results-shaped DataFrame of resultset rows.
+
+    Each row dict has: transcript_id, results (list of result dicts),
+    target (validation target), result (validation result).
+    """
+    return pd.DataFrame(
+        [
+            {
+                "transcript_id": row["transcript_id"],
+                "value": json.dumps(row["results"]),
+                "value_type": "resultset",
+                "validation_target": json.dumps(row["target"]),
+                "validation_result": json.dumps(row["result"]),
+            }
+            for row in rows
+        ]
+    )
 
 
-@pytest.mark.skip(reason="Integration test - simplified to unit tests for now")
-def test_synthetic_row_creation() -> None:
-    """Test that synthetic rows are created for missing labels with negative expected values."""
-    pass
+class TestLabelValidationExpansion:
+    """Label validation presentation is scoped per resultset row.
 
+    That is, per transcript/case, matching how it is computed at scan time
+    by _validate_labels().
+    """
 
-@pytest.mark.skip(reason="Integration test - simplified to unit tests for now")
-def test_at_least_one_validation() -> None:
-    """Test 'at least one' validation logic with multiple results for same label."""
-    pass
+    def test_propagates_per_label_validation_results(self) -> None:
+        """Each expanded row gets its own label's validation result."""
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [
+                        {"label": "deception", "value": "found"},
+                        {"label": "phishing", "value": ""},
+                    ],
+                    "target": {"deception": True, "phishing": True},
+                    "result": {"deception": True, "phishing": False},
+                }
+            ]
+        )
 
+        expanded = _expand_resultset_rows(df)
 
-@pytest.mark.skip(reason="Integration test - simplified to unit tests for now")
-def test_validation_failure() -> None:
-    """Test that validation correctly fails when no results match."""
-    pass
+        by_label = expanded.set_index("label")["validation_result"]
+        assert by_label["deception"] == True  # noqa: E712
+        assert by_label["phishing"] == False  # noqa: E712
+
+    def test_synthetic_rows_scoped_per_resultset_row(self) -> None:
+        """A label in one transcript doesn't suppress another's synthetic row."""
+        target = {"deception": True, "phishing": False}
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [
+                        {"label": "deception", "value": "found"},
+                        {"label": "phishing", "value": "found"},
+                    ],
+                    "target": target,
+                    "result": {"deception": True, "phishing": False},
+                },
+                {
+                    "transcript_id": "t2",
+                    "results": [{"label": "deception", "value": "found"}],
+                    "target": target,
+                    "result": {"deception": True, "phishing": True},
+                },
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        # three real results plus one synthetic true-negative for t2
+        assert len(expanded) == 4
+
+        t2_phishing = expanded[
+            (expanded["transcript_id"] == "t2") & (expanded["label"] == "phishing")
+        ]
+        assert len(t2_phishing) == 1
+        synthetic = t2_phishing.iloc[0]
+        assert synthetic["value"] == False  # noqa: E712
+        assert synthetic["value_type"] == "boolean"
+        assert synthetic["validation_result"] == True  # noqa: E712
+
+        # t1's phishing row is its real result, not a synthetic one
+        t1_phishing = expanded[
+            (expanded["transcript_id"] == "t1") & (expanded["label"] == "phishing")
+        ]
+        assert t1_phishing.iloc[0]["value"] == "found"
+
+        # internal bookkeeping column doesn't leak
+        assert not any(col.startswith("_resultset") for col in expanded.columns)
+
+    def test_synthetic_rows_for_empty_resultset(self) -> None:
+        """An empty resultset still yields synthetic true-negative rows."""
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [],
+                    "target": {"phishing": False},
+                    "result": {"phishing": True},
+                }
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        assert len(expanded) == 1
+        row = expanded.iloc[0]
+        assert row["transcript_id"] == "t1"
+        assert row["label"] == "phishing"
+        assert row["value"] == False  # noqa: E712
+        assert row["validation_result"] == True  # noqa: E712
+
+    def test_synthetic_rows_use_each_rows_own_target(self) -> None:
+        """Each transcript gets synthetic rows for its own expected labels."""
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [],
+                    "target": {"alpha": False},
+                    "result": {"alpha": True},
+                },
+                {
+                    "transcript_id": "t2",
+                    "results": [],
+                    "target": {"beta": False},
+                    "result": {"beta": True},
+                },
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        labels_by_transcript = expanded.set_index("transcript_id")["label"]
+        assert labels_by_transcript["t1"] == "alpha"
+        assert labels_by_transcript["t2"] == "beta"
+
+    def test_scalar_validation_rows_unaffected(self) -> None:
+        """Non-label (scalar target) validation is left untouched."""
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [{"label": "x", "value": "found"}],
+                    "target": True,
+                    "result": True,
+                }
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        assert len(expanded) == 1
+        # validation_result stays as stored (JSON scalar), no synthetic rows
+        assert expanded.iloc[0]["validation_result"] == "true"
+
+    def test_label_rows_handled_even_when_first_row_is_scalar(self) -> None:
+        """Label validation applies per row, not gated on the frame's first row."""
+        df = _resultset_df(
+            [
+                {
+                    "transcript_id": "t1",
+                    "results": [{"label": "x", "value": "found"}],
+                    "target": True,
+                    "result": True,
+                },
+                {
+                    "transcript_id": "t2",
+                    "results": [],
+                    "target": {"phishing": False},
+                    "result": {"phishing": True},
+                },
+            ]
+        )
+
+        expanded = _expand_resultset_rows(df)
+
+        t2_rows = expanded[expanded["transcript_id"] == "t2"]
+        assert len(t2_rows) == 1
+        assert t2_rows.iloc[0]["label"] == "phishing"
+        assert t2_rows.iloc[0]["validation_result"] == True  # noqa: E712
 
 
 # ============================================================================

--- a/tests/test_label_validation.py
+++ b/tests/test_label_validation.py
@@ -227,12 +227,12 @@ class TestLabelValidationExpansion:
         # internal bookkeeping column doesn't leak
         assert not any(col.startswith("_resultset") for col in expanded.columns)
 
-    def test_synthetic_rows_without_stored_validation_result(self) -> None:
-        """A label-based target alone drives synthesis.
+    def test_no_synthetic_rows_without_stored_validation_result(self) -> None:
+        """Synthesis requires a stored per-label validation result.
 
-        If a row's validation_result is missing (e.g. a scan error), its
-        expected-absent labels still get synthetic rows, with a None
-        validation result.
+        Synthetic rows surface verdicts computed at scan time; if a row's
+        validation_result is missing (e.g. the scan errored), there are no
+        verdicts to surface, so no synthetic rows are created.
         """
         df = _resultset_df(
             [
@@ -247,14 +247,10 @@ class TestLabelValidationExpansion:
 
         expanded = _expand_resultset_rows(df)
 
-        phishing = expanded[expanded["label"] == "phishing"]
-        assert len(phishing) == 1
-        assert phishing.iloc[0]["value"] == False  # noqa: E712
-        assert pd.isna(phishing.iloc[0]["validation_result"])
-
+        # only the real result row; no synthetic phishing row
+        assert expanded["label"].tolist() == ["deception"]
         # the real row's validation_result is left as stored
-        deception = expanded[expanded["label"] == "deception"]
-        assert deception.iloc[0]["validation_result"] == "null"
+        assert expanded.iloc[0]["validation_result"] == "null"
 
     def test_synthetic_rows_for_empty_resultset(self) -> None:
         """An empty resultset still yields synthetic true-negative rows."""

--- a/tests/test_label_validation.py
+++ b/tests/test_label_validation.py
@@ -174,28 +174,6 @@ class TestLabelValidationExpansion:
     by _validate_labels().
     """
 
-    def test_propagates_per_label_validation_results(self) -> None:
-        """Each expanded row gets its own label's validation result."""
-        df = _resultset_df(
-            [
-                {
-                    "transcript_id": "t1",
-                    "results": [
-                        {"label": "deception", "value": "found"},
-                        {"label": "phishing", "value": ""},
-                    ],
-                    "target": {"deception": True, "phishing": True},
-                    "result": {"deception": True, "phishing": False},
-                }
-            ]
-        )
-
-        expanded = _expand_resultset_rows(df)
-
-        by_label = expanded.set_index("label")["validation_result"]
-        assert by_label["deception"] == True  # noqa: E712
-        assert by_label["phishing"] == False  # noqa: E712
-
     def test_one_row_per_transcript_label_pair(self) -> None:
         """Regression test for whole-frame scoping (worked example in PR #545).
 
@@ -240,51 +218,43 @@ class TestLabelValidationExpansion:
             ("t2", "deception"): (False, True),  # synthetic true negative
         }
 
-    def test_synthetic_rows_scoped_per_resultset_row(self) -> None:
-        """A label in one transcript doesn't suppress another's synthetic row."""
-        target = {"deception": True, "phishing": False}
+        # synthetic rows carry a boolean value type
+        synthetic = expanded[
+            (expanded["transcript_id"] == "t1") & (expanded["label"] == "phishing")
+        ]
+        assert synthetic.iloc[0]["value_type"] == "boolean"
+
+        # internal bookkeeping column doesn't leak
+        assert not any(col.startswith("_resultset") for col in expanded.columns)
+
+    def test_synthetic_rows_without_stored_validation_result(self) -> None:
+        """A label-based target alone drives synthesis.
+
+        If a row's validation_result is missing (e.g. a scan error), its
+        expected-absent labels still get synthetic rows, with a None
+        validation result.
+        """
         df = _resultset_df(
             [
                 {
                     "transcript_id": "t1",
-                    "results": [
-                        {"label": "deception", "value": "found"},
-                        {"label": "phishing", "value": "found"},
-                    ],
-                    "target": target,
-                    "result": {"deception": True, "phishing": False},
-                },
-                {
-                    "transcript_id": "t2",
                     "results": [{"label": "deception", "value": "found"}],
-                    "target": target,
-                    "result": {"deception": True, "phishing": True},
-                },
+                    "target": {"deception": True, "phishing": False},
+                    "result": None,
+                }
             ]
         )
 
         expanded = _expand_resultset_rows(df)
 
-        # three real results plus one synthetic true-negative for t2
-        assert len(expanded) == 4
+        phishing = expanded[expanded["label"] == "phishing"]
+        assert len(phishing) == 1
+        assert phishing.iloc[0]["value"] == False  # noqa: E712
+        assert pd.isna(phishing.iloc[0]["validation_result"])
 
-        t2_phishing = expanded[
-            (expanded["transcript_id"] == "t2") & (expanded["label"] == "phishing")
-        ]
-        assert len(t2_phishing) == 1
-        synthetic = t2_phishing.iloc[0]
-        assert synthetic["value"] == False  # noqa: E712
-        assert synthetic["value_type"] == "boolean"
-        assert synthetic["validation_result"] == True  # noqa: E712
-
-        # t1's phishing row is its real result, not a synthetic one
-        t1_phishing = expanded[
-            (expanded["transcript_id"] == "t1") & (expanded["label"] == "phishing")
-        ]
-        assert t1_phishing.iloc[0]["value"] == "found"
-
-        # internal bookkeeping column doesn't leak
-        assert not any(col.startswith("_resultset") for col in expanded.columns)
+        # the real row's validation_result is left as stored
+        deception = expanded[expanded["label"] == "deception"]
+        assert deception.iloc[0]["validation_result"] == "null"
 
     def test_synthetic_rows_for_empty_resultset(self) -> None:
         """An empty resultset still yields synthetic true-negative rows."""


### PR DESCRIPTION
(written by Claude, edited by Thomas)

## Repro case

Suppose we have two transcripts and one scanner that detects multiple kinds of findings and returns labeled Results in a ResultSet. Also, we have a validation set saying what each transcript should contain:

```yaml
- id: t1
  labels: { deception: true,  phishing: false }   # t1 really contains deception, no phishing
- id: t2
  labels: { deception: false, phishing: false }   # t2 is clean
```

The scanner runs once per transcript:

- On `t1` it returns `[Result(label="deception", value="found")]`. This is a true positive for deception and a true negative for phishing.
- On `t2` it returns `[Result(label="phishing", value="found")]`. This is a true negative for deception and a false positive for phishing.

`validation_result` is stored as follows:

| row | value (resultset JSON) | validation_target | validation_result |
|---|---|---|---|
| t1 | `[{label: deception, value: found}]` | `{deception: true, phishing: false}` | `{deception: true, phishing: true}` |
| t2 | `[{label: phishing, value: found}]` | `{deception: false, phishing: false}` | `{deception: true, phishing: false}` |

`scan_results_df()` expands each ResultSet into a single DataFrame row per Result. It adds synthetic rows for true negatives that otherwise wouldn't appear in the DataFrame. The correct output is one row per transcript and label:

| transcript | label | value | validation_result | |
|---|---|---|---|---|
| t1 | deception | found | True | real |
| t1 | phishing | False | True | **synthetic** (true negative) |
| t2 | phishing | found | False | real (false positive) |
| t2 | deception | False | True | **synthetic** (true negative) |

However, `_handle_label_validation()` computes whether each label is present by looking over the entire DataFrame. Both labels are present on at least one row in the DataFrame, causing this function to skip adding true negatives.

## The fix

Instead of computing label presence over the entire DataFrame, compute it for each row with a ResultSet value separately. That way, the logic correctly detects that deception is missing for one transcript and phishing for the other, and creates the true negative rows.
Also, the per-label result propagation now assigns only the `validation_result` column instead of applying a whole-row transform. `DataFrame.apply(axis=1)` over whole rows lets pandas re-infer dtypes of untouched columns (e.g. coercing an object column of Python bools to numpy bool dtype, which conflicts with #544's guarantee that boolean resultset values come back as real `True`/`False`).