### PR TITLE
fix: prevent deferred metrics write to closed active scans store

### DIFF
--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -342,6 +342,7 @@ def single_process_strategy(
             raise inner_exception(ex) from None
         finally:
             set_batch_status_callback(None)
+            set_batch_log_callback(None)
             metrics.process_count = 0
             metrics.tasks_parsing = 0
             metrics.tasks_scanning = 0

--- a/src/inspect_scout/_recorder/active_scans_store.py
+++ b/src/inspect_scout/_recorder/active_scans_store.py
@@ -113,9 +113,18 @@ def active_scans_store() -> Generator[ActiveScansStore, None, None]:
                 kvstore.delete(key)
 
         class _Store:
+            def __init__(self) -> None:
+                # deferred writers (e.g. a throttled metrics callback) can fire
+                # after the scan is over: a put would then raise on the closed
+                # sqlite connection, or resurrect the just-deleted entry. once
+                # closed, all puts are ignored.
+                self._closed = False
+
             def put_spec(
                 self, scan_id: str, spec: "ScanSpec", total_scans: int, location: str
             ) -> None:
+                if self._closed:
+                    return
                 scanner_names = list(spec.scanners.keys())
                 existing = json.loads(kvstore.get(pid_key) or "{}")
                 existing.update(
@@ -135,6 +144,8 @@ def active_scans_store() -> Generator[ActiveScansStore, None, None]:
                 kvstore.put(pid_key, json.dumps(existing))
 
             def put_metrics(self, scan_id: str, metrics: ScanMetrics) -> None:
+                if self._closed:
+                    return
                 existing = json.loads(kvstore.get(pid_key) or "{}")
                 existing.update(
                     {
@@ -148,6 +159,8 @@ def active_scans_store() -> Generator[ActiveScansStore, None, None]:
             def put_scanner_results(
                 self, scan_id: str, scanner: str, results: Sequence["ResultReport"]
             ) -> None:
+                if self._closed:
+                    return
                 existing = json.loads(kvstore.get(pid_key) or "{}")
                 summary = Summary.model_validate(
                     existing.get("summary", {"complete": False})
@@ -184,7 +197,11 @@ def active_scans_store() -> Generator[ActiveScansStore, None, None]:
                 data = json.loads(value)
                 return _parse_active_scan_info(data)
 
-        yield _Store()
+        store = _Store()
+        try:
+            yield store
+        finally:
+            store._closed = True
 
 
 def _parse_active_scan_info(data: dict[str, object]) -> ActiveScanInfo:

--- a/src/inspect_scout/_recorder/active_scans_store.py
+++ b/src/inspect_scout/_recorder/active_scans_store.py
@@ -115,9 +115,8 @@ def active_scans_store() -> Generator[ActiveScansStore, None, None]:
         class _Store:
             def __init__(self) -> None:
                 # deferred writers (e.g. a throttled metrics callback) can fire
-                # after the scan is over: a put would then raise on the closed
-                # sqlite connection, or resurrect the just-deleted entry. once
-                # closed, all puts are ignored.
+                # after the scan is over. once closed, puts are ignored rather
+                # than raising or resurrecting the just-deleted entry.
                 self._closed = False
 
             def put_spec(

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -756,7 +756,15 @@ async def _scan_async_inner(
                         )
                         maybe_start_results_sync()
 
+                    # metrics reporting is throttled, so a trailing-edge write can
+                    # be deferred past the end of the scan. by then the store's
+                    # connection is closed and its entry has been deleted, so the
+                    # write must not run at all.
+                    scan_finished = False
+
                     def update_metrics(metrics: ScanMetrics) -> None:
+                        if scan_finished:
+                            return
                         active_store.put_metrics(scan.spec.scan_id, metrics)
                         scan_display.metrics(metrics)
 
@@ -792,6 +800,9 @@ async def _scan_async_inner(
                             await recorder.location(), complete=len(errors) == 0
                         )
                     finally:
+                        # nothing awaits between here and the delete, so a deferred
+                        # metrics write cannot land in the gap
+                        scan_finished = True
                         active_store.delete_current()
 
         # report scan complete

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -756,10 +756,9 @@ async def _scan_async_inner(
                         )
                         maybe_start_results_sync()
 
-                    # metrics reporting is throttled, so a trailing-edge write can
-                    # be deferred past the end of the scan. by then the store's
-                    # connection is closed and its entry has been deleted, so the
-                    # write must not run at all.
+                    # the store ignores writes once closed (see _Store); this
+                    # guard additionally keeps a late trailing-edge fire away
+                    # from the finished display.
                     scan_finished = False
 
                     def update_metrics(metrics: ScanMetrics) -> None:
@@ -800,8 +799,6 @@ async def _scan_async_inner(
                             await recorder.location(), complete=len(errors) == 0
                         )
                     finally:
-                        # nothing awaits between here and the delete, so a deferred
-                        # metrics write cannot land in the gap
                         scan_finished = True
                         active_store.delete_current()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ import secrets
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
+from unittest.mock import patch
 
 from inspect_ai._util.kvstore import inspect_kvstore
 
@@ -19,6 +20,21 @@ def temp_kvstore() -> Iterator[str]:
     try:
         yield name
     finally:
-        with inspect_kvstore(name) as kvstore:
-            path = kvstore.filename
-        Path(path).unlink()
+        # filename is computed at construction; no need to open the store
+        # (which would create the file) just to delete it
+        Path(inspect_kvstore(name).filename).unlink(missing_ok=True)
+
+
+@contextmanager
+def temp_active_scans_store() -> Iterator[str]:
+    """Redirect the active-scans store to a temp kvstore, cleaned up on exit.
+
+    Keeps tests that run real scans from writing into the developer's live
+    scout_active_scans store (and from sweeping its real entries).
+
+    Yields:
+        The temporary kvstore name.
+    """
+    with temp_kvstore() as name:
+        with patch("inspect_scout._recorder.active_scans_store._STORE_NAME", name):
+            yield name

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,11 +29,8 @@ def temp_kvstore() -> Iterator[str]:
 def temp_active_scans_store() -> Iterator[str]:
     """Redirect the active-scans store to a temp kvstore, cleaned up on exit.
 
-    Keeps tests that run real scans from writing into the developer's live
-    scout_active_scans store (and from sweeping its real entries).
-
-    Yields:
-        The temporary kvstore name.
+    Keeps scan-running tests out of the developer's live scout_active_scans
+    store. Yields the temporary kvstore name.
     """
     with temp_kvstore() as name:
         with patch("inspect_scout._recorder.active_scans_store._STORE_NAME", name):

--- a/tests/recorder/test_active_scans_store.py
+++ b/tests/recorder/test_active_scans_store.py
@@ -1,12 +1,7 @@
 """Tests for the active scans KV store."""
 
 import os
-import secrets
 import time
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Iterator
-from unittest.mock import patch
 
 from inspect_ai._util.kvstore import inspect_kvstore
 from inspect_scout._concurrency.common import ScanMetrics
@@ -19,6 +14,8 @@ from inspect_scout._recorder.active_scans_store import (
 from inspect_scout._recorder.summary import Summary
 from inspect_scout._scanspec import ScannerSpec, ScanSpec
 
+from tests.helpers import temp_active_scans_store
+
 
 def _make_spec(scan_id: str) -> ScanSpec:
     """Create minimal ScanSpec for testing."""
@@ -29,22 +26,9 @@ def _make_spec(scan_id: str) -> ScanSpec:
     )
 
 
-@contextmanager
-def _temp_store_name() -> Iterator[str]:
-    """Override store name for isolated testing."""
-    name = f"__testing_active_scans_{secrets.token_hex(4)}__"
-    with patch("inspect_scout._recorder.active_scans_store._STORE_NAME", name):
-        try:
-            yield name
-        finally:
-            with inspect_kvstore(name) as kvstore:
-                path = kvstore.filename
-            Path(path).unlink(missing_ok=True)
-
-
 def test_put_and_read_all() -> None:
     """Store metrics and verify read returns them."""
-    with _temp_store_name():
+    with temp_active_scans_store():
         metrics = ScanMetrics(process_count=2, task_count=4, completed_scans=10)
         scan_id = "test-scan-123"
 
@@ -64,7 +48,7 @@ def test_put_and_read_all() -> None:
 
 def test_delete_current() -> None:
     """Store metrics, delete, verify empty."""
-    with _temp_store_name():
+    with temp_active_scans_store():
         metrics = ScanMetrics(completed_scans=5)
         scan_id = "delete-test"
 
@@ -78,7 +62,7 @@ def test_delete_current() -> None:
 
 def test_multiple_scans_same_process() -> None:
     """Put twice replaces entry since keyed by PID."""
-    with _temp_store_name():
+    with temp_active_scans_store():
         scan_id_1 = "scan-1"
         scan_id_2 = "scan-2"
 
@@ -101,7 +85,7 @@ def test_multiple_scans_same_process() -> None:
 
 def test_overwrite_updates_metrics_and_timestamp() -> None:
     """Put twice with same scan_id updates metrics and timestamp."""
-    with _temp_store_name():
+    with temp_active_scans_store():
         scan_id = "update-test"
 
         with active_scans_store() as store:
@@ -120,7 +104,7 @@ def test_overwrite_updates_metrics_and_timestamp() -> None:
 
 def test_stale_pid_cleanup() -> None:
     """Dead PIDs get cleaned on store access."""
-    with _temp_store_name() as name:
+    with temp_active_scans_store() as name:
         # Manually insert entry with fake dead PID
         fake_pid = 99999999  # Unlikely to exist
         with inspect_kvstore(name) as kvstore:
@@ -139,7 +123,7 @@ def test_stale_pid_cleanup() -> None:
 
 def test_version_migration_clears_store() -> None:
     """Store clears when version mismatches."""
-    with _temp_store_name() as name:
+    with temp_active_scans_store() as name:
         # Pre-populate with old version
         with inspect_kvstore(name) as kvstore:
             kvstore.put(_VERSION_KEY, "0")  # Old version
@@ -157,7 +141,7 @@ def test_version_migration_clears_store() -> None:
 
 def test_read_all_returns_empty_when_no_entries() -> None:
     """Fresh store returns empty dict."""
-    with _temp_store_name():
+    with temp_active_scans_store():
         with active_scans_store() as store:
             result = store.read_all()
 

--- a/tests/scan/test_active_scan_cleanup.py
+++ b/tests/scan/test_active_scan_cleanup.py
@@ -1,15 +1,32 @@
-import os
+import time
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any, Callable, Iterator
 
 import anyio
+import inspect_scout._scan as scan_module
 import pytest
+from inspect_ai.util import throttle
 from inspect_scout import Result, Scanner, Status, scan, scanner
-from inspect_scout._recorder.active_scans_store import active_scans_store
+from inspect_scout._concurrency import single_process
+from inspect_scout._recorder.active_scans_store import (
+    ActiveScansStore,
+    active_scans_store,
+)
 from inspect_scout._recorder.file import FileRecorder
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
 
+from tests.helpers import temp_active_scans_store
+
 LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+# the strategy hardcodes @throttle(1); shrinking the window keeps the same
+# trailing-edge mechanics while the test holds the vulnerable gap open for
+# fractions of a second instead of multiples of it. the window must still be
+# generous enough that the strategy's teardown metrics call lands inside it
+# even on a loaded CI machine, or no trailing-edge fire gets scheduled.
+THROTTLE_WINDOW = 0.3
 
 
 @scanner(name="cleanup_probe_scanner", messages="all")
@@ -22,52 +39,35 @@ def cleanup_probe_scanner() -> Scanner[Transcript]:
 
 @scanner(name="failing_probe_scanner", messages="all")
 def failing_probe_scanner() -> Scanner[Transcript]:
-    first_transcript = True
-
     async def scan_transcript(transcript: Transcript) -> Result:
-        nonlocal first_transcript
-        if first_transcript:
-            first_transcript = False
-            return Result(value=True)
-        # let the first result get recorded before failing (the test docstring
-        # explains why this ordering leaves a trailing write pending)
-        await anyio.sleep(0.3)
         raise ValueError("injected scanner failure")
 
     return scan_transcript
 
 
-def assert_no_active_scan_entry() -> None:
-    """The active-scans entry for this process must be gone after a scan.
+def test_completed_scan_leaves_no_active_scan_entry(tmp_path: Path) -> None:
+    """Cleanup smoke test for the success path.
 
-    Checked by PID rather than by an empty store: under pytest-xdist other
-    worker processes have live entries of their own.
+    A completed scan must delete its active-scans entry. (The late
+    metrics-write hazard is only reachable on the interrupted path -- on
+    completion the pending trailing-edge write is cancelled with the scan's
+    task group -- so this test pins only the cleanup behavior.)
     """
-    with active_scans_store() as store:
-        assert store.read_by_pid(os.getpid()) is None
+    with temp_active_scans_store():
+        status = scan(
+            scanners=[cleanup_probe_scanner()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=str(tmp_path),
+            limit=2,
+            # single-process path: the strategy whose metrics callback and
+            # store cleanup are under test here
+            max_processes=1,
+            display="none",
+        )
 
-
-def test_scan_completes_with_a_metrics_write_still_throttled(tmp_path: Path) -> None:
-    """A scan short enough to end while a throttled metrics write is pending.
-
-    The scan issues its metrics updates within a few tens of milliseconds and
-    finishes well inside the one second throttle window, so the trailing-edge
-    write is still pending when the scan ends. It must not fire against the
-    closed store, and the scan must leave no active-scans entry behind.
-    """
-    status = scan(
-        scanners=[cleanup_probe_scanner()],
-        transcripts=transcripts_from(LOGS_DIR),
-        scans=str(tmp_path),
-        limit=2,
-        # the deferred write only exists on the single-process path, where
-        # metrics reporting goes through a throttled callback
-        max_processes=1,
-        display="none",
-    )
-
-    assert status.complete
-    assert_no_active_scan_entry()
+        assert status.complete
+        with active_scans_store() as store:
+            assert store.read_all() == {}
 
 
 def test_interrupted_scan_survives_a_late_metrics_write(
@@ -81,27 +81,73 @@ def test_interrupted_scan_survives_a_late_metrics_write(
     that sync must not run: the store's sqlite connection is closed and the
     write would raise (and resurrect the deleted entry if it got further).
 
-    Holding the interrupted-path sync open past the one second throttle window
-    makes the write come due inside that gap deterministically, no wall-clock
-    aiming involved.
+    Holding the interrupted-path sync open past the throttle window makes the
+    write come due inside that gap deterministically. The test records when
+    throttled fires happen and when the scan deletes its store entry, and
+    asserts a fire actually came due after the delete -- so it fails loudly
+    if the vulnerable window ever stops opening, rather than passing
+    vacuously. (Without the guards, that post-delete fire raises
+    sqlite3.ProgrammingError out of scan() itself, failing the test with the
+    original error.)
     """
+    # shrink the throttle window and record when the throttled function fires
+    fire_times: list[float] = []
+
+    def recording_throttle(_seconds: float) -> Callable[..., Any]:
+        def decorate(fn: Callable[..., Any]) -> Callable[..., Any]:
+            def recorded(*args: Any, **kwargs: Any) -> Any:
+                fire_times.append(time.monotonic())
+                return fn(*args, **kwargs)
+
+            return throttle(THROTTLE_WINDOW)(recorded)
+
+        return decorate
+
+    monkeypatch.setattr(single_process, "throttle", recording_throttle)
+
+    # record when the scan deletes its active-scans entry
+    deleted_at: list[float] = []
+
+    @contextmanager
+    def tracking_store() -> Iterator[ActiveScansStore]:
+        with active_scans_store() as store:
+            real_delete = store.delete_current
+
+            def tracked_delete() -> None:
+                deleted_at.append(time.monotonic())
+                real_delete()
+
+            store.delete_current = tracked_delete  # type: ignore[method-assign]
+            yield store
+
+    monkeypatch.setattr(scan_module, "active_scans_store", tracking_store)
+
+    # hold the interrupted-path sync open past the throttle window
     real_sync = FileRecorder.sync
 
     async def slow_sync(scan_location: str, complete: bool) -> Status:
-        await anyio.sleep(2)
+        await anyio.sleep(THROTTLE_WINDOW * 2)
         return await real_sync(scan_location, complete)
 
     monkeypatch.setattr(FileRecorder, "sync", staticmethod(slow_sync))
 
-    status = scan(
-        scanners=[failing_probe_scanner()],
-        transcripts=transcripts_from(LOGS_DIR),
-        scans=str(tmp_path),
-        limit=2,
-        max_processes=1,
-        fail_on_error=True,
-        display="none",
-    )
+    with temp_active_scans_store():
+        status = scan(
+            scanners=[failing_probe_scanner()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=str(tmp_path),
+            limit=2,
+            max_processes=1,
+            fail_on_error=True,
+            display="none",
+        )
 
-    assert not status.complete
-    assert_no_active_scan_entry()
+        assert not status.complete
+        assert deleted_at, "scan never deleted its active-scans entry"
+        assert fire_times and max(fire_times) > deleted_at[0], (
+            "no trailing-edge metrics write came due after the store entry "
+            "was deleted -- the vulnerable window this test exercises did "
+            "not open"
+        )
+        with active_scans_store() as store:
+            assert store.read_all() == {}

--- a/tests/scan/test_active_scan_cleanup.py
+++ b/tests/scan/test_active_scan_cleanup.py
@@ -130,8 +130,8 @@ def test_interrupted_scan_survives_a_late_metrics_write(
         assert deleted_at, "scan never deleted its active-scans entry"
         assert fire_times and max(fire_times) > deleted_at[0], (
             "no trailing-edge metrics write came due after the store entry "
-            "was deleted -- the vulnerable window this test exercises did "
-            "not open"
+            "was deleted, so the vulnerable window this test exercises "
+            "never opened"
         )
         with active_scans_store() as store:
             assert store.read_all() == {}

--- a/tests/scan/test_active_scan_cleanup.py
+++ b/tests/scan/test_active_scan_cleanup.py
@@ -21,11 +21,9 @@ from tests.helpers import temp_active_scans_store
 
 LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
 
-# the strategy hardcodes @throttle(1); shrinking the window keeps the same
-# trailing-edge mechanics while the test holds the vulnerable gap open for
-# fractions of a second instead of multiples of it. the window must still be
-# generous enough that the strategy's teardown metrics call lands inside it
-# even on a loaded CI machine, or no trailing-edge fire gets scheduled.
+# shrinks the strategy's hardcoded @throttle(1) window, but stays generous
+# enough that the strategy's teardown metrics call lands inside it on a
+# loaded CI machine (otherwise no trailing-edge fire gets scheduled at all)
 THROTTLE_WINDOW = 0.3
 
 
@@ -46,12 +44,10 @@ def failing_probe_scanner() -> Scanner[Transcript]:
 
 
 def test_completed_scan_leaves_no_active_scan_entry(tmp_path: Path) -> None:
-    """Cleanup smoke test for the success path.
+    """Cleanup smoke test: a completed scan deletes its active-scans entry.
 
-    A completed scan must delete its active-scans entry. (The late
-    metrics-write hazard is only reachable on the interrupted path -- on
-    completion the pending trailing-edge write is cancelled with the scan's
-    task group -- so this test pins only the cleanup behavior.)
+    The late-write hazard is only reachable on the interrupted path (on
+    completion the pending write is cancelled with the scan's task group).
     """
     with temp_active_scans_store():
         status = scan(
@@ -75,20 +71,8 @@ def test_interrupted_scan_survives_a_late_metrics_write(
 ) -> None:
     """A trailing-edge metrics write coming due after the store has closed.
 
-    When a scanner error interrupts the scan, the active-scans store is closed
-    and its entry deleted, then handle_scan_interrupted awaits a final sync.
-    A pending trailing-edge metrics write whose throttle window expires during
-    that sync must not run: the store's sqlite connection is closed and the
-    write would raise (and resurrect the deleted entry if it got further).
-
-    Holding the interrupted-path sync open past the throttle window makes the
-    write come due inside that gap deterministically. The test records when
-    throttled fires happen and when the scan deletes its store entry, and
-    asserts a fire actually came due after the delete -- so it fails loudly
-    if the vulnerable window ever stops opening, rather than passing
-    vacuously. (Without the guards, that post-delete fire raises
-    sqlite3.ProgrammingError out of scan() itself, failing the test with the
-    original error.)
+    Holds the interrupted-path sync open past the throttle window and asserts
+    a fire came due after the entry delete (fails loudly if the window closes).
     """
     # shrink the throttle window and record when the throttled function fires
     fire_times: list[float] = []

--- a/tests/scan/test_active_scan_cleanup.py
+++ b/tests/scan/test_active_scan_cleanup.py
@@ -1,0 +1,107 @@
+import os
+from pathlib import Path
+
+import anyio
+import pytest
+from inspect_scout import Result, Scanner, Status, scan, scanner
+from inspect_scout._recorder.active_scans_store import active_scans_store
+from inspect_scout._recorder.file import FileRecorder
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+
+@scanner(name="cleanup_probe_scanner", messages="all")
+def cleanup_probe_scanner() -> Scanner[Transcript]:
+    async def scan_transcript(transcript: Transcript) -> Result:
+        return Result(value=True)
+
+    return scan_transcript
+
+
+@scanner(name="failing_probe_scanner", messages="all")
+def failing_probe_scanner() -> Scanner[Transcript]:
+    first_transcript = True
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        nonlocal first_transcript
+        if first_transcript:
+            first_transcript = False
+            return Result(value=True)
+        # let the first result get recorded before failing (the test docstring
+        # explains why this ordering leaves a trailing write pending)
+        await anyio.sleep(0.3)
+        raise ValueError("injected scanner failure")
+
+    return scan_transcript
+
+
+def assert_no_active_scan_entry() -> None:
+    """The active-scans entry for this process must be gone after a scan.
+
+    Checked by PID rather than by an empty store: under pytest-xdist other
+    worker processes have live entries of their own.
+    """
+    with active_scans_store() as store:
+        assert store.read_by_pid(os.getpid()) is None
+
+
+def test_scan_completes_with_a_metrics_write_still_throttled(tmp_path: Path) -> None:
+    """A scan short enough to end while a throttled metrics write is pending.
+
+    The scan issues its metrics updates within a few tens of milliseconds and
+    finishes well inside the one second throttle window, so the trailing-edge
+    write is still pending when the scan ends. It must not fire against the
+    closed store, and the scan must leave no active-scans entry behind.
+    """
+    status = scan(
+        scanners=[cleanup_probe_scanner()],
+        transcripts=transcripts_from(LOGS_DIR),
+        scans=str(tmp_path),
+        limit=2,
+        # the deferred write only exists on the single-process path, where
+        # metrics reporting goes through a throttled callback
+        max_processes=1,
+        display="none",
+    )
+
+    assert status.complete
+    assert_no_active_scan_entry()
+
+
+def test_interrupted_scan_survives_a_late_metrics_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A trailing-edge metrics write coming due after the store has closed.
+
+    When a scanner error interrupts the scan, the active-scans store is closed
+    and its entry deleted, then handle_scan_interrupted awaits a final sync.
+    A pending trailing-edge metrics write whose throttle window expires during
+    that sync must not run: the store's sqlite connection is closed and the
+    write would raise (and resurrect the deleted entry if it got further).
+
+    Holding the interrupted-path sync open past the one second throttle window
+    makes the write come due inside that gap deterministically, no wall-clock
+    aiming involved.
+    """
+    real_sync = FileRecorder.sync
+
+    async def slow_sync(scan_location: str, complete: bool) -> Status:
+        await anyio.sleep(2)
+        return await real_sync(scan_location, complete)
+
+    monkeypatch.setattr(FileRecorder, "sync", staticmethod(slow_sync))
+
+    status = scan(
+        scanners=[failing_probe_scanner()],
+        transcripts=transcripts_from(LOGS_DIR),
+        scans=str(tmp_path),
+        limit=2,
+        max_processes=1,
+        fail_on_error=True,
+        display="none",
+    )
+
+    assert not status.complete
+    assert_no_active_scan_entry()


### PR DESCRIPTION
Fixes #558.

**What happens**

The scan reports metrics through a callback that the single process strategy wraps in `@throttle(1)` with trailing-edge semantics. A call arriving inside the throttle window is saved and fired up to a second later by a background task in the scan's outer task group, so the write can outlive the `active_scans_store()` block that owns the sqlite connection.

The path where this actually fires in a real scan is the interrupted one. When a scanner error ends the scan, the store's connection closes and its entry is deleted, then `handle_scan_interrupted` still awaits a final `recorder.sync()`. If the pending trailing-edge write comes due during that sync, `put_metrics` runs against the closed connection and raises `sqlite3.ProgrammingError: Cannot operate on a closed database`. Past the connection error it would also resurrect the deleted entry, because `put_metrics` starts from `kvstore.get(pid_key) or "{}"`.

**The fix**

`update_metrics` now checks a `scan_finished` flag set in the same `finally` that deletes the store entry. Nothing awaits between setting the flag and the delete, so a deferred write cannot land in the gap. The `finally` runs on the success, error, and cancellation paths alike, so the guard covers all three. This is a more contained version of the issue's first suggested direction. Rather than adding a flush or cancel handle to the throttle in inspect_ai, the callback itself refuses to write once the scan is over. The callback is also the one choke point that covers both targets a late fire would hit, the store write and the display update, which is why the guard sits here rather than inside `put_metrics`.

**Verification**

Reproduced end to end through the public `scan()` API. The new test holds the interrupted-path sync open past the throttle window with a monkeypatch, so the pending write always comes due in the vulnerable gap, with no wall-clock aiming. On current main it fails 3 of 3 runs. The surfaced error varies because `_scan_async` re-raises with `from None` and severs the cause chain. Two runs showed the ProgrammingError above directly, and one showed only a downstream `RuntimeError: no running event loop` from the crashed scan's teardown. The root is the same deferred write either way, and it is the only background task in the group. With the fix the test passes 3 of 3 runs and the full suite passes.

I also probed the other two paths with instrumented runs. On successful completion nothing yields between the entry delete and the task group exit, and the pending timer is cancelled with the task group about a second before it would fire (5 of 5 runs). Under a real SIGINT the global cancellation kills the timer at unwind time (3 of 3 runs). So the interrupted path is the only one I could make fire, and the guard covers the others as insurance.

One thing I did not check is remote (S3) transcript sources, where reader shutdown does real async work and might open a success-path window too. The guard would cover that case the same way.

cc @epatey
