### PR TITLE
feat: surface loader-item metadata on scan result rows

### DIFF
--- a/docs/custom_scanner.qmd
+++ b/docs/custom_scanner.qmd
@@ -317,6 +317,10 @@ def assistant_refusals() -> Scanner[list[ChatMessage]]:
     return scan
 ```
 
+### Item Metadata
+
+Loaders that yield synthetic per-item `Transcript` objects can attach per-item context (e.g. input provenance) via `Transcript.metadata`. Loader-authored metadata is automatically merged into the `metadata` of results produced for that item, with scanner-authored keys taking precedence.
+
 ## Packaging {#packaging}
 
 A convenient way to distribute scanners is to include them in a Python package. This makes it very easy for others to use your scanner and ensure they have all of the required dependencies.

--- a/docs/custom_scanner.qmd
+++ b/docs/custom_scanner.qmd
@@ -321,6 +321,14 @@ def assistant_refusals() -> Scanner[list[ChatMessage]]:
 
 Loaders that yield synthetic per-item `Transcript` objects can attach per-item context (e.g. input provenance) via `Transcript.metadata`. Loader-authored metadata is automatically merged into the `metadata` of results produced for that item, with scanner-authored keys taking precedence.
 
+The item's metadata must be a new dict — don't mutate the source transcript's metadata in place (the source transcript is shared with other scanners, and metadata passed through from it unchanged is not merged). For example:
+
+``` python
+yield transcript.model_copy(
+    update={"metadata": {"provenance": provenance}}
+)
+```
+
 ## Packaging {#packaging}
 
 A convenient way to distribute scanners is to include them in a Python package. This makes it very easy for others to use your scanner and ensure they have all of the required dependencies.

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -1041,6 +1041,20 @@ async def _scan_one(
             async with span("scan"):
                 result = await job.scanner(loader_result)
 
+            # merge loader-authored item metadata into results (scanner keys
+            # win); skip metadata passed through from the source transcript
+            if (
+                result is not None
+                and isinstance(loader_result, Transcript)
+                and loader_result.metadata
+                and loader_result.metadata is not job.union_transcript.metadata
+            ):
+                for r in result if isinstance(result, list) else [result]:
+                    r.metadata = {
+                        **loader_result.metadata,
+                        **(r.metadata or {}),
+                    }
+
             # handle lists
             final_result = as_resultset(result) if isinstance(result, list) else result
 

--- a/tests/scan/test_loader_metadata.py
+++ b/tests/scan/test_loader_metadata.py
@@ -1,0 +1,131 @@
+"""Tests for surfacing loader-item metadata on scan result rows."""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+from inspect_scout import Result, Scanner, loader, scan, scanner
+from inspect_scout._scanner.loader import Loader
+from inspect_scout._scanresults import scan_results_df
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+
+@loader(name="item_metadata_loader", messages="all")
+def item_metadata_loader_factory() -> Loader[Transcript]:
+    """Loader that yields synthetic per-item transcripts with item metadata."""
+
+    async def load(transcript: Transcript) -> AsyncIterator[Transcript]:
+        for i in range(2):
+            yield transcript.model_copy(
+                update={"metadata": {"provenance": f"item-{i}", "shared": "loader"}}
+            )
+
+    return load
+
+
+@scanner(name="merged_metadata_scanner", loader=item_metadata_loader_factory())
+def merged_metadata_scanner_factory() -> Scanner[Transcript]:
+    """Scanner that authors metadata overlapping the loader item metadata."""
+
+    async def scan_item(transcript: Transcript) -> Result:
+        return Result(value=True, metadata={"shared": "scanner", "scanner_only": 1})
+
+    return scan_item
+
+
+@scanner(name="loader_only_metadata_scanner", loader=item_metadata_loader_factory())
+def loader_only_metadata_scanner_factory() -> Scanner[Transcript]:
+    """Scanner that authors no metadata of its own."""
+
+    async def scan_item(transcript: Transcript) -> Result:
+        return Result(value=True)
+
+    return scan_item
+
+
+@scanner(name="resultset_metadata_scanner", loader=item_metadata_loader_factory())
+def resultset_metadata_scanner_factory() -> Scanner[Transcript]:
+    """Scanner that returns a list of results (recorded as a resultset)."""
+
+    async def scan_item(transcript: Transcript) -> list[Result]:
+        return [
+            Result(value=1, label="a", metadata={"shared": "scanner"}),
+            Result(value=2, label="b"),
+        ]
+
+    return scan_item
+
+
+@scanner(name="default_loader_scanner", messages="all")
+def default_loader_scanner_factory() -> Scanner[Transcript]:
+    """Scanner using the default (identity) loader, authoring no metadata."""
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        return Result(value=True)
+
+    return scan_transcript
+
+
+def _metadata_rows(location: str, scanner_name: str) -> list[dict[str, Any]]:
+    results = scan_results_df(location, scanner=scanner_name)
+    df = results.scanners[scanner_name]
+    return [json.loads(m) for m in df["metadata"].tolist()]
+
+
+def test_loader_item_metadata_on_result_rows() -> None:
+    """Loader-item metadata is merged into result metadata (scanner keys win)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[
+                merged_metadata_scanner_factory(),
+                loader_only_metadata_scanner_factory(),
+                resultset_metadata_scanner_factory(),
+                default_loader_scanner_factory(),
+            ],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+        )
+        assert status.complete
+        assert status.location is not None
+
+        # scanner-authored keys win over loader item keys; both are present
+        merged = _metadata_rows(status.location, "merged_metadata_scanner")
+        assert sorted(merged, key=lambda m: str(m["provenance"])) == [
+            {"provenance": "item-0", "shared": "scanner", "scanner_only": 1},
+            {"provenance": "item-1", "shared": "scanner", "scanner_only": 1},
+        ]
+
+        # loader item metadata surfaces even when the scanner authors none
+        loader_only = _metadata_rows(status.location, "loader_only_metadata_scanner")
+        assert sorted(loader_only, key=lambda m: str(m["provenance"])) == [
+            {"provenance": "item-0", "shared": "loader"},
+            {"provenance": "item-1", "shared": "loader"},
+        ]
+
+        # results within a resultset each carry the merged metadata, surfaced
+        # by resultset expansion as flattened metadata.<key> columns
+        results = scan_results_df(status.location, scanner="resultset_metadata_scanner")
+        df = results.scanners["resultset_metadata_scanner"]
+        rows = sorted(
+            (
+                (row["metadata.provenance"], row["label"], row["metadata.shared"])
+                for _, row in df.iterrows()
+            ),
+        )
+        assert rows == [
+            ("item-0", "a", "scanner"),
+            ("item-0", "b", "loader"),
+            ("item-1", "a", "scanner"),
+            ("item-1", "b", "loader"),
+        ]
+
+        # default loaders pass the source transcript through: its metadata is
+        # already surfaced as transcript_metadata and must not leak into the
+        # result metadata column
+        default = _metadata_rows(status.location, "default_loader_scanner")
+        assert default == [{}]

--- a/tests/scan/test_loader_metadata.py
+++ b/tests/scan/test_loader_metadata.py
@@ -13,6 +13,12 @@ from inspect_scout._transcript.types import Transcript
 
 LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
 
+# pin the scanned transcript to one with non-empty source metadata so the
+# no-leak assertion below cannot pass vacuously
+POPULARITY_LOG = (
+    LOGS_DIR / "2025-09-23T08-09-58-04-00_popularity_DN2wbX2ZvACsBpjwptzBRo.eval"
+)
+
 
 @loader(name="item_metadata_loader", messages="all")
 def item_metadata_loader_factory() -> Loader[Transcript]:
@@ -86,7 +92,7 @@ def test_loader_item_metadata_on_result_rows() -> None:
                 resultset_metadata_scanner_factory(),
                 default_loader_scanner_factory(),
             ],
-            transcripts=transcripts_from(LOGS_DIR),
+            transcripts=transcripts_from(str(POPULARITY_LOG)),
             scans=tmpdir,
             limit=1,
         )
@@ -127,5 +133,13 @@ def test_loader_item_metadata_on_result_rows() -> None:
         # default loaders pass the source transcript through: its metadata is
         # already surfaced as transcript_metadata and must not leak into the
         # result metadata column
-        default = _metadata_rows(status.location, "default_loader_scanner")
-        assert default == [{}]
+        results = scan_results_df(status.location, scanner="default_loader_scanner")
+        df = results.scanners["default_loader_scanner"]
+        transcript_metadata = df["transcript_metadata"].iloc[0]
+        if isinstance(transcript_metadata, str):
+            transcript_metadata = json.loads(transcript_metadata)
+        assert transcript_metadata, (
+            "scanned transcript must have source metadata for this test to be "
+            "meaningful"
+        )
+        assert [json.loads(m) for m in df["metadata"]] == [{}]


### PR DESCRIPTION
## Motivation

Custom loaders can yield synthetic per-item `Transcripts` (e.g. composed with an `llm_scanner` wrapped in `@scanner(loader=…)`), where the loader computes per-item context — such as input provenance — carried on the item's `Transcript.metadata`. Today that context survives only inside the serialized `input` column (workable, but buried in the full item JSON), and `Result.metadata` comes back `{}`.

## What changed

- `_scan_one` now merges loader-authored item metadata into each `Result`'s metadata, with scanner-authored keys winning on collision.
- The merge is gated on object identity (`loader_result.metadata is not job.union_transcript.metadata`): the default loaders pass the source transcript's metadata dict through by reference, and that is already recorded on every row as `transcript_metadata` — without the gate, every existing transcript scanner would duplicate the full source metadata into the `metadata` column. The identity check also avoids materializing `LazyJSONDict` metadata.
- For scanners returning `list[Result]`, the merge is applied to each inner result before `as_resultset` wraps them, since resultset expansion in `scan_results_df` surfaces the *inner* results' metadata (as flattened `metadata.<key>` columns) — a wrapper-only merge would be invisible there.
- Added an "Item Metadata" note to the Custom Loaders section of the scanner docs.

## Design consideration: why `metadata` and not `transcript_metadata`?

Loader-item metadata describes the *input* rather than the scan outcome, so `transcript_metadata` was considered as the destination. We kept it out of that column deliberately: `transcript_metadata` is a faithful copy of the source transcript's row in the transcripts DB (written by the recorder from `TranscriptInfo`), identical across all rows for a given `transcript_id`, and used to join results back to `Transcripts.where()` fields. Writing synthesized per-item values there would break that invariant and could disagree with the transcripts DB. Merging into result `metadata` (with scanner keys winning) is the pragmatic option; if per-item provenance becomes a first-class concept people filter/group on, a dedicated `input_metadata` column would be the cleaner follow-up.

## Testing

End-to-end test (`tests/scan/test_loader_metadata.py`) covering: scanner keys winning over loader keys, loader-only metadata surfacing when the scanner authors none, resultset expansion carrying merged metadata per inner result, and the non-regression that default-loader scanners still get `{}` (no transcript-metadata leakage). Full suite passes (3179 passed, 107 skipped); ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)