### PR TITLE
fix: stream scan result compaction to disk

### DIFF
--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -316,9 +316,20 @@ def resolve_success_value(value: bool | None, score: JsonValue | None) -> bool |
 def scanner_table(
     buffer_dir: UPath,
     scanner: str,
+    output_file: str,
     *,
     extra_inputs: list[UPath] | None = None,
-) -> bytes | None:
+) -> bool:
+    """Compact per-transcript buffer parquets into a single parquet file.
+
+    Streams batches from the buffer (and any `extra_inputs`) directly into
+    `output_file` (a local path), so peak memory stays bounded regardless of
+    the total size of the compacted output.
+
+    Returns:
+        True if `output_file` was written, False if there was nothing to
+        compact (in which case no file is created).
+    """
     import pyarrow as pa
     import pyarrow.dataset as ds
     import pyarrow.parquet as pq
@@ -369,7 +380,7 @@ def scanner_table(
         # avoid creating a schema-less empty parquet when there's nothing to
         # compact. If you *must* emit a file in that case, you need a known
         # schema.
-        return None
+        return False
     # set of paths whose batches need transcript_id filtering against
     # `buffer_tids` (paths NOT in the buffer dir → from extra_inputs)
     extra_paths_set: set[str] = set(extra_paths)
@@ -418,69 +429,63 @@ def scanner_table(
         accumulated.clear()
         accumulated_bytes = 0
 
-    # Create an in-memory buffer (use PyArrow's native type for efficiency)
-    buffer = pa.BufferOutputStream()
-    writer = pq.ParquetWriter(
-        buffer,
+    with pq.ParquetWriter(
+        output_file,
         schema,
         compression="zstd",
         use_dictionary=True,
-    )
+    ) as writer:
+        # iterate materialized batches; to keep memory in check we use a small batch_size.
+        # We iterate fragments and manually cast to handle schema inconsistencies
+        for fragment in dataset.get_fragments():
+            # batches from `extra_inputs` get filtered against buffer_tids
+            # so a transcript represented in the buffer doesn't double-count
+            is_extra = fragment.path in extra_paths_set
+            for batch in fragment.to_batches(
+                batch_size=DEFAULT_BATCH_ROWS,
+                use_threads=False,
+            ):
+                # Cast batch to corrected schema to handle type mismatches
+                # (e.g., null columns promoted to string, or missing columns)
+                try:
+                    arrays = []
+                    for field in schema:
+                        if field.name in batch.schema.names:
+                            # Column exists - cast it to target type
+                            col = batch.column(field.name)
+                            arrays.append(col.cast(field.type))
+                        else:
+                            # Column missing - create null array
+                            arrays.append(
+                                pa.array([None] * len(batch), type=field.type)
+                            )
 
-    # iterate materialized batches; to keep memory in check we use a small batch_size.
-    # We iterate fragments and manually cast to handle schema inconsistencies
-    for fragment in dataset.get_fragments():
-        # batches from `extra_inputs` get filtered against buffer_tids
-        # so a transcript represented in the buffer doesn't double-count
-        is_extra = fragment.path in extra_paths_set
-        for batch in fragment.to_batches(
-            batch_size=DEFAULT_BATCH_ROWS,
-            use_threads=False,
-        ):
-            # Cast batch to corrected schema to handle type mismatches
-            # (e.g., null columns promoted to string, or missing columns)
-            try:
-                arrays = []
-                for field in schema:
-                    if field.name in batch.schema.names:
-                        # Column exists - cast it to target type
-                        col = batch.column(field.name)
-                        arrays.append(col.cast(field.type))
-                    else:
-                        # Column missing - create null array
-                        arrays.append(pa.array([None] * len(batch), type=field.type))
+                    batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+                except Exception as e:
+                    raise RuntimeError(f"Failed to cast batch to schema: {e}") from e
 
-                batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
-            except Exception as e:
-                raise RuntimeError(f"Failed to cast batch to schema: {e}") from e
+                # drop rows whose transcript_id is already covered by a
+                # buffer file (the buffer is authoritative for those tids)
+                if is_extra and buffer_tid_array is not None:
+                    mask = pc.invert(
+                        pc.is_in(
+                            batch.column("transcript_id"), value_set=buffer_tid_array
+                        )
+                    )
+                    batch = batch.filter(mask)
+                    if batch.num_rows == 0:
+                        continue
 
-            # drop rows whose transcript_id is already covered by a
-            # buffer file (the buffer is authoritative for those tids)
-            if is_extra and buffer_tid_array is not None:
-                mask = pc.invert(
-                    pc.is_in(batch.column("transcript_id"), value_set=buffer_tid_array)
-                )
-                batch = batch.filter(mask)
-                if batch.num_rows == 0:
-                    continue
+                size = batch.nbytes
+                if accumulated_bytes and accumulated_bytes + size > MAX_BYTES:
+                    flush_accumulated(writer)
+                accumulated.append(batch)
+                accumulated_bytes += size
 
-            size = batch.nbytes
-            if accumulated_bytes and accumulated_bytes + size > MAX_BYTES:
-                flush_accumulated(writer)
-            accumulated.append(batch)
-            accumulated_bytes += size
+        # Final flush. If no rows were seen, this still leaves us with an empty file (schema only).
+        flush_accumulated(writer)
 
-    # Final flush. If no rows were seen, this still leaves us with an empty file (schema only).
-    flush_accumulated(writer)
-    writer.close()
-
-    # TODO: If we changed the signature of this function from:
-    #   bytes | None
-    #     to
-    #   pa.Buffer | None
-    # We could avoid the copy (that to_pybytes does) altogether.
-    # Keep in mind that the previous BytesIO.getvalue() made a copy too.
-    return buffer.getvalue().to_pybytes()
+    return True
 
 
 def _persist_scan_summary(buffer_dir: UPath, summary: Summary) -> None:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -317,16 +317,31 @@ class FileRecorder(ScanRecorder):
         async with AsyncFilesystem() as fs:
             for scanner in sorted(scan_spec.scanners.keys()):
                 output_path = _scanner_parquet_file(scan_dir, scanner)
-                parquet_bytes = await _compact_with_prior(
-                    fs, scan_buffer_dir, scanner, prior=UPath(output_path)
-                )
-                if parquet_bytes is not None:
-                    if remote:
-                        await fs.write_file(output_path, parquet_bytes)
-                    else:
-                        tmp_path = f"{output_path}.tmp"
-                        await fs.write_file(tmp_path, parquet_bytes)
-                        filesystem(scan_dir.as_posix()).mv(tmp_path, output_path)
+                if remote:
+                    tmp_fd, compact_file = tempfile.mkstemp(suffix=".parquet")
+                    os.close(tmp_fd)
+                else:
+                    compact_file = f"{output_path}.tmp"
+                try:
+                    if await _compact_with_prior(
+                        fs,
+                        scan_buffer_dir,
+                        scanner,
+                        prior=UPath(output_path),
+                        output_file=compact_file,
+                    ):
+                        if remote:
+                            with open(compact_file, "rb") as f:
+                                await fs.write_file_streaming(output_path, f)
+                        else:
+                            filesystem(scan_dir.as_posix()).mv(
+                                compact_file, output_path
+                            )
+                finally:
+                    # remove leftovers: the remote-upload temp file, or a
+                    # partially-written local `.tmp` after a failure (after
+                    # a successful local rename the path no longer exists)
+                    UPath(compact_file).unlink(missing_ok=True)
 
             # sync summary and errors
             await _sync_status_files(fs, scan_dir, scan_buffer_dir, scan_spec, complete)
@@ -724,9 +739,17 @@ def _clear_prior_parquet_cache(scan_location: str) -> None:
 
 
 async def _compact_with_prior(
-    fs: AsyncFilesystem, scan_buffer_dir: UPath, scanner: str, *, prior: UPath
-) -> bytes | None:
+    fs: AsyncFilesystem,
+    scan_buffer_dir: UPath,
+    scanner: str,
+    *,
+    prior: UPath,
+    output_file: str,
+) -> bool:
     """Compact buffer parquets, merging in a prior compacted output (if any).
+
+    The compacted result is streamed to `output_file` (a local path);
+    returns True if it was written (False when there was nothing to compact).
 
     `scanner_table` requires uniform local paths and does blocking CPU +
     local file work, so remote priors are downloaded through the async
@@ -750,7 +773,9 @@ async def _compact_with_prior(
             cache[scanner] = None
         extra = [UPath(local_prior)] if local_prior is not None else None
     return await anyio.to_thread.run_sync(
-        functools.partial(scanner_table, scan_buffer_dir, scanner, extra_inputs=extra)
+        functools.partial(
+            scanner_table, scan_buffer_dir, scanner, output_file, extra_inputs=extra
+        )
     )
 
 

--- a/tests/scanner/test_recorder_buffer.py
+++ b/tests/scanner/test_recorder_buffer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 import json
 import tempfile
 from pathlib import Path
@@ -140,6 +139,7 @@ async def test_sanitize_table_names(
     recorder_buffer: RecorderBuffer,
     sample_transcript: TranscriptInfo,
     sample_results: list[ResultReport],
+    tmp_path: Path,
 ) -> None:
     """Test that table names with special characters are sanitized."""
     scanner_name = "test-scanner.with:special/chars"
@@ -148,13 +148,16 @@ async def test_sanitize_table_names(
     await recorder_buffer.record(sample_transcript, scanner_name, sample_results, None)
 
     # Should still be able to retrieve
-    scanner_table(recorder_buffer._buffer_dir, scanner_name)
+    scanner_table(
+        recorder_buffer._buffer_dir, scanner_name, str(tmp_path / "out.parquet")
+    )
 
 
 @pytest.mark.asyncio
 async def test_scanner_table_casts_mixed_transcript_score_to_string(
     recorder_buffer: RecorderBuffer,
     sample_results: list[ResultReport],
+    tmp_path: Path,
 ) -> None:
     scanner_name = "test_scanner"
     await recorder_buffer.record(
@@ -182,10 +185,11 @@ async def test_scanner_table_casts_mixed_transcript_score_to_string(
         None,
     )
 
-    parquet_bytes = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert parquet_bytes is not None
+    out_path = tmp_path / "out.parquet"
+    wrote = scanner_table(recorder_buffer._buffer_dir, scanner_name, str(out_path))
+    assert wrote
 
-    table = pq.read_table(io.BytesIO(parquet_bytes))
+    table = pq.read_table(out_path)
     assert table.schema.field("transcript_score").type == pa.string()
 
 
@@ -232,24 +236,23 @@ async def test_scanner_table_dedupes_extra_inputs_against_buffer(
 
     # snapshot the buffer's compacted output and use it as extra_inputs
     # — this mirrors what `_compact_with_prior` passes into `sync`.
-    first = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert first is not None
     prior_path = tmp_path / "prior.parquet"
-    prior_path.write_bytes(first)
+    assert scanner_table(recorder_buffer._buffer_dir, scanner_name, str(prior_path))
 
     # second compaction with the prior as extra_inputs. Without dedup
     # the output would have each tid's rows twice.
-    second = scanner_table(
+    second_path = tmp_path / "second.parquet"
+    assert scanner_table(
         recorder_buffer._buffer_dir,
         scanner_name,
+        str(second_path),
         extra_inputs=[UPath(prior_path)],
     )
-    assert second is not None
 
     # load and check: same row count as the original (no doubling),
     # same set of transcript_ids
-    first_tbl = pq.read_table(io.BytesIO(first))
-    second_tbl = pq.read_table(io.BytesIO(second))
+    first_tbl = pq.read_table(prior_path)
+    second_tbl = pq.read_table(second_path)
     assert second_tbl.num_rows == first_tbl.num_rows, (
         f"extra_inputs duplicated buffer rows: {second_tbl.num_rows} "
         f"vs expected {first_tbl.num_rows}"
@@ -287,10 +290,8 @@ async def test_scanner_table_keeps_extra_inputs_for_transcripts_not_in_buffer(
         sample_results,
         None,
     )
-    prior_bytes = scanner_table(recorder_buffer._buffer_dir, scanner_name)
-    assert prior_bytes is not None
     prior_path = tmp_path / "prior.parquet"
-    prior_path.write_bytes(prior_bytes)
+    assert scanner_table(recorder_buffer._buffer_dir, scanner_name, str(prior_path))
 
     # clear the buffer file for tid-old and write tid-new
     sdir = recorder_buffer._buffer_dir / f"scanner={scanner_name}"
@@ -308,13 +309,14 @@ async def test_scanner_table_keeps_extra_inputs_for_transcripts_not_in_buffer(
         None,
     )
 
-    out = scanner_table(
+    out_path = tmp_path / "out.parquet"
+    assert scanner_table(
         recorder_buffer._buffer_dir,
         scanner_name,
+        str(out_path),
         extra_inputs=[UPath(prior_path)],
     )
-    assert out is not None
-    tbl = pq.read_table(io.BytesIO(out))
+    tbl = pq.read_table(out_path)
     # both transcripts present: tid-new from buffer, tid-old from extras
     assert set(tbl.column("transcript_id").to_pylist()) == {"tid-old", "tid-new"}
 


### PR DESCRIPTION
Large scans can freeze the host when results are synced. Each result row embeds the scanned transcript and its scan events, so a ~48k transcript scan compacts to multi-GB parquets (a ~15GB buffer dir measured on agentic transcripts), and finalizing one repeatedly put a 48GB workstation into a swap storm. Ctrl-C runs the same sync, so interrupting does not help.

The cause is that `scanner_table` compacts into an in-memory buffer and copies it out as bytes, so each scanner's sync peaks at about twice its compacted parquet size. With `results_buffer` (#550) this happens on every periodic sync, not just at finalize.

`scanner_table` now streams the compacted parquet to an output file instead of returning bytes. Local scan dirs compact straight into the sibling `.tmp` and rename as before, remote ones compact into a local temp file that is streamed to the final key. Peak memory is the existing ~100MB batch accumulation cap regardless of output size.