### PR TITLE
ci: nightly full-CI run on main with Slack failure alert

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
       - main
       - "release/**"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   py-ruff:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,82 @@
+name: Nightly
+
+# Nightly run of the full CI gates against main. This repo can be broken by
+# upstream drift (build.yaml installs inspect_ai from git main, and
+# check-schema-and-types validates against it), so there is deliberately no
+# skip-if-unchanged check: re-testing an unchanged commit is the point.
+#
+# Reports to Slack only on failure (same channel as the inspect_ai slow
+# tests). Requires the SLACK_BOT_TOKEN and SLACK_CHANNEL_ID secrets, and the
+# Slack bot must be a member of the channel.
+
+on:
+  schedule:
+    # 08:00 UTC (4am Boston), matching the other nightlies
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/build.yaml
+
+  report:
+    needs: ci
+    if: always() && needs.ci.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get short SHA
+        id: commit
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Report failure to Slack
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "text": "🚨 Inspect Scout Nightly CI Failed",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🚨 Inspect Scout Nightly CI Failed"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Trigger:*\n${{ github.event_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tested:*\n<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|inspect_scout@${{ github.ref_name }}#${{ steps.commit.outputs.short_sha }}> against inspect_ai main"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<!channel> The nightly CI run has failed. Please investigate."
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Actor: ${{ github.actor }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,9 +14,6 @@ on:
     # 08:00 UTC (4am Boston), matching the other nightlies
     - cron: "0 8 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - nightly-ci # TEMPORARY: pre-merge test trigger, remove before merge
 
 jobs:
   ci:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,9 @@ on:
     # 08:00 UTC (4am Boston), matching the other nightlies
     - cron: "0 8 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - nightly-ci # TEMPORARY: pre-merge test trigger, remove before merge
 
 jobs:
   ci:


### PR DESCRIPTION
Runs the full CI gates (all of build.yaml: ruff, mypy, pytest, package build, schema/type sync, submodule check, js dist) nightly against main, and posts to Slack only when the run fails. This repo can be broken by upstream drift — build.yaml installs inspect_ai from git main — so there is deliberately no skip-if-unchanged check.

Changes:
- build.yaml gains a `workflow_call:` trigger so nightly.yaml can reuse it without duplicating the jobs
- nightly.yaml: cron at 08:00 UTC (4am Boston, matching the other nightlies in meridianlabs-ai/actions) + workflow_dispatch; on failure posts to Slack in the same format as the inspect_ai/inspect_swe nightlies, pinging @channel

Setup required before merge (repo/org admin):
1. Add `SLACK_BOT_TOKEN` secret to this repo (same bot token the meridianlabs-ai/actions nightlies use), or share it as an org secret
2. Add `SLACK_CHANNEL_ID` secret with the existing slow-tests channel ID (same value as `SLACK_CHANNEL_ID` in the actions repo)
3. The Slack bot is already in that channel, so no invite needed

After merge, trigger once via workflow_dispatch to verify the run (the Slack path only exercises on failure).