### PR TITLE
fix(examples/openclaw_telemetry_hal): accept 'explicit' session kind as an orchestrator surface

### DIFF
--- a/examples/sources/openclaw_telemetry_hal/detection.py
+++ b/examples/sources/openclaw_telemetry_hal/detection.py
@@ -12,11 +12,15 @@ import json
 
 # Session-kind classification (sessionKey = agent:<...>:<kind>:<uuid>).
 # ``main``/``telegram``/``dashboard`` are orchestrator surfaces (terminal, the
-# Telegram channel, and the web dashboard respectively); ``subagent`` is
-# delegated work. Any other kind on a consumed event (a surface we have not
+# Telegram channel, and the web dashboard respectively); ``explicit`` is an
+# explicitly-created session on the orchestrator agent — observed as
+# ``agent:main:explicit:gateway-fallback-<uuid>`` when OpenClaw's
+# gateway-fallback path opens a session for the main agent (same ``agentId``
+# as the ``main`` sessions, ordinary main-agent tool activity); ``subagent``
+# is delegated work. Any other kind on a consumed event (a surface we have not
 # seen, e.g. another chat channel) fails the import loudly — see
 # ``_consolidate`` — rather than silently dropping that session's turns.
-ORCH_KINDS = ("telegram", "main", "dashboard")  # the orchestrator
+ORCH_KINDS = ("telegram", "main", "dashboard", "explicit")  # the orchestrator
 SUBAGENT_KIND = "subagent"
 
 _REDACTED = "[REMOVED]"

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -20,9 +20,11 @@ JSONL, one event per line. Payload-bearing events:
 - ``tool.start`` / ``tool.end`` are individual tool calls (the only place
   schema-B sub-agent activity is recorded).
 - ``sessionKey`` is ``agent:<...>:<kind>:<uuid>`` with ``kind`` one of ``main``,
-  ``telegram``, ``dashboard`` (orchestrator surfaces) or ``subagent``
-  (delegated work). Any other kind on a consumed event fails the import
-  loudly rather than silently dropping that session's activity.
+  ``telegram``, ``dashboard``, ``explicit`` (orchestrator surfaces — ``explicit``
+  is an explicitly-created session on the orchestrator agent, e.g. OpenClaw's
+  gateway-fallback path) or ``subagent`` (delegated work). Any other kind on a
+  consumed event fails the import loudly rather than silently dropping that
+  session's activity.
 
 Intentionally NOT consumed: ``message.in`` / ``message.sending`` /
 ``message.out`` (channel I/O). A sub-agent's final report is auto-announced as a

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -251,6 +251,52 @@ class TestParse:
         with pytest.raises(ValueError, match=f"kind {expected_kind!r}"):
             parse_telemetry([*self._orch_raw("agent:main:main:s1"), event])
 
+    def test_explicit_kind_is_orchestrator(self) -> None:
+        # OpenClaw's gateway-fallback path opens explicitly-created sessions on
+        # the orchestrator agent (sessionKey
+        # ``agent:main:explicit:gateway-fallback-<uuid>``; observed carrying the
+        # same ``agentId`` as the ``main`` sessions and ordinary main-agent tool
+        # activity). Such a session must import as orchestrator activity: its
+        # assistant turns join ``orchestrator_turns``, it is NOT reconstructed
+        # as a sub-agent, and its always-on ``tool.*`` timing channel is
+        # accepted rather than tripping the unrecognized-kind refusal.
+        explicit_key = (
+            "agent:main:explicit:gateway-fallback-9b603d99-b6c2-477e-b61e-e079f0e8"
+        )
+        raw = [
+            *self._orch_raw("agent:main:main:s1"),
+            {
+                "type": "agent.start",
+                "sessionKey": explicit_key,
+                "prompt": "fallback prompt",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "responseId": "r2",
+                        "timestamp": 2,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "via fallback"}],
+                    }
+                ],
+            },
+            {
+                "type": "tool.start",
+                "sessionKey": explicit_key,
+                "toolName": "exec",
+                "params": {},
+            },
+            {
+                "type": "tool.end",
+                "sessionKey": explicit_key,
+                "toolName": "exec",
+                "durationMs": 5,
+                "success": True,
+            },
+        ]
+        parse = parse_telemetry(raw)
+        assert [t["responseId"] for t in parse.orchestrator_turns] == ["r1", "r2"]
+        assert parse.subagents == []
+
     def test_message_events_without_session_key_are_ignored(self) -> None:
         # message.* events carry no sessionKey and are intentionally not
         # consumed; their missing kind must NOT trip the unrecognized-kind


### PR DESCRIPTION
*Opened by Claude Code on behalf of @alexandraabbas.*

Closes #560

## What

The `examples/sources/openclaw_telemetry_hal` importer's unrecognized-kind fail-fast refused telemetry containing sessionKey kind `explicit` (e.g. `agent:main:explicit:gateway-fallback-<uuid>`), failing the whole import. This PR classifies `explicit` as an orchestrator kind (`ORCH_KINDS`), following a characterisation of the real failing data (below). Genuinely unknown kinds keep failing loudly — the example's refuse-rather-than-silently-drop philosophy is unchanged.

## Characterisation of the failing data (structural fields only)

In the failing transcript (~18k agent-keyed events), 88 events belong to 2 sessions with kind `explicit`, both keyed `agent:main:explicit:gateway-fallback-<uuid>`:

- Event types: 4 × `agent.start`, 42 × `tool.start`, 42 × `tool.end` (no `agent.end`).
- **All 88 carry `agentId: "main"`** — identical to the kind-`main` sessions' events.
- Tool vocabulary is ordinary main-agent tooling: `exec` ×28, `cron` ×5, `read` ×2, `subagents` ×2, `sessions_list` ×2, `edit`/`write`/`process` ×1 each; `tool.end` `success` 40 true / 2 false.
- The `agent.start` events carry a spawn-style `prompt` (`promptLength: 674`) and an **empty `messages[]`** — no assistant/user/toolResult roles recorded under the explicit keys in this capture.
- Cross-check against orchestrator `agent.*` snapshots: 5 of the 42 explicit `tool.start` calls also appear as identical `(name, arguments)` toolCalls inside non-explicit orchestrator snapshots; the rest exist only on the `tool.*` channel — i.e. these sessions look like the always-on timing channel of an orchestrator surface, not delegated sub-agent work.

Illustrative event shapes (structural fields only, content omitted):

```json
{"type": "agent.start", "agentId": "main", "sessionKey": "agent:main:explicit:gateway-fallback-<uuid>", "prompt": "<omitted>", "promptLength": 674, "messages": []}
{"type": "tool.start",  "agentId": "main", "sessionKey": "agent:main:explicit:gateway-fallback-<uuid>", "toolName": "exec", "params": {"...": "..."}}
{"type": "tool.end",    "agentId": "main", "sessionKey": "agent:main:explicit:gateway-fallback-<uuid>", "toolName": "exec", "durationMs": 1234, "success": true, "error": null}
```

**Conclusion**: these are main-agent (orchestrator) activity reaching OpenClaw via a gateway-fallback path that opens an explicitly-created session — so `explicit` on the orchestrator agent is an orchestrator kind. Any assistant turns recorded under an `explicit` key are attributed as orchestrator turns; like the other orchestrator surfaces, the `tool.*` channel on these sessions remains timing-only (not reconstructed into the message thread), consistent with how `main`/`telegram`/`dashboard` are treated today.

## Changes

- `detection.py`: add `"explicit"` to `ORCH_KINDS`, with a comment documenting the observed gateway-fallback shape.
- `parse.py`: module docstring updated to list the kind.
- `tests/test_telemetry_hal.py`: new `test_explicit_kind_is_orchestrator` — an `explicit`-kind session's assistant turns join `orchestrator_turns`, it is not reconstructed as a sub-agent, and its `tool.*` events are accepted. The existing parametrized unrecognized-kind test (`discord`, missing sessionKey) still passes unchanged, covering the still-refuses path.

`pytest examples/sources/openclaw_telemetry_hal/tests/`: 70 passed. Verified end-to-end against the real failing transcript: the `explicit` refusal is gone and the file imports.

## Note on a sibling PR

A separate PR from the `openclaw-hal-cron-operator` branch ports our vendored `cron`-kind + `message.in` patches to this same example. The two are intentionally independent (both based on `main`) but may conflict trivially on adjacent lines in `detection.py`/`parse.py` — whichever lands second needs a one-line rebase. (For full-fidelity import of the transcript behind #560 you need both: it contains `cron`-kind sessions too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
