### PR TITLE
chore: reformat design doc code blocks for ruff 0.16 formatter

### DIFF
--- a/design/claude-code-events.md
+++ b/design/claude-code-events.md
@@ -112,11 +112,13 @@ The retry/attempts loop needs to work with this streaming approach — each atte
 ```python
 bridge_model_events: dict[str, ModelEvent] = {}
 
+
 def on_event(event: Event) -> None:
     if isinstance(event, ModelEvent) and event.pending is None:
         msg_id = event.output.choices[0].message.id if event.output.choices else None
         if msg_id:
             bridge_model_events[msg_id] = event
+
 
 transcript()._subscribe(on_event)
 ```

--- a/design/generator-iterator.md
+++ b/design/generator-iterator.md
@@ -28,6 +28,7 @@ async def count_up(n: int) -> AsyncIterator[int]:
         await asyncio.sleep(0.1)
         yield i
 
+
 async for num in count_up(5):
     print(num)
 ```
@@ -63,6 +64,7 @@ class ManagedStream:
         if data is None:
             raise StopAsyncIteration
         return data
+
 
 # Consuming (context manager):
 async with ManagedStream(resource) as stream:

--- a/design/timeline-scanning.md
+++ b/design/timeline-scanning.md
@@ -38,6 +38,7 @@ A factory function `message_numbering()` returns a pair of functions — a `mess
 MessagesAsStr: TypeAlias = Callable[[list[ChatMessage]], Awaitable[str]]
 ExtractReferences: TypeAlias = Callable[[str], list[Reference]]
 
+
 def message_numbering(
     preprocessor: MessagesPreprocessor | None = None,
 ) -> tuple[MessagesAsStr, ExtractReferences]:
@@ -256,9 +257,10 @@ async def chunked_messages(
 @dataclass(frozen=True)
 class RenderedMessages:
     """A chunk of messages, pre-rendered and sized to fit a context window."""
+
     messages: list[ChatMessage]
-    text: str              # pre-rendered string from messages_as_str
-    segment: int           # 0-based segment index
+    text: str  # pre-rendered string from messages_as_str
+    segment: int  # 0-based segment index
 ```
 
 Segments result from either compaction boundaries (when given events) or context window chunking — `RenderedMessages` does not distinguish the cause. The `segment` index is 0-based and auto-increments across yields. No total count is tracked — async generators yield lazily and the total isn't known upfront.
@@ -386,6 +388,7 @@ Extends `RenderedMessages` with span context:
 @dataclass(frozen=True)
 class TimelineMessages(RenderedMessages):
     """A chunk of messages from a specific timeline span."""
+
     span: TimelineSpan
 ```
 
@@ -709,6 +712,7 @@ class TranscriptContent:
             timeline from all events; a list of event types builds
             a filtered timeline.
     """
+
     messages: MessageFilter = field(default=None)
     events: EventFilter = field(default=None)
     timeline: TimelineFilter = field(default=None)
@@ -772,8 +776,10 @@ def llm_scanner(
         template = DEFAULT_SCANNER_TEMPLATE
     resolved_answer = answer_from_argument(answer)
     retry_refusals = (
-        retry_refusals if isinstance(retry_refusals, int)
-        else 3 if retry_refusals is True
+        retry_refusals
+        if isinstance(retry_refusals, int)
+        else 3
+        if retry_refusals is True
         else 0
     )
 
@@ -904,7 +910,7 @@ The refactored `llm_scanner` scan loop is sequential:
 ```python
 async for segment in transcript_messages(...):
     prompt = await render_scanner_prompt(...)
-    result = await generate_answer(...)      # seconds per call
+    result = await generate_answer(...)  # seconds per call
     results.append(result)
 ```
 
@@ -966,9 +972,9 @@ async def parallel_scan(
     max_concurrency = model.config.max_connections or model.api.max_connections()
     results: dict[int, Result] = {}
 
-    send_stream, receive_stream = anyio.create_memory_object_stream[
-        RenderedMessages
-    ](max_buffer_size=max_concurrency)
+    send_stream, receive_stream = anyio.create_memory_object_stream[RenderedMessages](
+        max_buffer_size=max_concurrency
+    )
 
     async def producer() -> None:
         async with send_stream:


### PR DESCRIPTION
## Why

The `py-ruff` CI job installs the latest ruff at run time, and ruff 0.16.0 (just released) newly formats Python code blocks inside Markdown files. `ruff format --check .` now fails on three pre-existing design docs, breaking the Build workflow on `main` and every open PR (e.g. the py-ruff failure on #541 is this, not that PR's changes).

## What

Reformat the three design docs with ruff 0.16.0 so the repo passes with the latest formatter:

- `design/claude-code-events.md`
- `design/generator-iterator.md`
- `design/timeline-scanning.md`

The changes are purely formatting inside markdown code blocks (blank lines after defs, inline comment spacing, line-length rewraps). Per our convention, CI intentionally tracks the latest ruff rather than a pinned version — so the fix is to adapt to the new formatter behavior, not to pin. Local ruff 0.15.x ignores markdown code blocks entirely, so developers on older ruff won't see these files re-reformatted.

## Verification

With ruff 0.16.0 locally: `ruff format --check .` passes (472 files already formatted) and `ruff check .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReANxVmoeKrXM7q6i3UHzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReANxVmoeKrXM7q6i3UHzB)_