### PR TITLE
fix: bound the multiprocess results queue

### DIFF
--- a/design/mp.md
+++ b/design/mp.md
@@ -25,7 +25,7 @@ The architecture coordinates processes through three mechanisms (see `_mp_common
 A dataclass containing immutable configuration (parse/scan functions, task counts, IPC primitives, semaphore registry). Serialized and passed to workers at spawn time. Never mutated after initialization.
 
 ### 2. Multiprocessing Queues
-Two unbounded queues handle data flow:
+Two bounded queues handle data flow:
 - **parse_job_queue** (Main → Workers): Lightweight ParseJob metadata with `None` sentinels for completion
 - **upstream_queue** (Workers → Main): Multiplexed stream of results, metrics, semaphore requests, and control messages (using strongly-typed dataclasses: `ResultItem`, `MetricsItem`, `SemaphoreRequest`, `WorkerComplete`, `ShutdownSentinel`, `Exception`). Main uses pattern matching to discriminate message types.
 

--- a/src/inspect_scout/_concurrency/_mp_registry.py
+++ b/src/inspect_scout/_concurrency/_mp_registry.py
@@ -184,14 +184,12 @@ class ChildSemaphoreRegistry(ConcurrencySemaphoreRegistry):
 
         def wait_for_semaphore() -> PicklableMPSemaphore:
             """Synchronous function to run in thread."""
-            with self.condition:
-                if name not in self.registry:
-                    # Send IPC request to parent
-                    self.upstream_queue.put(
-                        SemaphoreRequest(name, concurrency, visible)
-                    )
+            if name not in self.registry:
+                # Send IPC request to parent
+                self.upstream_queue.put(SemaphoreRequest(name, concurrency, visible))
 
-                # Wait for parent to create it
+            # Wait for parent to create it
+            with self.condition:
                 while name not in self.registry:
                     self.condition.wait(timeout=1.0)
 

--- a/src/inspect_scout/_concurrency/_mp_shutdown.py
+++ b/src/inspect_scout/_concurrency/_mp_shutdown.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Sequence
 from multiprocessing.context import SpawnProcess
 from multiprocessing.queues import Queue
-from queue import Empty
+from queue import Empty, Full
 from typing import Any, Callable
 
 import anyio
@@ -125,8 +125,15 @@ async def shutdown_subprocesses(
     # PHASE 5: Inject shutdown sentinel to wake collector
     print_diagnostics("SubprocessShutdown", "Phase 5: Injecting shutdown sentinel")
     try:
-        ctx.upstream_queue.put(shutdown_sentinel)
+        # put_nowait: the queue is bounded, and a blocking put on a full queue
+        # would hang shutdown. If the queue is full the collector cannot be
+        # blocked on get() anyway, so the wake-up sentinel isn't needed.
+        ctx.upstream_queue.put_nowait(shutdown_sentinel)
         print_diagnostics("SubprocessShutdown", "Injected upstream queue sentinel")
+    except Full:
+        print_diagnostics(
+            "SubprocessShutdown", "Upstream queue full - sentinel not needed"
+        )
     except (ValueError, OSError) as e:
         # Queue already closed - collector likely already exited via cancellation
         print_diagnostics("SubprocessShutdown", f"Upstream queue closed: {e}")

--- a/src/inspect_scout/_concurrency/_mp_shutdown.py
+++ b/src/inspect_scout/_concurrency/_mp_shutdown.py
@@ -125,9 +125,12 @@ async def shutdown_subprocesses(
     # PHASE 5: Inject shutdown sentinel to wake collector
     print_diagnostics("SubprocessShutdown", "Phase 5: Injecting shutdown sentinel")
     try:
-        # put_nowait: the queue is bounded, and a blocking put on a full queue
-        # would hang shutdown. If the queue is full the collector cannot be
-        # blocked on get() anyway, so the wake-up sentinel isn't needed.
+        # put_nowait: by Phase 5 the collector *task* has already exited (the
+        # task group is done); the sentinel only wakes an abandoned daemon
+        # reader thread, so it's best-effort. A blocking put could hang
+        # forever: workers killed in Phases 3/4 may have died between
+        # acquiring the bounded queue's semaphore and flushing to the pipe,
+        # leaking permits that Phase 6's drain can never release.
         ctx.upstream_queue.put_nowait(shutdown_sentinel)
         print_diagnostics("SubprocessShutdown", "Injected upstream queue sentinel")
     except Full:

--- a/src/inspect_scout/_concurrency/_mp_subprocess.py
+++ b/src/inspect_scout/_concurrency/_mp_subprocess.py
@@ -209,7 +209,12 @@ def subprocess_main(
     def _put_upstream_or_drop(item: _mp_common.UpstreamQueueItem) -> None:
         # sync context: never block the event loop on a full queue. Dropping
         # a metrics snapshot or log record under backpressure beats stalling
-        # the worker's event loop.
+        # the worker's event loop. Note the *final* metrics snapshot (sent
+        # after the strategy zeroes its counts) has no successor to supersede
+        # it, so it can be lost too — that only leaves the live display and
+        # active-scans store stale (authoritative metrics accumulate
+        # parent-side in record_results), so don't "fix" a stale end-of-scan
+        # count by making this put blocking.
         try:
             ipc_ctx.upstream_queue.put_nowait(item)
         except Full:

--- a/src/inspect_scout/_concurrency/_mp_subprocess.py
+++ b/src/inspect_scout/_concurrency/_mp_subprocess.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from queue import Full
 from threading import Condition
 from typing import Callable
 
@@ -105,7 +106,9 @@ def subprocess_main(
             "Worker main",
             f"Initialized with {task_count} max tasks. Waiting for start...",
         )
-        ipc_ctx.upstream_queue.put(_mp_common.WorkerReady(worker_id))
+        await run_sync_on_thread(
+            ipc_ctx.upstream_queue.put, _mp_common.WorkerReady(worker_id)
+        )
         await run_sync_on_thread(ipc_ctx.workers_ready_event.wait)
 
         # Run everything in a task group with shutdown monitor
@@ -142,7 +145,8 @@ def subprocess_main(
                     except Exception as ex:
                         print_diagnostics("Worker main", f"Work task error: {ex}")
                         # Send exception back to main process via upstream queue
-                        ipc_ctx.upstream_queue.put(ex)
+                        # (in a thread: the bounded queue can block when full)
+                        await run_sync_on_thread(ipc_ctx.upstream_queue.put, ex)
                         raise
                     finally:
                         # CRITICAL: Cancel the shutdown monitor to prevent hang.
@@ -176,7 +180,9 @@ def subprocess_main(
             # except blocks above would catch and handle it, making control flow unclear.
             # With else:, it's explicit: sentinel is sent ONLY on clean completion.
             print_diagnostics("Worker main", "Sending completion sentinel")
-            ipc_ctx.upstream_queue.put(_mp_common.WorkerComplete())
+            await run_sync_on_thread(
+                ipc_ctx.upstream_queue.put, _mp_common.WorkerComplete()
+            )
 
         print_diagnostics("Worker main", "exiting")
 
@@ -191,16 +197,32 @@ def subprocess_main(
     async def _record_to_queue(
         transcript: TranscriptInfo, scanner: str, results: list[ResultReport]
     ) -> None:
-        ipc_ctx.upstream_queue.put(_mp_common.ResultItem(transcript, scanner, results))
+        # when the bounded queue is full, put() blocks (backpressure when the
+        # main process records slower than workers scan), so run it in a
+        # thread where only this task waits, not the worker's whole event loop
+        item = _mp_common.ResultItem(transcript, scanner, results)
+        try:
+            ipc_ctx.upstream_queue.put_nowait(item)
+        except Full:
+            await run_sync_on_thread(ipc_ctx.upstream_queue.put, item)
+
+    def _put_upstream_or_drop(item: _mp_common.UpstreamQueueItem) -> None:
+        # sync context: never block the event loop on a full queue. Dropping
+        # a metrics snapshot or log record under backpressure beats stalling
+        # the worker's event loop.
+        try:
+            ipc_ctx.upstream_queue.put_nowait(item)
+        except Full:
+            pass
 
     def _update_worker_metrics(metrics: ScanMetrics) -> None:
-        ipc_ctx.upstream_queue.put(_mp_common.MetricsItem(worker_id, metrics))
+        _put_upstream_or_drop(_mp_common.MetricsItem(worker_id, metrics))
 
     def _log_in_parent(record: logging.LogRecord) -> None:
         # Strip exc_info from record to avoid pickling traceback objects since it
         # cannot be serialized across process boundaries
         record.exc_info = None
-        ipc_ctx.upstream_queue.put(LoggingItem(record))
+        _put_upstream_or_drop(LoggingItem(record))
 
     def _initialize_subprocess() -> None:
         # Set up sys.path with plugin directory before any user imports

--- a/src/inspect_scout/_concurrency/multi_process.py
+++ b/src/inspect_scout/_concurrency/multi_process.py
@@ -77,6 +77,13 @@ DEFAULT_MAX_PROCESS = 4
 # when parse_jobs iterator is very large. Producer will block when queue is full.
 PARSE_JOB_PREFETCH_SIZE = 50
 
+# Maximum number of items buffered in the upstream (results) queue.
+# Provides backpressure when workers produce results faster than the main
+# process can record them: each ResultItem embeds the scanned transcript(s),
+# so an unbounded queue can grow to many GB over a large scan. Workers block
+# (in a worker thread, not the event loop) when the queue is full.
+UPSTREAM_QUEUE_MAXSIZE = 100
+
 # Sentinel value to signal collectors to shut down during Ctrl-C.
 #
 # MUST be a sentinel: During Ctrl-C shutdown, workers are terminated before they can
@@ -187,7 +194,7 @@ def multi_process_strategy(
                 diagnostics=diagnostics,
                 overall_start_time=time.time(),
                 parse_job_queue=spawn_ctx.Queue(maxsize=PARSE_JOB_PREFETCH_SIZE),
-                upstream_queue=spawn_ctx.Queue(),
+                upstream_queue=spawn_ctx.Queue(maxsize=UPSTREAM_QUEUE_MAXSIZE),
                 shutdown_condition=manager.Condition(),
                 workers_ready_event=manager.Event(),
                 semaphore_registry=parent_registry.sync_manager_dict,
@@ -214,7 +221,9 @@ def multi_process_strategy(
             # ParseJob queue is bounded to prevent memory explosion when parse_jobs
             # iterator contains a huge number of items. Producer blocks when queue
             # is full, providing lazy consumption.
-            # Upstream queue is unbounded and multiplexes both results and metrics.
+            # Upstream queue multiplexes results, metrics, logging, and semaphore
+            # requests. It is bounded so result backlog can't grow without limit
+            # when the collector records slower than workers scan.
             parse_job_queue = ipc_ctx.parse_job_queue
             upstream_queue = ipc_ctx.upstream_queue
 


### PR DESCRIPTION
On large multiprocess scans the main process grows without limit whenever workers produce results faster than it records them: the upstream queue is unbounded and every `ResultItem` embeds the scanned transcripts, so the backlog can reach many GB over the life of a scan. The parse-job direction is already bounded, with a comment explaining exactly this risk.

The upstream queue now has `maxsize=100`, so workers feel backpressure instead. Per put site:

- Blocking puts (results, worker lifecycle messages, work exceptions) run on a thread, so only the putting task waits, never the worker's event loop. Results try `put_nowait` first so the common not-full case pays no thread hop.
- Sync-context puts (metrics snapshots, forwarded log records) drop on `Full`. The next snapshot supersedes, and dropping a log record beats stalling the event loop from inside a logging handler.
- The shutdown sentinel uses `put_nowait`. A blocking put on a full queue would hang shutdown, and a full queue means the collector cannot be blocked on `get()` anyway.
- Semaphore requests no longer hold the shared semaphore condition across the put. A worker blocked mid-put while holding it would deadlock the collector, which needs that condition to service an earlier request and is the only consumer freeing queue slots. Sending the request before taking the condition is safe because parent-side creation is idempotent.