### PR TITLE
fix: bound memory usage on large scans (streamed compaction + bounded results queue)

### DIFF
--- a/src/inspect_scout/_concurrency/_mp_shutdown.py
+++ b/src/inspect_scout/_concurrency/_mp_shutdown.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Sequence
 from multiprocessing.context import SpawnProcess
 from multiprocessing.queues import Queue
-from queue import Empty
+from queue import Empty, Full
 from typing import Any, Callable
 
 import anyio
@@ -125,8 +125,15 @@ async def shutdown_subprocesses(
     # PHASE 5: Inject shutdown sentinel to wake collector
     print_diagnostics("SubprocessShutdown", "Phase 5: Injecting shutdown sentinel")
     try:
-        ctx.upstream_queue.put(shutdown_sentinel)
+        # put_nowait: the queue is bounded, and a blocking put on a full queue
+        # would hang shutdown. If the queue is full the collector cannot be
+        # blocked on get() anyway, so the wake-up sentinel isn't needed.
+        ctx.upstream_queue.put_nowait(shutdown_sentinel)
         print_diagnostics("SubprocessShutdown", "Injected upstream queue sentinel")
+    except Full:
+        print_diagnostics(
+            "SubprocessShutdown", "Upstream queue full - sentinel not needed"
+        )
     except (ValueError, OSError) as e:
         # Queue already closed - collector likely already exited via cancellation
         print_diagnostics("SubprocessShutdown", f"Upstream queue closed: {e}")

--- a/src/inspect_scout/_concurrency/_mp_subprocess.py
+++ b/src/inspect_scout/_concurrency/_mp_subprocess.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from queue import Full
 from threading import Condition
 from typing import Callable
 
@@ -105,7 +106,9 @@ def subprocess_main(
             "Worker main",
             f"Initialized with {task_count} max tasks. Waiting for start...",
         )
-        ipc_ctx.upstream_queue.put(_mp_common.WorkerReady(worker_id))
+        await run_sync_on_thread(
+            ipc_ctx.upstream_queue.put, _mp_common.WorkerReady(worker_id)
+        )
         await run_sync_on_thread(ipc_ctx.workers_ready_event.wait)
 
         # Run everything in a task group with shutdown monitor
@@ -142,7 +145,8 @@ def subprocess_main(
                     except Exception as ex:
                         print_diagnostics("Worker main", f"Work task error: {ex}")
                         # Send exception back to main process via upstream queue
-                        ipc_ctx.upstream_queue.put(ex)
+                        # (in a thread: the bounded queue can block when full)
+                        await run_sync_on_thread(ipc_ctx.upstream_queue.put, ex)
                         raise
                     finally:
                         # CRITICAL: Cancel the shutdown monitor to prevent hang.
@@ -176,7 +180,9 @@ def subprocess_main(
             # except blocks above would catch and handle it, making control flow unclear.
             # With else:, it's explicit: sentinel is sent ONLY on clean completion.
             print_diagnostics("Worker main", "Sending completion sentinel")
-            ipc_ctx.upstream_queue.put(_mp_common.WorkerComplete())
+            await run_sync_on_thread(
+                ipc_ctx.upstream_queue.put, _mp_common.WorkerComplete()
+            )
 
         print_diagnostics("Worker main", "exiting")
 
@@ -191,16 +197,36 @@ def subprocess_main(
     async def _record_to_queue(
         transcript: TranscriptInfo, scanner: str, results: list[ResultReport]
     ) -> None:
-        ipc_ctx.upstream_queue.put(_mp_common.ResultItem(transcript, scanner, results))
+        # put() blocks when the bounded queue is full (backpressure when the
+        # main process records slower than workers scan) — run it in a thread
+        # so only this task waits, not the worker's whole event loop
+        await run_sync_on_thread(
+            ipc_ctx.upstream_queue.put,
+            _mp_common.ResultItem(transcript, scanner, results),
+        )
 
     def _update_worker_metrics(metrics: ScanMetrics) -> None:
-        ipc_ctx.upstream_queue.put(_mp_common.MetricsItem(worker_id, metrics))
+        # sync context: never block the event loop on a full queue. Metrics
+        # are periodic snapshots — dropping one is harmless, the next
+        # update supersedes it.
+        try:
+            ipc_ctx.upstream_queue.put_nowait(
+                _mp_common.MetricsItem(worker_id, metrics)
+            )
+        except Full:
+            pass
 
     def _log_in_parent(record: logging.LogRecord) -> None:
         # Strip exc_info from record to avoid pickling traceback objects since it
         # cannot be serialized across process boundaries
         record.exc_info = None
-        ipc_ctx.upstream_queue.put(LoggingItem(record))
+        # sync context (called from the logging handler): never block on a
+        # full queue — under backpressure it's better to drop a log record
+        # than to stall the worker's event loop
+        try:
+            ipc_ctx.upstream_queue.put_nowait(LoggingItem(record))
+        except Full:
+            pass
 
     def _initialize_subprocess() -> None:
         # Set up sys.path with plugin directory before any user imports

--- a/src/inspect_scout/_concurrency/multi_process.py
+++ b/src/inspect_scout/_concurrency/multi_process.py
@@ -77,6 +77,13 @@ DEFAULT_MAX_PROCESS = 4
 # when parse_jobs iterator is very large. Producer will block when queue is full.
 PARSE_JOB_PREFETCH_SIZE = 50
 
+# Maximum number of items buffered in the upstream (results) queue.
+# Provides backpressure when workers produce results faster than the main
+# process can record them: each ResultItem embeds the scanned transcript(s),
+# so an unbounded queue can grow to many GB over a large scan. Workers block
+# (in a worker thread, not the event loop) when the queue is full.
+UPSTREAM_QUEUE_MAXSIZE = 100
+
 # Sentinel value to signal collectors to shut down during Ctrl-C.
 #
 # MUST be a sentinel: During Ctrl-C shutdown, workers are terminated before they can
@@ -187,7 +194,7 @@ def multi_process_strategy(
                 diagnostics=diagnostics,
                 overall_start_time=time.time(),
                 parse_job_queue=spawn_ctx.Queue(maxsize=PARSE_JOB_PREFETCH_SIZE),
-                upstream_queue=spawn_ctx.Queue(),
+                upstream_queue=spawn_ctx.Queue(maxsize=UPSTREAM_QUEUE_MAXSIZE),
                 shutdown_condition=manager.Condition(),
                 workers_ready_event=manager.Event(),
                 semaphore_registry=parent_registry.sync_manager_dict,
@@ -214,7 +221,9 @@ def multi_process_strategy(
             # ParseJob queue is bounded to prevent memory explosion when parse_jobs
             # iterator contains a huge number of items. Producer blocks when queue
             # is full, providing lazy consumption.
-            # Upstream queue is unbounded and multiplexes both results and metrics.
+            # Upstream queue multiplexes results, metrics, logging, and semaphore
+            # requests. It is bounded so result backlog can't grow without limit
+            # when the collector records slower than workers scan.
             parse_job_queue = ipc_ctx.parse_job_queue
             upstream_queue = ipc_ctx.upstream_queue
 

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -319,9 +319,20 @@ def resolve_success_value(value: bool | None, score: JsonValue | None) -> bool |
 def scanner_table(
     buffer_dir: UPath,
     scanner: str,
+    output_file: str,
     *,
     extra_inputs: list[UPath] | None = None,
-) -> bytes | None:
+) -> bool:
+    """Compact per-transcript buffer parquets into a single parquet file.
+
+    Streams batches from the buffer (and any `extra_inputs`) directly into
+    `output_file` (a local path), so peak memory stays bounded regardless of
+    the total size of the compacted output.
+
+    Returns:
+        True if `output_file` was written, False if there was nothing to
+        compact (in which case no file is created).
+    """
     import pyarrow as pa
     import pyarrow.dataset as ds
     import pyarrow.parquet as pq
@@ -372,7 +383,7 @@ def scanner_table(
         # avoid creating a schema-less empty parquet when there's nothing to
         # compact. If you *must* emit a file in that case, you need a known
         # schema.
-        return None
+        return False
     # set of paths whose batches need transcript_id filtering against
     # `buffer_tids` (paths NOT in the buffer dir → from extra_inputs)
     extra_paths_set: set[str] = set(extra_paths)
@@ -421,10 +432,12 @@ def scanner_table(
         accumulated.clear()
         accumulated_bytes = 0
 
-    # Create an in-memory buffer (use PyArrow's native type for efficiency)
-    buffer = pa.BufferOutputStream()
+    # Stream the compacted output directly to `output_file`. On large scans
+    # the compacted parquet can be multiple GB — materializing it in an
+    # in-memory buffer (and then copying it to bytes) caused a ~2x-output-size
+    # memory spike at scan finalize, large enough to OOM the host.
     writer = pq.ParquetWriter(
-        buffer,
+        output_file,
         schema,
         compression="zstd",
         use_dictionary=True,
@@ -477,13 +490,7 @@ def scanner_table(
     flush_accumulated(writer)
     writer.close()
 
-    # TODO: If we changed the signature of this function from:
-    #   bytes | None
-    #     to
-    #   pa.Buffer | None
-    # We could avoid the copy (that to_pybytes does) altogether.
-    # Keep in mind that the previous BytesIO.getvalue() made a copy too.
-    return buffer.getvalue().to_pybytes()
+    return True
 
 
 def cleanup_buffer_dir(buffer_dir: UPath) -> None:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -294,22 +294,45 @@ class FileRecorder(ScanRecorder):
         # prior compacted parquet is remote, download it to a local temp
         # file before passing to `scanner_table`.
         #
-        # write to a sibling `.tmp` then atomically rename so the same path
-        # is never simultaneously an input to scanner_table and the target
-        # of an in-progress write (avoids any read/write overlap and gives
-        # crash resilience: a failure mid-write leaves the prior compacted
-        # file intact).
+        # the compacted output is streamed to a local file (never held in
+        # memory — on large scans it can be multiple GB): directly to a
+        # sibling `.tmp` when the scan dir is local, or to a temp file that
+        # is then streamed up to the remote `.tmp`. The `.tmp` is atomically
+        # renamed into place so the same path is never simultaneously an
+        # input to scanner_table and the target of an in-progress write
+        # (avoids any read/write overlap and gives crash resilience: a
+        # failure mid-write leaves the prior compacted file intact).
         sync_fs = filesystem(scan_dir.as_posix())
+        local_scan_dir = scan_dir.protocol in ("", "file")
         async with AsyncFilesystem() as fs:
             for scanner in sorted(scan_spec.scanners.keys()):
                 output_path = _scanner_parquet_file(scan_dir, scanner)
-                parquet_bytes = await _compact_with_prior(
-                    scan_buffer_dir, scanner, prior=UPath(output_path)
-                )
-                if parquet_bytes is not None:
-                    tmp_path = f"{output_path}.tmp"
-                    await fs.write_file(tmp_path, parquet_bytes)
-                    sync_fs.mv(tmp_path, output_path)
+                if local_scan_dir:
+                    compact_file = f"{output_path}.tmp"
+                else:
+                    tmp_fd, compact_file = tempfile.mkstemp(suffix=".parquet")
+                    os.close(tmp_fd)
+                try:
+                    wrote = await _compact_with_prior(
+                        scan_buffer_dir,
+                        scanner,
+                        prior=UPath(output_path),
+                        output_file=compact_file,
+                    )
+                    if wrote:
+                        if local_scan_dir:
+                            sync_fs.mv(compact_file, output_path)
+                        else:
+                            tmp_path = f"{output_path}.tmp"
+                            with open(compact_file, "rb") as f:
+                                await fs.write_file_streaming(tmp_path, f)
+                            sync_fs.mv(tmp_path, output_path)
+                finally:
+                    # remove leftovers: the remote-upload temp file, or a
+                    # partially-written local `.tmp` after a failure (after
+                    # a successful local rename the path no longer exists)
+                    if os.path.exists(compact_file):
+                        os.unlink(compact_file)
 
         # sync summary and errors
         _sync_status_files(scan_dir, scan_buffer_dir, scan_spec, complete)
@@ -697,16 +720,19 @@ class FileRecorder(ScanRecorder):
 
 
 async def _compact_with_prior(
-    scan_buffer_dir: UPath, scanner: str, *, prior: UPath
-) -> bytes | None:
+    scan_buffer_dir: UPath, scanner: str, *, prior: UPath, output_file: str
+) -> bool:
     """Compact buffer parquets, optionally merging in a prior compacted output.
+
+    The compacted result is streamed to `output_file` (a local path);
+    returns True if it was written (False when there was nothing to compact).
 
     `scanner_table` requires uniform local paths. If `prior` exists on a
     remote filesystem, download it to a local temp file before passing it
     in, then clean up.
     """
     if not prior.exists():
-        return scanner_table(scan_buffer_dir, scanner)
+        return scanner_table(scan_buffer_dir, scanner, output_file)
 
     local_prior: UPath | None = None
     try:
@@ -718,7 +744,7 @@ async def _compact_with_prior(
             local_prior = UPath(tmp_name)
             local_prior.write_bytes(prior.read_bytes())
             extra = [local_prior]
-        return scanner_table(scan_buffer_dir, scanner, extra_inputs=extra)
+        return scanner_table(scan_buffer_dir, scanner, output_file, extra_inputs=extra)
     finally:
         if local_prior is not None:
             local_prior.unlink(missing_ok=True)

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 import json
 import tempfile
 from pathlib import Path
@@ -140,6 +139,7 @@ async def test_sanitize_table_names(
     recorder_buffer: RecorderBuffer,
     sample_transcript: TranscriptInfo,
     sample_results: list[ResultReport],
+    tmp_path: Path,
 ) -> None:
     """Test that table names with special characters are sanitized."""
     scanner_name = "test-scanner.with:special/chars"
@@ -148,13 +148,16 @@ async def test_sanitize_table_names(
     await recorder_buffer.record(sample_transcript, scanner_name, sample_results, None)
 
     # Should still be able to retrieve
-    scanner_table(recorder_buffer._buffer_dir, scanner_name)
+    scanner_table(
+        recorder_buffer._buffer_dir, scanner_name, str(tmp_path / "out.parquet")
+    )
 
 
 @pytest.mark.asyncio
 async def test_scanner_table_casts_mixed_transcript_score_to_string(
     recorder_buffer: RecorderBuffer,
     sample_results: list[ResultReport],
+    tmp_path: Path,
 ) -> None:
     scanner_name = "test_scanner"
     await recorder_buffer.record(
@@ -182,10 +185,11 @@ async def test_scanner_table_casts_mixed_transcript_score_to_string(
         None,
     )
 
-    parquet_bytes = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert parquet_bytes is not None
+    out_path = tmp_path / "out.parquet"
+    wrote = scanner_table(recorder_buffer._buffer_dir, scanner_name, str(out_path))
+    assert wrote
 
-    table = pq.read_table(io.BytesIO(parquet_bytes))
+    table = pq.read_table(out_path)
     assert table.schema.field("transcript_score").type == pa.string()
 
 
@@ -232,24 +236,23 @@ async def test_scanner_table_dedupes_extra_inputs_against_buffer(
 
     # snapshot the buffer's compacted output and use it as extra_inputs
     # — this mirrors what `_compact_with_prior` passes into `sync`.
-    first = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert first is not None
     prior_path = tmp_path / "prior.parquet"
-    prior_path.write_bytes(first)
+    assert scanner_table(recorder_buffer._buffer_dir, scanner_name, str(prior_path))
 
     # second compaction with the prior as extra_inputs. Without dedup
     # the output would have each tid's rows twice.
-    second = scanner_table(
+    second_path = tmp_path / "second.parquet"
+    assert scanner_table(
         recorder_buffer._buffer_dir,
         scanner_name,
+        str(second_path),
         extra_inputs=[UPath(prior_path)],
     )
-    assert second is not None
 
     # load and check: same row count as the original (no doubling),
     # same set of transcript_ids
-    first_tbl = pq.read_table(io.BytesIO(first))
-    second_tbl = pq.read_table(io.BytesIO(second))
+    first_tbl = pq.read_table(prior_path)
+    second_tbl = pq.read_table(second_path)
     assert second_tbl.num_rows == first_tbl.num_rows, (
         f"extra_inputs duplicated buffer rows: {second_tbl.num_rows} "
         f"vs expected {first_tbl.num_rows}"
@@ -287,10 +290,8 @@ async def test_scanner_table_keeps_extra_inputs_for_transcripts_not_in_buffer(
         sample_results,
         None,
     )
-    prior_bytes = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert prior_bytes is not None
     prior_path = tmp_path / "prior.parquet"
-    prior_path.write_bytes(prior_bytes)
+    assert scanner_table(recorder_buffer._buffer_dir, scanner_name, str(prior_path))
 
     # clear the buffer file for tid-old and write tid-new
     sdir = recorder_buffer._buffer_dir / f"scanner={scanner_name}"
@@ -308,13 +309,14 @@ async def test_scanner_table_keeps_extra_inputs_for_transcripts_not_in_buffer(
         None,
     )
 
-    out = scanner_table(
+    out_path = tmp_path / "out.parquet"
+    assert scanner_table(
         recorder_buffer._buffer_dir,
         scanner_name,
+        str(out_path),
         extra_inputs=[UPath(prior_path)],
     )
-    assert out is not None
-    tbl = pq.read_table(io.BytesIO(out))
+    tbl = pq.read_table(out_path)
     # both transcripts present: tid-new from buffer, tid-old from extras
     assert set(tbl.column("transcript_id").to_pylist()) == {"tid-old", "tid-new"}
 


### PR DESCRIPTION
## Problem

On large scans (tens of thousands of transcripts), scout's main-process memory usage can grow far beyond the working set of the scan itself — in our case repeatedly freezing a 48GB workstation (macOS swap storm) late in a ~48k-transcript scan. Two mechanisms compound:

1. **Finalize compaction materializes the entire output in RAM.** `scanner_table` writes the compacted parquet into a `pa.BufferOutputStream` and then copies it out with `to_pybytes()`, so `sync()` peaks at ~2x the compacted parquet size per scanner. Because each result row embeds the scanned transcript (`input`) and the scan events, large scans compact to multi-GB parquets (we measured ~310KB/row on agentic transcripts, i.e. a ~15GB buffer dir for one scan), making that spike large enough to take down the host. Interrupts hit the same path, since Ctrl-C handling also runs `sync()`.

2. **The upstream results queue is unbounded.** The parse-job queue is bounded (with a comment explaining exactly this risk), but the results direction is not: each `ResultItem` embeds full transcripts, so whenever workers produce results faster than the main process can record them the backlog grows without limit for the life of the scan.

## Changes

**Streamed compaction** (`_recorder/buffer.py`, `_recorder/file.py`):
- `scanner_table` now streams the compacted parquet directly to a local output file via `ParquetWriter` instead of an in-memory buffer + bytes copy (this also resolves the existing TODO about avoiding the `to_pybytes` copy). Signature changes from returning `bytes | None` to writing `output_file` and returning `bool`.
- `FileRecorder.sync` compacts straight into the sibling `.tmp` when the scan dir is local (same atomic-rename semantics as before), or into a temp file that is uploaded with `AsyncFilesystem.write_file_streaming` for remote scan dirs. Compaction memory is now bounded by the existing ~100MB input-accumulation cap regardless of output size.

**Bounded upstream queue** (`_concurrency/multi_process.py`, `_mp_subprocess.py`, `_mp_shutdown.py`):
- `upstream_queue` gets `maxsize=UPSTREAM_QUEUE_MAXSIZE` (100), so workers experience backpressure instead of the main process accumulating results.
- Worker-side puts that can now block (`ResultItem`, `WorkerReady`, `WorkerComplete`, work-task exceptions) are wrapped in `run_sync_on_thread` so only the putting task waits, never the worker's event loop.
- Sync-context puts use `put_nowait` and drop on `Full`: metrics snapshots (the next update supersedes) and forwarded log records (dropping a record under backpressure beats stalling the event loop from inside a logging handler).
- The shutdown sentinel injection uses `put_nowait`: a blocking put on a full queue would hang shutdown, and if the queue is full the collector cannot be blocked on `get()` anyway.

## Testing

- Adapted `tests/scanner/test_recorder_buffer.py` to the new `scanner_table` signature.
- `pytest tests/recorder tests/concurrency tests/scan tests/scanner`: 679 passed, 1 skipped.
- Full suite run: the only failures (`test_project.py`, langsmith source, anthropic cache-control import) fail identically on `main` in my environment (missing optional deps), i.e. pre-existing.
- `ruff check`/`ruff format` and `mypy` clean on all touched files.

Co-Authored-By: Claude
