### PR TITLE
feat: cron kind, operator provenance, reconstruction fidelity + spawn-less session placement in the openclaw telemetry-hal example

### DIFF
--- a/examples/sources/openclaw_telemetry_hal/README.md
+++ b/examples/sources/openclaw_telemetry_hal/README.md
@@ -311,11 +311,15 @@ that does not generalize. We therefore **do not** consume the outbound
 `message.sending`/`message.out` events or nest reports inside sub-agent spans.
 
 The inbound `message.in` events (the operator channel) **are** consumed, for
-provenance rather than content: an inbound message whose text matches a user
-turn marks that turn `source="operator"`, and one that never entered the
-session thread (e.g. delivered while the agent was busy) becomes its own
-operator-sourced user message — so mid-run operator interventions are
-preserved for downstream analysis.
+provenance rather than content: each inbound send marks the first user turn
+carrying the same text at-or-after it `source="operator"`
+(occurrence-for-occurrence, so a repeated send is never collapsed into its
+first match), and a send that never entered the session thread (e.g.
+delivered while the agent was busy) becomes its own operator-sourced user
+message — so mid-run operator interventions are preserved for downstream
+analysis. Such a message appears in the message thread only, **not** in later
+`ModelEvent.input`: the model never saw it, and `input` reflects only what
+the model was actually shown.
 
 ### Spawn-less sub-agent sessions are placed by file-order anchor
 

--- a/examples/sources/openclaw_telemetry_hal/README.md
+++ b/examples/sources/openclaw_telemetry_hal/README.md
@@ -63,7 +63,7 @@ entirely different schema. This example only handles the `openclaw-telemetry-hal
 schema.
 
 Within that schema, the importer is strict about session classification: a
-`sessionKey` kind outside `main`/`telegram`/`dashboard`/`subagent` on a consumed
+`sessionKey` kind outside `main`/`telegram`/`dashboard`/`cron`/`subagent` on a consumed
 (`agent.*`/`tool.*`) event — e.g. a chat surface we have not seen — fails the
 import with an error naming the kind, rather than silently dropping that
 session's activity. Native session support is a future, separate source — see "Native
@@ -307,8 +307,15 @@ sub-agent that produced it**. File order misleads (reports arrive in completion
 order, not spawn order; e.g. the *Eastern* report can immediately follow the
 *weather-west* sub-agent's activity), and the only thing tying a report to a
 sub-agent is the report text echoing the spawn `label` — a content heuristic
-that does not generalize. We therefore **do not** consume `message.*` events or
-nest reports inside sub-agent spans.
+that does not generalize. We therefore **do not** consume the outbound
+`message.sending`/`message.out` events or nest reports inside sub-agent spans.
+
+The inbound `message.in` events (the operator channel) **are** consumed, for
+provenance rather than content: an inbound message whose text matches a user
+turn marks that turn `source="operator"`, and one that never entered the
+session thread (e.g. delivered while the agent was busy) becomes its own
+operator-sourced user message — so mid-run operator interventions are
+preserved for downstream analysis.
 
 ### Schema-B sub-agents have no internal transcript
 

--- a/examples/sources/openclaw_telemetry_hal/README.md
+++ b/examples/sources/openclaw_telemetry_hal/README.md
@@ -214,7 +214,9 @@ labelled by `span_id`, so code that reads only `messages` will not see them.
 
 Assistant turns recur across the cumulative `agent.*` snapshots and are deduped
 by `responseId`. Service-sink captures (e.g. CRUX1) carry **no** `responseId`,
-so the fallback key is `(timestamp, content)` — and that content is serialized
+so the fallback key is `(session, timestamp, content)` — session-scoped because
+re-dumps always come from the turn's own session while concurrent sessions can
+genuinely coincide on `(timestamp, content)` — and that content is serialized
 with toolCall ids **masked** (`_keyless_content_json` in `parse.py`).
 
 The masking exists because OpenClaw's history sanitizer rewrites tool-call ids

--- a/examples/sources/openclaw_telemetry_hal/README.md
+++ b/examples/sources/openclaw_telemetry_hal/README.md
@@ -317,16 +317,35 @@ session thread (e.g. delivered while the agent was busy) becomes its own
 operator-sourced user message — so mid-run operator interventions are
 preserved for downstream analysis.
 
+### Spawn-less sub-agent sessions are placed by file-order anchor
+
+Not every sub-agent session is created by a `sessions_spawn` tool call:
+cron/system-spawned sessions (a normal OpenClaw pattern on scheduled runs)
+appear in the telemetry with no spawn call to link to — on one real
+cron-scheduled CRUX capture, 46 of 101 sub-agent sessions. Dropping them would
+silently lose that delegated activity, so an unlinked session is instead
+**placed at its file-order anchor**: its agent span is emitted immediately
+after the latest orchestrator turn seen (in file order) before the session's
+first event. No spawn tool call is fabricated — the span simply has no folded
+`sessions_spawn` child — and its span is named from the spawn `label` when one
+exists, else the first task-bearing line of the session's own prompt (skipping
+the `[Subagent Context]` scaffold preamble). The placement is a *file-order*
+heuristic, not a recorded parent link: it says "the orchestrator was here when
+this session started", nothing stronger.
+
 ### Schema-B sub-agents have no internal transcript
 
 Under schema B, a sub-agent's `agent.start` carries only the
 spawn `prompt` with an empty `messages[]`; its activity is visible solely as
-`tool.start`/`tool.end` events, which record **no result body, no usage, and no
-timestamps** (only `durationMs` on `tool.end`). Consequently a schema-B
-sub-agent span shows its reconstructed tool calls but no model turns, token
-totals, or wall-clock duration (it renders as `0 · 0s`). This is a property of
-the source telemetry, not the importer. Schema-A sub-agents (which carry their
-own assistant turns in `messages[]`) are reconstructed in full.
+`tool.start`/`tool.end` events, which record **no result body and no usage**.
+Consequently a schema-B sub-agent span shows its reconstructed tool calls but
+no model turns or token totals. This is a property of the source telemetry,
+not the importer. Per-call timing is best-effort: the enriched (service-sink)
+envelope's `ts` gives each call a real start→end span; bare captures carry no
+`ts`, so the call is stamped at the spawn time and `durationMs` (from
+`tool.end`) supplies its width — only a call with neither collapses to zero
+duration. Schema-A sub-agents (which carry their own assistant turns in
+`messages[]`) are reconstructed in full.
 
 ### Sub-agent compactions are not surfaced
 

--- a/examples/sources/openclaw_telemetry_hal/detection.py
+++ b/examples/sources/openclaw_telemetry_hal/detection.py
@@ -11,16 +11,17 @@ from __future__ import annotations
 import json
 
 # Session-kind classification (sessionKey = agent:<...>:<kind>:<uuid>).
-# ``main``/``telegram``/``dashboard`` are orchestrator surfaces (terminal, the
-# Telegram channel, and the web dashboard respectively); ``explicit`` is an
-# explicitly-created session on the orchestrator agent — observed as
-# ``agent:main:explicit:gateway-fallback-<uuid>`` when OpenClaw's
+# ``main``/``telegram``/``dashboard``/``cron`` are orchestrator surfaces
+# (terminal, the Telegram channel, the web dashboard, and the cron scheduler —
+# a cron-scheduled run's orchestrator session carries the ``cron`` kind);
+# ``explicit`` is an explicitly-created session on the orchestrator agent —
+# observed as ``agent:main:explicit:gateway-fallback-<uuid>`` when OpenClaw's
 # gateway-fallback path opens a session for the main agent (same ``agentId``
 # as the ``main`` sessions, ordinary main-agent tool activity); ``subagent``
 # is delegated work. Any other kind on a consumed event (a surface we have not
 # seen, e.g. another chat channel) fails the import loudly — see
 # ``_consolidate`` — rather than silently dropping that session's turns.
-ORCH_KINDS = ("telegram", "main", "dashboard", "explicit")  # the orchestrator
+ORCH_KINDS = ("telegram", "main", "dashboard", "cron", "explicit")  # orchestrator
 SUBAGENT_KIND = "subagent"
 
 _REDACTED = "[REMOVED]"

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -14,8 +14,10 @@ Mapping (mirrors the Claude Code importer):
   linkable (e.g. cron/system-spawned sessions), placed at its file-order
   anchor. Sub-agent messages are excluded from the main thread.
 - Inbound operator messages (``message.in``) mark the matching user turns
-  ``source="operator"``; an inbound message with no matching user turn (it never
-  entered the session thread) becomes its own operator-sourced user message.
+  ``source="operator"`` (occurrence-for-occurrence, in time order); an inbound
+  message with no matching user turn (it never entered the session thread)
+  becomes its own operator-sourced user message in the thread — excluded from
+  later ``ModelEvent.input``, which reflects only what the model was shown.
 """
 
 from __future__ import annotations
@@ -49,6 +51,7 @@ from inspect_ai.tool import ToolResult as ToolResultContent
 
 from .extraction import (
     content_blocks,
+    content_to_text,
     rich_or_text,
     toolcalls_of,
     usage_to_inspect,
@@ -90,19 +93,16 @@ def _stop_and_error(turn: dict[str, Any]) -> tuple[StopReason, str | None]:
     return "unknown", (str(message) if message else None)
 
 
-def _plain_text(content: object) -> str:
-    """A message ``content`` as comparable plain text (str or rich blocks).
+def _match_text(content: object) -> str:
+    """A message ``content`` as comparable text for operator reconciliation.
 
-    Used to match an inbound ``message.in`` (always a plain string) against the
-    session's user turns (plain strings or content-block lists).
+    Both sides flatten through :func:`.extraction.content_to_text`: an inbound
+    ``message.in`` is a plain string, but its user turn may have re-entered
+    the thread as a content-block list, and the two must compare equal (same
+    joiner, same block filter) or the turn is left unstamped and the send
+    duplicated as a standalone message.
     """
-    if isinstance(content, str):
-        return content.strip()
-    if isinstance(content, list):
-        return " ".join(
-            str(b.get("text", "")) for b in content if isinstance(b, dict)
-        ).strip()
-    return str(content or "").strip()
+    return content_to_text(content).strip()
 
 
 def build_content(
@@ -111,16 +111,19 @@ def build_content(
     """Build the event stream and the main-thread messages in one pass.
 
     User turns, orchestrator assistant turns, and real compactions are
-    interleaved by timestamp. A single running conversation is threaded through
-    both outputs: each ``ModelEvent.input`` carries the conversation up to that
+    interleaved by timestamp. A running conversation is threaded through both
+    outputs: each ``ModelEvent.input`` carries the conversation up to that
     turn (so the events view shows user prompts and tool results, matching the
-    Claude Code importer), and the final running list is the message thread.
+    Claude Code importer), and the full running list is the message thread.
 
     Inbound operator messages (``message.in``) are reconciled with the user
-    turns by content: a match stamps the existing turn ``source="operator"``
-    (never a duplicate message); an unmatched inbound message — one that never
-    entered the session thread — is added as its own operator-sourced user
-    message so mid-run operator interventions are preserved.
+    turns by content, occurrence-for-occurrence in time order: each send
+    stamps the first unconsumed user turn carrying the same text at-or-after
+    it ``source="operator"`` (never a duplicate message). A send with no such
+    turn — it never entered the session thread — is added as its own
+    operator-sourced user message so mid-run operator interventions are
+    preserved; it appears in the message thread only, NOT in later
+    ``ModelEvent.input``, because the model never saw it.
 
     Each sub-agent agent span is inserted immediately after the orchestrator
     tool event that spawned it. A sub-agent whose spawn could not be linked to
@@ -154,20 +157,32 @@ def build_content(
             ", ".join(sa.session_key for sa in unlinked),
         )
 
-    # The inbound operator channel (``message.in``). An inbound message whose
-    # text matches a user turn marks THAT turn ``source="operator"`` (no
-    # duplicate message); one with no matching user turn (it never entered the
-    # session thread, e.g. delivered while the agent was busy) becomes its own
-    # operator-sourced user message, placed by its timestamp.
-    operator_contents = {_plain_text(m.get("content")) for m in parse.operator_messages}
-    matched = {
-        _plain_text(t.get("content")) for t in parse.user_turns
-    } & operator_contents
-    extra_operator = [
-        m
-        for m in parse.operator_messages
-        if _plain_text(m.get("content")) not in matched
-    ]
+    # The inbound operator channel (``message.in``). Each send pairs with at
+    # most ONE user turn carrying the same text — the first unconsumed one
+    # at-or-after the send, since a message can only enter the session thread
+    # after it arrives (observed lags on real captures run from 0 to minutes;
+    # user turns carry no idempotencyKey there, so text is the only join key).
+    # Set-of-texts matching would silently drop a repeated send once its first
+    # occurrence matched, and could stamp a twin turn that predates the send.
+    # A send with no matching turn (it never entered the session thread, e.g.
+    # delivered while the agent was busy) becomes its own operator-sourced
+    # user message, placed by its timestamp.
+    turns_by_text: dict[str, list[dict[str, Any]]] = {}
+    for turn in parse.user_turns:  # already timestamp-sorted
+        turns_by_text.setdefault(_match_text(turn.get("content")), []).append(turn)
+    operator_turn_ids: set[int] = set()
+    extra_operator: list[dict[str, Any]] = []
+    for m in sorted(
+        parse.operator_messages, key=lambda m: int(m.get("timestamp") or 0)
+    ):
+        queue = turns_by_text.get(_match_text(m.get("content")), [])
+        m_ts = int(m.get("timestamp") or 0)
+        turn = next((t for t in queue if int(t.get("timestamp") or 0) >= m_ts), None)
+        if turn is not None:
+            queue.remove(turn)
+            operator_turn_ids.add(id(turn))
+        else:
+            extra_operator.append(m)
 
     # Merge user turns + operator messages + assistant turns + real compactions,
     # ordered by timestamp.
@@ -183,7 +198,8 @@ def build_content(
     ordered.sort(key=lambda item: item[0])
 
     events: list[Event] = []
-    messages: list[ChatMessage] = []  # running conversation; also the final thread
+    thread: list[ChatMessage] = []  # the final message thread (all messages)
+    conversation: list[ChatMessage] = []  # what the model saw (ModelEvent.input)
     order = 0  # monotonic working_start ordinal (stable tie-break for the timeline)
     last_ts = _ts_to_datetime(ordered[0][0]) if ordered else None
     last_ts = last_ts or _EPOCH
@@ -196,17 +212,19 @@ def build_content(
             # An operator-delivered turn carries its true source; other user
             # turns (runtime context, inter-session messages) carry none.
             source: Literal["operator"] | None = (
-                "operator" if _plain_text(item.get("content")) in matched else None
+                "operator" if id(item) in operator_turn_ids else None
             )
-            messages.append(
-                ChatMessageUser(
-                    content=rich_or_text(item.get("content")), source=source
-                )
+            user_msg = ChatMessageUser(
+                content=rich_or_text(item.get("content")), source=source
             )
+            thread.append(user_msg)
+            conversation.append(user_msg)
             continue
 
         if kind == "operator":  # message.in not present in the session thread
-            messages.append(
+            # Thread-only: the model never saw this message, so it must not
+            # appear in later ModelEvents' input.
+            thread.append(
                 ChatMessageUser(
                     content=rich_or_text(item.get("content")), source="operator"
                 )
@@ -273,7 +291,7 @@ def build_content(
         events.append(
             ModelEvent(
                 model=turn_model,
-                input=list(messages),  # conversation up to (not including) this turn
+                input=list(conversation),  # what the model saw before this turn
                 tools=[],
                 tool_choice="auto",
                 config=GenerateConfig(),
@@ -285,7 +303,8 @@ def build_content(
             )
         )
         order += 1
-        messages.append(assistant_msg)
+        thread.append(assistant_msg)
+        conversation.append(assistant_msg)
 
         for tc in toolcalls:
             tc_id = str(tc.get("id") or "")
@@ -322,14 +341,14 @@ def build_content(
 
             # The tool result still belongs in the orchestrator message thread,
             # whether or not the tool spawned a sub-agent.
-            messages.append(
-                ChatMessageTool(
-                    content=result_content,
-                    tool_call_id=tc_id,
-                    function=function,
-                    error=error,
-                )
+            tool_msg = ChatMessageTool(
+                content=result_content,
+                tool_call_id=tc_id,
+                function=function,
+                error=error,
             )
+            thread.append(tool_msg)
+            conversation.append(tool_msg)
 
     # Any unlinked sub-agent spans anchored after the last orchestrator turn.
     for sa in unlinked:
@@ -337,7 +356,7 @@ def build_content(
             events, sa, last_ts, order, parse.result_by_callid, spawn_tool=None
         )
 
-    return events, messages
+    return events, thread
 
 
 def _emit_subagent_span(

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -181,8 +181,10 @@ def build_content(
     # delivered while the agent was busy) becomes its own operator-sourced
     # user message, placed by its timestamp.
     turns_by_text: dict[str, list[dict[str, Any]]] = {}
-    for turn in parse.user_turns:  # already timestamp-sorted
-        turns_by_text.setdefault(_match_text(turn.get("content")), []).append(turn)
+    for user_turn in parse.user_turns:  # already timestamp-sorted
+        turns_by_text.setdefault(_match_text(user_turn.get("content")), []).append(
+            user_turn
+        )
     operator_turn_ids: set[int] = set()
     extra_operator: list[dict[str, Any]] = []
     for m in sorted(
@@ -190,7 +192,9 @@ def build_content(
     ):
         queue = turns_by_text.get(_match_text(m.get("content")), [])
         m_ts = int(m.get("timestamp") or 0)
-        turn = next((t for t in queue if int(t.get("timestamp") or 0) >= m_ts), None)
+        turn: dict[str, Any] | None = next(
+            (t for t in queue if int(t.get("timestamp") or 0) >= m_ts), None
+        )
         if turn is not None:
             queue.remove(turn)
             operator_turn_ids.add(id(turn))

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -136,18 +136,31 @@ def build_content(
     """
     # Each spawned sub-agent links to the single orchestrator toolCall that
     # spawned it: a spawn result names exactly one ``childSessionKey``, so the
-    # mapping is 1:1. A sub-agent with no linkable spawn call (or, defensively,
-    # one whose call is already claimed) is placed by its file-order anchor
-    # instead — dropping it would silently lose that session's activity (46 of
-    # 101 sub-agent sessions on a real cron-scheduled CRUX capture).
+    # mapping is 1:1. A sub-agent with no linkable spawn call is placed by its
+    # file-order anchor instead — dropping it would silently lose that
+    # session's activity (46 of 101 sub-agent sessions on a real
+    # cron-scheduled CRUX capture).
     subagent_by_tool_call: dict[str, SubagentSpan] = {}
     unlinked: list[SubagentSpan] = []
     for sa in parse.subagents:
         tc_id = sa.spawn_tool_call_id
-        if tc_id is not None and tc_id not in subagent_by_tool_call:
-            subagent_by_tool_call[tc_id] = sa
-        else:
+        if tc_id is None:
             unlinked.append(sa)
+        elif tc_id in subagent_by_tool_call:
+            # A second claim on the same spawn call violates the documented
+            # 1:1 spawn->session mapping (corrupt/ambiguous linkage). Place it
+            # like a spawn-less session, but — unlike that normal cron
+            # pattern — surface the anomaly as a warning.
+            logger.warning(
+                "OpenClaw sub-agent %s claims spawn call %s already claimed "
+                "by %s; placing it by file-order anchor instead",
+                sa.session_key,
+                tc_id,
+                subagent_by_tool_call[tc_id].session_key,
+            )
+            unlinked.append(sa)
+        else:
+            subagent_by_tool_call[tc_id] = sa
     unlinked.sort(key=lambda sa: sa.anchor_ts)
     if unlinked:
         logger.info(
@@ -208,6 +221,25 @@ def build_content(
         ts = _ts_to_datetime(ts_ms) or last_ts
         last_ts = ts
 
+        # Emit any unlinked sub-agent spans whose file-order anchor has been
+        # passed, so each lands immediately AFTER the orchestrator turn the
+        # run was on when the session first appeared. Strictly-before (<): a
+        # span whose anchor EQUALS this item's ts belongs on the far side of
+        # the anchor turn — the turn had already been produced when the
+        # session appeared. Running the flush on every timeline item keeps
+        # the span as close to its anchor as possible (in particular, before
+        # an interleaved compaction rather than after it); the trailing loop
+        # below covers anchors at or past the last item.
+        while unlinked and unlinked[0].anchor_ts < ts_ms:
+            order = _emit_subagent_span(
+                events,
+                unlinked.pop(0),
+                ts,
+                order,
+                parse.result_by_callid,
+                spawn_tool=None,
+            )
+
         if kind == "user":
             # An operator-delivered turn carries its true source; other user
             # turns (runtime context, inter-session messages) carry none.
@@ -248,19 +280,6 @@ def build_content(
             )
             order += 1
             continue
-
-        # Emit any unlinked sub-agent spans whose file-order anchor has been
-        # reached, so each lands next to the orchestrator turn the run was on
-        # when the session first appeared.
-        while unlinked and unlinked[0].anchor_ts <= ts_ms:
-            order = _emit_subagent_span(
-                events,
-                unlinked.pop(0),
-                ts,
-                order,
-                parse.result_by_callid,
-                spawn_tool=None,
-            )
 
         # Assistant turn: emit a model event (carrying the conversation so far as
         # input), then its tool events.
@@ -546,7 +565,7 @@ def _emit_subagent_span(
         # call a real width — downstream busy-time sums rely on it — so only a
         # call with neither collapses to zero duration.
         call_start = _ts_to_datetime(call.get("startTs")) or timestamp
-        duration_ms = call.get("durationMs")
+        duration_ms = _duration_to_ms(call.get("durationMs"))
         call_end = _ts_to_datetime(call.get("endTs")) or (
             call_start + timedelta(milliseconds=duration_ms)
             if duration_ms
@@ -626,17 +645,47 @@ def _ts_to_datetime(value: Any) -> datetime | None:
     return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
 
 
+def _duration_to_ms(value: Any) -> int | None:
+    """Coerce a telemetry ``durationMs`` to positive-int milliseconds.
+
+    The value comes verbatim out of ``json.loads``, so guard it the way
+    ``_ts_to_datetime`` guards timestamps: a numeric string still yields a
+    width; a non-numeric or non-positive value yields ``None`` (zero width)
+    rather than aborting the import inside ``timedelta`` arithmetic — or
+    placing a call's completion before its start.
+    """
+    try:
+        ms = int(value)
+    except (TypeError, ValueError):
+        return None
+    return ms if ms > 0 else None
+
+
+_TASK_TAG = "[Subagent Task]"
+
+
 def _task_line(prompt: str | None) -> str | None:
     """The first task-bearing line of a sub-agent prompt, for span naming.
 
     A spawn-less (anchor-placed) session has no ``label``/``task`` arguments to
     name its span from, only its own prompt — which opens with OpenClaw's
-    scaffold preamble (e.g. ``[Subagent Context] You are running as a
-    subagent…``). Skip bracketed and boilerplate lines and return the first
-    line that carries the actual task, or ``None`` when there is none.
+    scaffold preamble (a timestamp tag and/or ``[Subagent Context] You are
+    running as a subagent…``) and usually announces the task with a
+    ``[Subagent Task]`` tag: inline (``[Subagent Task]: <task>``) or with the
+    task on the following line. The tag is authoritative when present.
+    Otherwise fall back to the first line that is neither bracketed nor the
+    subagent boilerplate — prompt BODIES also carry bracketed lines (template
+    placeholders), so an unrecognized bracket line never becomes a name.
+    Returns ``None`` when nothing task-bearing is found.
     """
-    for line in (prompt or "").splitlines():
-        line = line.strip()
+    lines = [line.strip() for line in (prompt or "").splitlines()]
+    for i, line in enumerate(lines):
+        if line.startswith(_TASK_TAG):
+            inline = line[len(_TASK_TAG) :].lstrip(" :").strip()
+            if inline:
+                return inline
+            return next((follow for follow in lines[i + 1 :] if follow), None)
+    for line in lines:
         if (
             line
             and not line.startswith("[")

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -12,13 +12,16 @@ Mapping (mirrors the Claude Code importer):
   (``SpanBeginEvent`` / ``SpanEndEvent``, ``type="agent"``) anchored at the
   ``sessions_spawn`` tool call that created it. Sub-agent messages are excluded
   from the main thread.
+- Inbound operator messages (``message.in``) mark the matching user turns
+  ``source="operator"``; an inbound message with no matching user turn (it never
+  entered the session thread) becomes its own operator-sourced user message.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from inspect_ai.event import (
     CompactionEvent,
@@ -86,6 +89,21 @@ def _stop_and_error(turn: dict[str, Any]) -> tuple[StopReason, str | None]:
     return "unknown", (str(message) if message else None)
 
 
+def _plain_text(content: object) -> str:
+    """A message ``content`` as comparable plain text (str or rich blocks).
+
+    Used to match an inbound ``message.in`` (always a plain string) against the
+    session's user turns (plain strings or content-block lists).
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        return " ".join(
+            str(b.get("text", "")) for b in content if isinstance(b, dict)
+        ).strip()
+    return str(content or "").strip()
+
+
 def build_content(
     parse: OpenClawTelemetry,
 ) -> tuple[list[Event], list[ChatMessage]]:
@@ -96,6 +114,12 @@ def build_content(
     both outputs: each ``ModelEvent.input`` carries the conversation up to that
     turn (so the events view shows user prompts and tool results, matching the
     Claude Code importer), and the final running list is the message thread.
+
+    Inbound operator messages (``message.in``) are reconciled with the user
+    turns by content: a match stamps the existing turn ``source="operator"``
+    (never a duplicate message); an unmatched inbound message — one that never
+    entered the session thread — is added as its own operator-sourced user
+    message so mid-run operator interventions are preserved.
 
     Each sub-agent agent span is inserted immediately after the orchestrator
     tool event that spawned it. A sub-agent whose spawn could not be linked to a
@@ -123,9 +147,26 @@ def build_content(
             ", ".join(sa.session_key for sa in dropped),
         )
 
-    # Merge user turns + assistant turns + real compactions, ordered by timestamp.
+    # The inbound operator channel (``message.in``). An inbound message whose
+    # text matches a user turn marks THAT turn ``source="operator"`` (no
+    # duplicate message); one with no matching user turn (it never entered the
+    # session thread, e.g. delivered while the agent was busy) becomes its own
+    # operator-sourced user message, placed by its timestamp.
+    operator_contents = {_plain_text(m.get("content")) for m in parse.operator_messages}
+    matched = {
+        _plain_text(t.get("content")) for t in parse.user_turns
+    } & operator_contents
+    extra_operator = [
+        m
+        for m in parse.operator_messages
+        if _plain_text(m.get("content")) not in matched
+    ]
+
+    # Merge user turns + operator messages + assistant turns + real compactions,
+    # ordered by timestamp.
     ordered: list[tuple[int, str, dict[str, Any]]] = (
         [(int(t.get("timestamp") or 0), "user", t) for t in parse.user_turns]
+        + [(int(m.get("timestamp") or 0), "operator", m) for m in extra_operator]
         + [
             (int(t.get("timestamp") or 0), "assistant", t)
             for t in parse.orchestrator_turns
@@ -145,7 +186,24 @@ def build_content(
         last_ts = ts
 
         if kind == "user":
-            messages.append(ChatMessageUser(content=rich_or_text(item.get("content"))))
+            # An operator-delivered turn carries its true source; other user
+            # turns (runtime context, inter-session messages) carry none.
+            source: Literal["operator"] | None = (
+                "operator" if _plain_text(item.get("content")) in matched else None
+            )
+            messages.append(
+                ChatMessageUser(
+                    content=rich_or_text(item.get("content")), source=source
+                )
+            )
+            continue
+
+        if kind == "operator":  # message.in not present in the session thread
+            messages.append(
+                ChatMessageUser(
+                    content=rich_or_text(item.get("content")), source="operator"
+                )
+            )
             continue
 
         if kind == "compaction":

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -10,8 +10,9 @@ Mapping (mirrors the Claude Code importer):
   main ``messages`` thread.
 - Each delegated sub-agent becomes a nested **agent span**
   (``SpanBeginEvent`` / ``SpanEndEvent``, ``type="agent"``) anchored at the
-  ``sessions_spawn`` tool call that created it. Sub-agent messages are excluded
-  from the main thread.
+  ``sessions_spawn`` tool call that created it — or, when no spawn call is
+  linkable (e.g. cron/system-spawned sessions), placed at its file-order
+  anchor. Sub-agent messages are excluded from the main thread.
 - Inbound operator messages (``message.in``) mark the matching user turns
   ``source="operator"``; an inbound message with no matching user turn (it never
   entered the session thread) becomes its own operator-sourced user message.
@@ -19,7 +20,7 @@ Mapping (mirrors the Claude Code importer):
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from typing import Any, Literal, cast
 
@@ -122,29 +123,35 @@ def build_content(
     message so mid-run operator interventions are preserved.
 
     Each sub-agent agent span is inserted immediately after the orchestrator
-    tool event that spawned it. A sub-agent whose spawn could not be linked to a
-    tool call is dropped with a warning (not observed in practice — every
-    sub-agent in the CRUX1 captures links via its spawn result's
-    ``childSessionKey``). Sub-agent messages are excluded from the thread.
+    tool event that spawned it. A sub-agent whose spawn could not be linked to
+    a tool call — cron/system-spawned sessions have no ``sessions_spawn`` call
+    at all, and are the majority on scheduled runs — is placed at its
+    file-order anchor (the latest orchestrator turn before the session's first
+    activity) with NO spawn tool call fabricated, so its delegated activity is
+    kept rather than silently lost. Sub-agent messages are excluded from the
+    thread.
     """
-    # Each sub-agent links to the single orchestrator toolCall that spawned it:
-    # a spawn result names exactly one ``childSessionKey``, so the mapping is
-    # 1:1. A sub-agent whose spawn call is missing (or, defensively, already
-    # claimed) cannot be placed in the timeline, so it is dropped with a warning
-    # rather than guessed at (see docstring).
+    # Each spawned sub-agent links to the single orchestrator toolCall that
+    # spawned it: a spawn result names exactly one ``childSessionKey``, so the
+    # mapping is 1:1. A sub-agent with no linkable spawn call (or, defensively,
+    # one whose call is already claimed) is placed by its file-order anchor
+    # instead — dropping it would silently lose that session's activity (46 of
+    # 101 sub-agent sessions on a real cron-scheduled CRUX capture).
     subagent_by_tool_call: dict[str, SubagentSpan] = {}
-    dropped: list[SubagentSpan] = []
+    unlinked: list[SubagentSpan] = []
     for sa in parse.subagents:
         tc_id = sa.spawn_tool_call_id
         if tc_id is not None and tc_id not in subagent_by_tool_call:
             subagent_by_tool_call[tc_id] = sa
         else:
-            dropped.append(sa)
-    if dropped:
-        logger.warning(
-            "Dropping %d OpenClaw sub-agent(s) with no linkable spawn call: %s",
-            len(dropped),
-            ", ".join(sa.session_key for sa in dropped),
+            unlinked.append(sa)
+    unlinked.sort(key=lambda sa: sa.anchor_ts)
+    if unlinked:
+        logger.info(
+            "Placing %d OpenClaw sub-agent(s) without a linkable spawn call "
+            "by file-order anchor: %s",
+            len(unlinked),
+            ", ".join(sa.session_key for sa in unlinked),
         )
 
     # The inbound operator channel (``message.in``). An inbound message whose
@@ -223,6 +230,19 @@ def build_content(
             )
             order += 1
             continue
+
+        # Emit any unlinked sub-agent spans whose file-order anchor has been
+        # reached, so each lands next to the orchestrator turn the run was on
+        # when the session first appeared.
+        while unlinked and unlinked[0].anchor_ts <= ts_ms:
+            order = _emit_subagent_span(
+                events,
+                unlinked.pop(0),
+                ts,
+                order,
+                parse.result_by_callid,
+                spawn_tool=None,
+            )
 
         # Assistant turn: emit a model event (carrying the conversation so far as
         # input), then its tool events.
@@ -311,6 +331,12 @@ def build_content(
                 )
             )
 
+    # Any unlinked sub-agent spans anchored after the last orchestrator turn.
+    for sa in unlinked:
+        order = _emit_subagent_span(
+            events, sa, last_ts, order, parse.result_by_callid, spawn_tool=None
+        )
+
     return events, messages
 
 
@@ -320,7 +346,7 @@ def _emit_subagent_span(
     timestamp: datetime,
     order: int,
     result_by_callid: dict[str, ToolResult],
-    spawn_tool: dict[str, Any],
+    spawn_tool: dict[str, Any] | None,
 ) -> int:
     """Emit a delegated sub-agent as a nested agent span and return next order.
 
@@ -329,7 +355,9 @@ def _emit_subagent_span(
     Claude Code importer, the orchestrator ``sessions_spawn`` call
     (``spawn_tool``) is emitted as the span's FIRST child, tagged with
     ``agent_span_id`` so the view folds it into the agent header rather than
-    drawing a standalone tool row.
+    drawing a standalone tool row. ``spawn_tool`` is ``None`` for an unlinked
+    (anchor-placed) session — no spawn call was recorded, so none is emitted
+    (fabricating one would forge telemetry that does not exist).
 
     - Schema A: each ``messages[]`` assistant turn becomes a ``ModelEvent``
     (with usage) followed by its ``ToolEvent``s (results matched by
@@ -352,7 +380,11 @@ def _emit_subagent_span(
     events.append(
         SpanBeginEvent(
             id=span_id,
-            name=sa.spawn_label or "subagent",
+            name=(
+                sa.spawn_label
+                or _short_description(_task_line(sa.prompt))
+                or "subagent"
+            ),
             type="agent",
             timestamp=timestamp,
             working_start=float(order),
@@ -370,32 +402,34 @@ def _emit_subagent_span(
 
     # The spawning sessions_spawn call, folded into the agent span (mirrors the
     # Claude Code importer's Task-tool handling) so it is not shown as a
-    # separate root-level tool event.
-    spawn_id = str(spawn_tool.get("id") or "")
-    spawn_function = str(spawn_tool.get("name") or "sessions_spawn")
-    spawn_arguments = spawn_tool.get("arguments") or {}
-    spawn_arguments = spawn_arguments if isinstance(spawn_arguments, dict) else {}
-    spawn_result, spawn_completed, spawn_error, spawn_failed = _tool_result_fields(
-        result_by_callid.get(spawn_id), timestamp
-    )
-    span_end_ts = max(span_end_ts, spawn_completed)
-    events.append(
-        ToolEvent(
-            id=spawn_id,
-            function=spawn_function,
-            arguments=spawn_arguments,
-            result=cast(ToolResultContent, spawn_result),
-            error=spawn_error,
-            failed=spawn_failed,
-            timestamp=timestamp,
-            completed=spawn_completed,
-            working_start=float(order),
-            span_id=span_id,
-            agent_span_id=span_id,
-            view=_tool_call_view(spawn_function, spawn_arguments),
+    # separate root-level tool event. An unlinked (anchor-placed) session has
+    # no spawn call to fold in.
+    if spawn_tool is not None:
+        spawn_id = str(spawn_tool.get("id") or "")
+        spawn_function = str(spawn_tool.get("name") or "sessions_spawn")
+        spawn_arguments = spawn_tool.get("arguments") or {}
+        spawn_arguments = spawn_arguments if isinstance(spawn_arguments, dict) else {}
+        spawn_result, spawn_completed, spawn_error, spawn_failed = _tool_result_fields(
+            result_by_callid.get(spawn_id), timestamp
         )
-    )
-    order += 1
+        span_end_ts = max(span_end_ts, spawn_completed)
+        events.append(
+            ToolEvent(
+                id=spawn_id,
+                function=spawn_function,
+                arguments=spawn_arguments,
+                result=cast(ToolResultContent, spawn_result),
+                error=spawn_error,
+                failed=spawn_failed,
+                timestamp=timestamp,
+                completed=spawn_completed,
+                working_start=float(order),
+                span_id=span_id,
+                agent_span_id=span_id,
+                view=_tool_call_view(spawn_function, spawn_arguments),
+            )
+        )
+        order += 1
 
     # Schema A: rebuild the sub-agent's own model + tool events from its turns.
     sub_messages: list[ChatMessage] = []
@@ -488,9 +522,17 @@ def _emit_subagent_span(
         }
         # Prefer the tool.*'s own ``ts`` (enriched envelope) so a call carries a
         # real start->end span; fall back to the spawn time when absent (bare
-        # captures), which collapses it to zero duration but never mis-orders it.
+        # captures), which never mis-orders it. Bare captures record no
+        # ``endTs`` either, but ``durationMs`` (from tool.end) still gives the
+        # call a real width — downstream busy-time sums rely on it — so only a
+        # call with neither collapses to zero duration.
         call_start = _ts_to_datetime(call.get("startTs")) or timestamp
-        call_end = _ts_to_datetime(call.get("endTs")) or call_start
+        duration_ms = call.get("durationMs")
+        call_end = _ts_to_datetime(call.get("endTs")) or (
+            call_start + timedelta(milliseconds=duration_ms)
+            if duration_ms
+            else call_start
+        )
         # A recorded ``success`` of false is a real failure: surface it through
         # the standard ToolEvent fields (with the tool.end ``error`` as the
         # message) rather than leaving ``failed``/``error`` unset.
@@ -563,6 +605,26 @@ def _ts_to_datetime(value: Any) -> datetime | None:
     if ms <= 0:
         return None
     return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+
+
+def _task_line(prompt: str | None) -> str | None:
+    """The first task-bearing line of a sub-agent prompt, for span naming.
+
+    A spawn-less (anchor-placed) session has no ``label``/``task`` arguments to
+    name its span from, only its own prompt — which opens with OpenClaw's
+    scaffold preamble (e.g. ``[Subagent Context] You are running as a
+    subagent…``). Skip bracketed and boilerplate lines and return the first
+    line that carries the actual task, or ``None`` when there is none.
+    """
+    for line in (prompt or "").splitlines():
+        line = line.strip()
+        if (
+            line
+            and not line.startswith("[")
+            and "you are running as a subagent" not in line.lower()
+        ):
+            return line
+    return None
 
 
 def _short_description(task: str | None, limit: int = 80) -> str | None:

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -180,20 +180,31 @@ def build_content(
     # A send with no matching turn (it never entered the session thread, e.g.
     # delivered while the agent was busy) becomes its own operator-sourced
     # user message, placed by its timestamp.
+    # Empty text never joins: a content-less send (media-only) and an
+    # image-only turn both flatten to "", and pairing them would stamp an
+    # unrelated turn. Empty sends surface standalone. A turn with NO
+    # timestamp cannot fail the at-or-after check — it is always eligible
+    # (surfacing a duplicate would be worse than the loose match).
     turns_by_text: dict[str, list[dict[str, Any]]] = {}
     for user_turn in parse.user_turns:  # already timestamp-sorted
-        turns_by_text.setdefault(_match_text(user_turn.get("content")), []).append(
-            user_turn
-        )
+        turn_text = _match_text(user_turn.get("content"))
+        if turn_text:
+            turns_by_text.setdefault(turn_text, []).append(user_turn)
     operator_turn_ids: set[int] = set()
     extra_operator: list[dict[str, Any]] = []
     for m in sorted(
         parse.operator_messages, key=lambda m: int(m.get("timestamp") or 0)
     ):
-        queue = turns_by_text.get(_match_text(m.get("content")), [])
+        text = _match_text(m.get("content"))
+        queue = turns_by_text.get(text, []) if text else []
         m_ts = int(m.get("timestamp") or 0)
         turn: dict[str, Any] | None = next(
-            (t for t in queue if int(t.get("timestamp") or 0) >= m_ts), None
+            (
+                t
+                for t in queue
+                if (t_ts := int(t.get("timestamp") or 0)) == 0 or t_ts >= m_ts
+            ),
+            None,
         )
         if turn is not None:
             queue.remove(turn)
@@ -676,6 +687,20 @@ def _duration_to_ms(value: Any) -> int | None:
 _TASK_TAG = "[Subagent Task]"
 
 
+def _is_task_bearing(line: str) -> bool:
+    """A prompt line usable as a span name.
+
+    Non-empty, not a bracketed line (scaffold tags, timestamps, and template
+    placeholders all take that shape — an unrecognized bracket line must
+    never become a name), and not the subagent boilerplate sentence.
+    """
+    return (
+        bool(line)
+        and not line.startswith("[")
+        and "you are running as a subagent" not in line.lower()
+    )
+
+
 def _task_line(prompt: str | None) -> str | None:
     """The first task-bearing line of a sub-agent prompt, for span naming.
 
@@ -683,26 +708,29 @@ def _task_line(prompt: str | None) -> str | None:
     name its span from, only its own prompt — which opens with OpenClaw's
     scaffold preamble (a timestamp tag and/or ``[Subagent Context] You are
     running as a subagent…``) and usually announces the task with a
-    ``[Subagent Task]`` tag: inline (``[Subagent Task]: <task>``) or with the
-    task on the following line. The tag is authoritative when present.
-    Otherwise fall back to the first line that is neither bracketed nor the
-    subagent boilerplate — prompt BODIES also carry bracketed lines (template
-    placeholders), so an unrecognized bracket line never becomes a name.
-    Returns ``None`` when nothing task-bearing is found.
+    ``[Subagent Task]`` tag: inline (``[Subagent Task]: <task>``), possibly
+    sharing its line with the timestamp preamble, or with the task on a
+    following line. The tag is authoritative when present anywhere on a line,
+    and prompts may repeat it — a bare heading first, the task-carrying tag
+    line after — so a bare tag's lookahead runs only up to the NEXT tag line
+    and defers to it, applying the same bracket/boilerplate skip as the
+    no-tag fallback. Returns ``None`` when nothing task-bearing is found.
     """
     lines = [line.strip() for line in (prompt or "").splitlines()]
-    for i, line in enumerate(lines):
-        if line.startswith(_TASK_TAG):
-            inline = line[len(_TASK_TAG) :].lstrip(" :").strip()
-            if inline:
-                return inline
-            return next((follow for follow in lines[i + 1 :] if follow), None)
+    tag_idxs = [i for i, line in enumerate(lines) if _TASK_TAG in line]
+    for pos, i in enumerate(tag_idxs):
+        line = lines[i]
+        inline = line[line.find(_TASK_TAG) + len(_TASK_TAG) :].lstrip(" :").strip()
+        if inline:
+            return inline
+        stop = tag_idxs[pos + 1] if pos + 1 < len(tag_idxs) else len(lines)
+        for follow in lines[i + 1 : stop]:
+            if _is_task_bearing(follow):
+                return follow
+    if tag_idxs:
+        return None
     for line in lines:
-        if (
-            line
-            and not line.startswith("[")
-            and "you are running as a subagent" not in line.lower()
-        ):
+        if _is_task_bearing(line):
             return line
     return None
 

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -5,7 +5,8 @@ the consolidated intermediate produced by :mod:`.parse`.
 
 Mapping (mirrors the Claude Code importer):
 
-- The orchestrator (``main``/``telegram``) is the spine: its turns become the
+- The orchestrator (any orchestrator-surface session — ``main``, ``telegram``,
+  ``dashboard``, ``cron``, ``explicit``) is the spine: its turns become the
   root-level ``ModelEvent`` / ``ToolEvent`` / ``CompactionEvent`` stream and the
   main ``messages`` thread.
 - Each delegated sub-agent becomes a nested **agent span**
@@ -119,7 +120,10 @@ def build_content(
     Inbound operator messages (``message.in``) are reconciled with the user
     turns by content, occurrence-for-occurrence in time order: each send
     stamps the first unconsumed user turn carrying the same text at-or-after
-    it ``source="operator"`` (never a duplicate message). A send with no such
+    it ``source="operator"`` (never a duplicate message). Two edge rules:
+    empty text never joins (a media-only send surfaces standalone rather than
+    stamping an image-only turn), and a turn with no timestamp stays eligible
+    as a fallback when no at-or-after turn exists. A send with no matching
     turn — it never entered the session thread — is added as its own
     operator-sourced user message so mid-run operator interventions are
     preserved; it appears in the message thread only, NOT in later
@@ -183,8 +187,10 @@ def build_content(
     # Empty text never joins: a content-less send (media-only) and an
     # image-only turn both flatten to "", and pairing them would stamp an
     # unrelated turn. Empty sends surface standalone. A turn with NO
-    # timestamp cannot fail the at-or-after check — it is always eligible
-    # (surfacing a duplicate would be worse than the loose match).
+    # timestamp cannot fail the at-or-after check — it stays eligible
+    # (surfacing a duplicate would be worse than the loose match), but only
+    # as a FALLBACK: a turn satisfying at-or-after wins first, so a ts-less
+    # twin never steals a send whose true match exists.
     turns_by_text: dict[str, list[dict[str, Any]]] = {}
     for user_turn in parse.user_turns:  # already timestamp-sorted
         turn_text = _match_text(user_turn.get("content"))
@@ -202,10 +208,12 @@ def build_content(
             (
                 t
                 for t in queue
-                if (t_ts := int(t.get("timestamp") or 0)) == 0 or t_ts >= m_ts
+                if (t_ts := int(t.get("timestamp") or 0)) != 0 and t_ts >= m_ts
             ),
             None,
         )
+        if turn is None:
+            turn = next((t for t in queue if int(t.get("timestamp") or 0) == 0), None)
         if turn is not None:
             queue.remove(turn)
             operator_turn_ids.add(id(turn))

--- a/examples/sources/openclaw_telemetry_hal/events.py
+++ b/examples/sources/openclaw_telemetry_hal/events.py
@@ -233,12 +233,15 @@ def build_content(
         # session appeared. Running the flush on every timeline item keeps
         # the span as close to its anchor as possible (in particular, before
         # an interleaved compaction rather than after it); the trailing loop
-        # below covers anchors at or past the last item.
+        # below covers anchors at or past the last item. Each span is STAMPED
+        # at its own anchor time — not this (later) item's — falling back to
+        # the current ts only for a zero/invalid anchor.
         while unlinked and unlinked[0].anchor_ts < ts_ms:
+            anchored = unlinked.pop(0)
             order = _emit_subagent_span(
                 events,
-                unlinked.pop(0),
-                ts,
+                anchored,
+                _ts_to_datetime(anchored.anchor_ts) or ts,
                 order,
                 parse.result_by_callid,
                 spawn_tool=None,
@@ -376,7 +379,12 @@ def build_content(
     # Any unlinked sub-agent spans anchored after the last orchestrator turn.
     for sa in unlinked:
         order = _emit_subagent_span(
-            events, sa, last_ts, order, parse.result_by_callid, spawn_tool=None
+            events,
+            sa,
+            _ts_to_datetime(sa.anchor_ts) or last_ts,
+            order,
+            parse.result_by_callid,
+            spawn_tool=None,
         )
 
     return events, thread

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -17,8 +17,8 @@ JSONL, one event per line. Payload-bearing events:
   ``(timestamp, content)`` with toolCall ids masked, because OpenClaw's history
   sanitizer rewrites those ids between a turn's first snapshot and all later
   ones (see :func:`_keyless_content_json`). Snapshots may also carry scaffold
-  *roll-up* records — turn-finalization aggregates whose usage duplicates the
-  preceding per-call records; these are dropped (see
+  *roll-up* records — turn-finalization aggregates whose usage restates (sums)
+  the preceding per-call block; these are dropped (see
   :func:`_drop_rollup_aggregates`).
 - ``tool.start`` / ``tool.end`` are individual tool calls (the only place
   schema-B sub-agent activity is recorded).
@@ -74,6 +74,7 @@ from .detection import (
 from .extraction import (
     content_to_text,
     rich_or_text,
+    tokens_from_usage,
     toolcalls_of,
 )
 
@@ -188,20 +189,31 @@ def _primary_model(orchestrator_turns: list[dict[str, Any]]) -> str | None:
 
 
 def _drop_rollup_aggregates(
-    orchestrator_turns: list[dict[str, Any]],
+    turns: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Drop scaffold roll-up aggregate records from the assembled turns.
+    """Drop scaffold roll-up aggregate records from one assembled turn stream.
 
     OpenClaw's turn-finalization bookkeeping appends an AGGREGATE assistant
-    record after a block of per-call records: no ``responseId``, stopReason
-    ``stop``, no toolCalls, and a ``totalTokens`` FROZEN at the previous
-    record's value (its usage restates the block it closes, not a new API
-    call). Keeping it double-counts every usage field — ~23M phantom
-    ``cache_read`` tokens on one real CRUX capture — so a record matching the
-    full signature against the previously KEPT turn is dropped, with an info
-    log of how many. The signature is deliberately conjunctive: a turn with a
-    ``responseId``, a non-``stop`` stopReason, any toolCall, or a moving
-    ``totalTokens`` is never touched.
+    record after a block of per-call records. Its signature — deliberately
+    conjunctive, all five conditions — against the previously KEPT turn: no
+    ``responseId``, stopReason ``stop``, no toolCalls, a ``totalTokens``
+    FROZEN at the previous record's value, and usage that is NOT internally
+    consistent. A genuine per-call record satisfies ``input + output +
+    cacheRead + cacheWrite == totalTokens`` (verified for every turn across
+    the real captures; see :func:`.extraction.usage_to_inspect`), while an
+    aggregate's components SUM the block it closes against that stale total,
+    breaking the identity. Keeping one double-counts every usage field — ~23M
+    phantom ``cache_read`` tokens on one real CRUX capture.
+
+    The consistency condition keeps the genuine turns the frozen-total
+    comparison alone would delete on rid-less (service-sink) captures: a
+    text-only reply that happens to repeat the previous total, and adjacent
+    zero-usage provider-failure placeholders (``0 == 0+0+0+0``).
+
+    ``turns`` must be a SINGLE surface's (or a single sub-agent session's)
+    stream: callers group per session kind / per session first, so a turn
+    interleaved from another surface cannot sit between a block's closing
+    record and its roll-up and mask the frozen-total comparison.
     """
 
     def _is_rollup(turn: dict[str, Any], prev: dict[str, Any] | None) -> bool:
@@ -213,11 +225,13 @@ def _drop_rollup_aggregates(
             return False
         total = (turn.get("usage") or {}).get("totalTokens")
         prev_total = (prev.get("usage") or {}).get("totalTokens")
-        return total is not None and total == prev_total
+        if total is None or total != prev_total:
+            return False
+        return tokens_from_usage(turn.get("usage")) != total
 
     kept: list[dict[str, Any]] = []
     n_rollups = 0
-    for turn in orchestrator_turns:
+    for turn in turns:
         if _is_rollup(turn, kept[-1] if kept else None):
             n_rollups += 1
             continue
@@ -225,7 +239,7 @@ def _drop_rollup_aggregates(
     if n_rollups:
         logger.info(
             "Dropped %d scaffold roll-up aggregate record(s) whose usage "
-            "duplicates the preceding per-call records",
+            "restates the preceding per-call records",
             n_rollups,
         )
     return kept
@@ -239,15 +253,23 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
     """
     c = _consolidate(raw_events)
 
-    orchestrator_turns = _drop_rollup_aggregates(
-        sorted(
-            (
-                c.assistant_by_id[rid]
-                for rid, kind in c.assistant_kind.items()
-                if is_orchestrator(kind)
-            ),
-            key=lambda m: int(m.get("timestamp") or 0),
-        )
+    # The roll-up filter runs per surface: an aggregate closes a block on ITS
+    # surface, so a turn interleaved from another orchestrator surface (real
+    # captures mix e.g. main/telegram/cron) must not sit between a block's
+    # closing record and its roll-up and mask the frozen-total comparison.
+    turns_by_surface: dict[str, list[dict[str, Any]]] = {}
+    for rid, kind in c.assistant_kind.items():
+        if is_orchestrator(kind):
+            turns_by_surface.setdefault(kind, []).append(c.assistant_by_id[rid])
+    orchestrator_turns = sorted(
+        (
+            turn
+            for surface_turns in turns_by_surface.values()
+            for turn in _drop_rollup_aggregates(
+                sorted(surface_turns, key=lambda m: int(m.get("timestamp") or 0))
+            )
+        ),
+        key=lambda m: int(m.get("timestamp") or 0),
     )
 
     # Keyed turns are canonical; a keyless turn whose text matches a keyed one is
@@ -286,21 +308,26 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
                 args = tc.get("arguments")
                 child_to_spawn_args[csk] = args if isinstance(args, dict) else {}
 
-    subagents = [
-        SubagentSpan(
-            session_key=sk,
-            prompt=s.get("prompt"),
-            n_tool_calls=s.get("n_tool_calls", 0),
-            n_assistant_turns=s.get("n_assistant_turns", 0),
-            spawn_tool_call_id=child_to_toolcall.get(sk),
-            spawn_label=(child_to_spawn_args.get(sk) or {}).get("label"),
-            spawn_task=(child_to_spawn_args.get(sk) or {}).get("task"),
-            turns=s.get("turns", []),
-            tool_calls=s.get("tool_calls", []),
-            anchor_ts=s.get("anchor_ts", 0),
+    subagents = []
+    for sk, s in c.sessions.items():
+        # The same scaffold finalizes sub-agent sessions, so their schema-A
+        # turns get the same roll-up filter (not yet observed inside real
+        # sub-agent sessions — defensive parity with the orchestrator).
+        turns = _drop_rollup_aggregates(s.get("turns", []))
+        subagents.append(
+            SubagentSpan(
+                session_key=sk,
+                prompt=s.get("prompt"),
+                n_tool_calls=s.get("n_tool_calls", 0),
+                n_assistant_turns=len(turns) if turns else s.get("n_assistant_turns", 0),
+                spawn_tool_call_id=child_to_toolcall.get(sk),
+                spawn_label=(child_to_spawn_args.get(sk) or {}).get("label"),
+                spawn_task=(child_to_spawn_args.get(sk) or {}).get("task"),
+                turns=turns,
+                tool_calls=s.get("tool_calls", []),
+                anchor_ts=s.get("anchor_ts", 0),
+            )
         )
-        for sk, s in c.sessions.items()
-    ]
 
     # Every assistant turn in valid telemetry-hal records its model. A missing
     # one means malformed / non-telemetry-hal input, so fail here — the single,

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -20,14 +20,20 @@ JSONL, one event per line. Payload-bearing events:
 - ``tool.start`` / ``tool.end`` are individual tool calls (the only place
   schema-B sub-agent activity is recorded).
 - ``sessionKey`` is ``agent:<...>:<kind>:<uuid>`` with ``kind`` one of ``main``,
-  ``telegram``, ``dashboard``, ``explicit`` (orchestrator surfaces — ``explicit``
-  is an explicitly-created session on the orchestrator agent, e.g. OpenClaw's
+  ``telegram``, ``dashboard``, ``cron``, ``explicit`` (orchestrator surfaces —
+  ``cron`` is the scheduler surface of a cron-scheduled run; ``explicit`` an
+  explicitly-created session on the orchestrator agent, e.g. OpenClaw's
   gateway-fallback path) or ``subagent`` (delegated work). Any other kind on a
   consumed event fails the import loudly rather than silently dropping that
   session's activity.
+- ``message.in`` is the inbound operator channel: each event carries the full
+  text of a message a human sent the agent mid-run. These are collected as
+  ``operator_messages`` so the mapping can stamp the corresponding user turns
+  ``source="operator"`` (and surface inbound messages that never entered the
+  session thread) — see :func:`events.build_content`.
 
-Intentionally NOT consumed: ``message.in`` / ``message.sending`` /
-``message.out`` (channel I/O). A sub-agent's final report is auto-announced as a
+Intentionally NOT consumed: ``message.sending`` / ``message.out`` (outbound
+channel I/O). A sub-agent's final report is auto-announced as a
 ``message.out`` on the orchestrator's outbound channel, but those events carry
 no ``sessionKey``, ``runId``, or ``agentId`` (and the spawn result is only an
 ``accepted`` ack), so a report cannot be deterministically attributed to the
@@ -138,6 +144,11 @@ class OpenClawTelemetry:
     session uuid for ``main``/``dashboard`` surfaces, but a chat id shared across
     runs for ``telegram``. It is therefore NOT unique per run on its own; the
     transcript layer combines it with the run's earliest timestamp.
+
+    ``operator_messages`` are the raw ``message.in`` events (inbound operator
+    channel), in file order. The mapping uses them to mark operator-delivered
+    user turns ``source="operator"`` and to surface inbound messages that never
+    entered the session thread.
     """
 
     orchestrator_turns: list[dict[str, Any]]
@@ -147,6 +158,7 @@ class OpenClawTelemetry:
     model_name: str | None
     subagents: list[SubagentSpan]
     session_id: str | None
+    operator_messages: list[dict[str, Any]] = field(default_factory=list)
 
 
 def _primary_model(orchestrator_turns: list[dict[str, Any]]) -> str | None:
@@ -252,6 +264,7 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
         model_name=_primary_model(orchestrator_turns),
         subagents=subagents,
         session_id=c.session_id,
+        operator_messages=c.message_ins,
     )
 
 
@@ -271,6 +284,7 @@ class _Consolidated:
     user_by_idempotency: dict[str, dict[str, Any]] = field(default_factory=dict)
     user_by_key: dict[Any, dict[str, Any]] = field(default_factory=dict)
     sessions: dict[str, dict[str, Any]] = field(default_factory=dict)
+    message_ins: list[dict[str, Any]] = field(default_factory=list)
     session_id: str | None = None
 
 
@@ -338,6 +352,12 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
         if not isinstance(ev, dict):
             continue
         t = ev.get("type")
+        # The inbound operator channel: collect message.in events whole (they
+        # carry no sessionKey — the mapping matches them to user turns by
+        # content, see ``events.build_content``).
+        if t == "message.in":
+            out.message_ins.append(ev)
+            continue
         sk = ev.get("sessionKey", "")
         kind = session_kind(sk)
         is_agent = t in ("agent.start", "agent.end")
@@ -345,9 +365,9 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
         # The events the importer consumes must classify as orchestrator or
         # sub-agent. Any other kind — a surface we have not seen (e.g. another
         # chat channel), or an absent/malformed sessionKey — would silently
-        # drop that session's activity, so fail loudly instead. (``message.*``
-        # events carry no sessionKey and are intentionally not consumed, so
-        # they are not checked.)
+        # drop that session's activity, so fail loudly instead. (The outbound
+        # ``message.sending``/``message.out`` events carry no sessionKey and
+        # are intentionally not consumed, so they are not checked.)
         if (is_agent or t in ("tool.start", "tool.end")) and not (
             is_orchestrator(kind) or kind == SUBAGENT_KIND
         ):

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -188,6 +188,19 @@ def _primary_model(orchestrator_turns: list[dict[str, Any]]) -> str | None:
     return winner[0][0] if winner else None
 
 
+def _int_or_none(value: Any) -> int | None:
+    """Coerce a telemetry numeric field to ``int``, else ``None``.
+
+    Conformant telemetry-hal records integers, but the values come verbatim
+    out of ``json.loads``, so a numeric string is coerced and anything else
+    yields ``None`` (callers treat that as unclassifiable, never as a match).
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _drop_rollup_aggregates(
     turns: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -224,11 +237,23 @@ def _drop_rollup_aggregates(
             return False
         if toolcalls_of(turn.get("content")):
             return False
-        total = (turn.get("usage") or {}).get("totalTokens")
-        prev_total = (prev.get("usage") or {}).get("totalTokens")
-        if total is None or total != prev_total:
+        # Coerce totals before comparing: raw json.loads output can carry a
+        # numeric STRING, and an un-coerced comparison would pass the frozen
+        # gate ("950" == "950") yet break the int-summed identity below,
+        # deleting a genuine turn. Non-numeric totals are unclassifiable.
+        usage = turn.get("usage") or {}
+        total = _int_or_none(usage.get("totalTokens"))
+        prev_total = _int_or_none((prev.get("usage") or {}).get("totalTokens"))
+        if total is None or prev_total is None or total != prev_total:
             return False
-        return bool(tokens_from_usage(turn.get("usage")) != total)
+        # A usage with no component fields gives the identity nothing to
+        # classify (its sum is 0 on genuine turns of that shape too): keep —
+        # the filter drops only on positive evidence of restated usage.
+        if all(
+            usage.get(k) is None for k in ("input", "output", "cacheRead", "cacheWrite")
+        ):
+            return False
+        return bool(tokens_from_usage(usage) != total)
 
     kept: list[dict[str, Any]] = []
     n_rollups = 0

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -227,7 +227,7 @@ def _drop_rollup_aggregates(
         prev_total = (prev.get("usage") or {}).get("totalTokens")
         if total is None or total != prev_total:
             return False
-        return tokens_from_usage(turn.get("usage")) != total
+        return bool(tokens_from_usage(turn.get("usage")) != total)
 
     kept: list[dict[str, Any]] = []
     n_rollups = 0
@@ -319,7 +319,9 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
                 session_key=sk,
                 prompt=s.get("prompt"),
                 n_tool_calls=s.get("n_tool_calls", 0),
-                n_assistant_turns=len(turns) if turns else s.get("n_assistant_turns", 0),
+                n_assistant_turns=len(turns)
+                if turns
+                else s.get("n_assistant_turns", 0),
                 spawn_tool_call_id=child_to_toolcall.get(sk),
                 spawn_label=(child_to_spawn_args.get(sk) or {}).get("label"),
                 spawn_task=(child_to_spawn_args.get(sk) or {}).get("task"),

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -138,9 +138,10 @@ class OpenClawTelemetry:
     The whole-file consolidation (turns deduped, sub-agents reconstructed) lands
     here so the event/message mapping never touches the raw cumulative snapshots.
 
-    ``orchestrator_turns`` are the deduped main/telegram assistant turns in
-    timestamp order (each a raw OpenClaw message dict with ``content``,
-    ``usage``, ``timestamp``, ``model``). ``compactions`` are the orchestrator's
+    ``orchestrator_turns`` are the deduped assistant turns of every
+    orchestrator surface (``main``/``telegram``/``dashboard``/``cron``/
+    ``explicit``) in timestamp order (each a raw OpenClaw message dict with
+    ``content``, ``usage``, ``timestamp``, ``model``). ``compactions`` are the orchestrator's
     real ``compactionSummary`` turns (a sub-agent's own compactions are dropped
     with a warning). ``result_by_callid`` maps a toolCall id to its
     :class:`ToolResult` (text + success/error + completion time).
@@ -307,20 +308,25 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
         key=turn_sort_key,
     )
 
-    # Keyed turns are canonical; a keyless turn whose text matches a keyed one is
-    # that prompt's transient first-snapshot serialization, so drop it. Keyless
-    # turns with no keyed twin (runtime context, inter-session messages, keyless
-    # human prompts) are kept.
-    keyed_texts = {
-        content_to_text(m.get("content")) for m in c.user_by_idempotency.values()
-    }
+    # Keyed turns are canonical; a keyless turn whose text matches a keyed one
+    # FROM ITS OWN SESSION is that prompt's transient first-snapshot
+    # serialization, so drop it — the transient and settled forms are the same
+    # session re-serializing its own prompt, so a same-text prompt in another
+    # session is a distinct turn. Keyless turns with no keyed twin (runtime
+    # context, inter-session messages, keyless human prompts) are kept.
+    keyed_texts_by_session: dict[str, set[str]] = {}
+    for idem, keyed_turn in c.user_by_idempotency.items():
+        keyed_texts_by_session.setdefault(
+            c.user_session_by_idempotency[idem], set()
+        ).add(content_to_text(keyed_turn.get("content")))
     user_turns = sorted(
         (
             *c.user_by_idempotency.values(),
             *(
                 m
-                for m in c.user_by_key.values()
-                if content_to_text(m.get("content")) not in keyed_texts
+                for (user_sk, _ts, _content), m in c.user_by_key.items()
+                if content_to_text(m.get("content"))
+                not in keyed_texts_by_session.get(user_sk, set())
             ),
         ),
         key=lambda m: int(m.get("timestamp") or 0),
@@ -404,6 +410,7 @@ class _Consolidated:
     result_by_callid: dict[str, ToolResult] = field(default_factory=dict)
     compactions: dict[Any, dict[str, Any]] = field(default_factory=dict)
     user_by_idempotency: dict[str, dict[str, Any]] = field(default_factory=dict)
+    user_session_by_idempotency: dict[str, str] = field(default_factory=dict)
     user_by_key: dict[Any, dict[str, Any]] = field(default_factory=dict)
     sessions: dict[str, dict[str, Any]] = field(default_factory=dict)
     message_ins: list[dict[str, Any]] = field(default_factory=list)
@@ -456,8 +463,8 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
        deduped by ``responseId`` (recording each turn's first-occurrence session
        kind), ``toolResult``s by ``toolCallId``, and orchestrator-only
        ``compactionSummary``s and ``user`` turns. Turns and user prompts with no
-       ``responseId`` are keyed by ``(timestamp, content)`` since they recur
-       across cumulative snapshots.
+       ``responseId`` are keyed by ``(session, timestamp, content)`` since they
+       recur across their own session's cumulative snapshots.
 
     2. Sub-agent reconstruction, robust across both export schemas. Schema A: the
        sub-agent's assistant turns live in its own ``agent.* messages[]`` (with
@@ -549,15 +556,22 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
                     # and a settled form carrying a stable ``idempotencyKey``
                     # (the inbound message id). Dedup keyed turns by that id (the
                     # user-turn analogue of ``responseId``); fall back to
-                    # (timestamp, content) only for genuinely keyless turns
-                    # (runtime context, inter-session messages, and human prompts
-                    # that arrived without a key). The transient twins are dropped
-                    # against the keyed set in ``parse_telemetry``.
+                    # (session, timestamp, content) only for genuinely keyless
+                    # turns (runtime context, inter-session messages, and human
+                    # prompts that arrived without a key) — session-scoped for
+                    # the same reason as the assistant key: re-dumps come from
+                    # the turn's own session, while two concurrent sessions can
+                    # genuinely coincide on (timestamp, content). The transient
+                    # twins are dropped against their own session's keyed set
+                    # in ``parse_telemetry``.
                     idem = m.get("idempotencyKey")
                     if idem is not None:
-                        out.user_by_idempotency.setdefault(idem, m)
+                        if idem not in out.user_by_idempotency:
+                            out.user_by_idempotency[idem] = m
+                            out.user_session_by_idempotency[idem] = sk
                     else:
                         key = (
+                            sk,
                             m.get("timestamp"),
                             json.dumps(m.get("content"), sort_keys=True, default=str),
                         )
@@ -577,9 +591,9 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
                         )
                 elif role == "compactionSummary":
                     if is_orchestrator(kind):
-                        key = (m.get("timestamp"), "compaction")
-                        if key not in out.compactions:
-                            out.compactions[key] = m
+                        compaction_key = (m.get("timestamp"), "compaction")
+                        if compaction_key not in out.compactions:
+                            out.compactions[compaction_key] = m
                     elif sk not in warned_compaction_sessions:
                         # A sub-agent compacting its own thread — never observed
                         # in the sample captures (all 467 CRUX1 compactions are
@@ -613,8 +627,8 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
                 if rid is None:
                     # No responseId (absent from service-sink captures: the
                     # datasets that carry a seq/ts envelope). Key by
-                    # (timestamp, id-masked content) so the SAME turn re-dumped
-                    # across cumulative snapshots — including with
+                    # (session, timestamp, id-masked content) so the SAME turn
+                    # re-dumped across cumulative snapshots — including with
                     # sanitizer-rewritten toolCall ids — collapses to one.
                     rid = (
                         "a",

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -14,9 +14,9 @@ JSONL, one event per line. Payload-bearing events:
   ``messages[]`` snapshot (assistant turns, ``toolResult``s,
   ``compactionSummary``s). The same turn recurs across snapshots, so turns must
   be deduped by ``responseId`` — or, when the capture carries none, by
-  ``(timestamp, content)`` with toolCall ids masked, because OpenClaw's history
-  sanitizer rewrites those ids between a turn's first snapshot and all later
-  ones (see :func:`_keyless_content_json`). Snapshots may also carry scaffold
+  ``(session, timestamp, content)`` with toolCall ids masked, because
+  OpenClaw's history sanitizer rewrites those ids between a turn's first
+  snapshot and all later ones (see :func:`_keyless_content_json`). Snapshots may also carry scaffold
   *roll-up* records — turn-finalization aggregates whose usage restates (sums)
   the preceding per-call block; these are dropped (see
   :func:`_drop_rollup_aggregates`).
@@ -210,10 +210,11 @@ def _drop_rollup_aggregates(
     text-only reply that happens to repeat the previous total, and adjacent
     zero-usage provider-failure placeholders (``0 == 0+0+0+0``).
 
-    ``turns`` must be a SINGLE surface's (or a single sub-agent session's)
-    stream: callers group per session kind / per session first, so a turn
-    interleaved from another surface cannot sit between a block's closing
-    record and its roll-up and mask the frozen-total comparison.
+    ``turns`` must be a SINGLE session's stream: callers group per
+    ``sessionKey`` (or per sub-agent session) first, so a turn interleaved
+    from another session — another surface, or another concurrent session of
+    the same kind — cannot sit between a block's closing record and its
+    roll-up and mask the frozen-total comparison.
     """
 
     def _is_rollup(turn: dict[str, Any], prev: dict[str, Any] | None) -> bool:
@@ -253,23 +254,32 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
     """
     c = _consolidate(raw_events)
 
-    # The roll-up filter runs per surface: an aggregate closes a block on ITS
-    # surface, so a turn interleaved from another orchestrator surface (real
-    # captures mix e.g. main/telegram/cron) must not sit between a block's
-    # closing record and its roll-up and mask the frozen-total comparison.
-    turns_by_surface: dict[str, list[dict[str, Any]]] = {}
+    # The roll-up filter runs per SESSION: an aggregate closes a block within
+    # its own session's message stream, so a turn interleaved from any OTHER
+    # session — another surface, or another session of the same kind (real
+    # captures carry hundreds of concurrent cron sessions) — must not sit
+    # between a block's closing record and its roll-up and mask the
+    # frozen-total comparison. Timestamp ties keep file order through the
+    # regroup (``_primary_model``'s first-seen tie-break reads this ordering).
+    file_order = {id(m): i for i, m in enumerate(c.assistant_by_id.values())}
+
+    def turn_sort_key(m: dict[str, Any]) -> tuple[int, int]:
+        return (int(m.get("timestamp") or 0), file_order[id(m)])
+
+    turns_by_session: dict[str, list[dict[str, Any]]] = {}
     for rid, kind in c.assistant_kind.items():
         if is_orchestrator(kind):
-            turns_by_surface.setdefault(kind, []).append(c.assistant_by_id[rid])
+            session = c.assistant_session[rid]
+            turns_by_session.setdefault(session, []).append(c.assistant_by_id[rid])
     orchestrator_turns = sorted(
         (
             turn
-            for surface_turns in turns_by_surface.values()
+            for session_turns in turns_by_session.values()
             for turn in _drop_rollup_aggregates(
-                sorted(surface_turns, key=lambda m: int(m.get("timestamp") or 0))
+                sorted(session_turns, key=turn_sort_key)
             )
         ),
-        key=lambda m: int(m.get("timestamp") or 0),
+        key=turn_sort_key,
     )
 
     # Keyed turns are canonical; a keyless turn whose text matches a keyed one is
@@ -365,6 +375,7 @@ class _Consolidated:
 
     assistant_by_id: dict[Any, dict[str, Any]] = field(default_factory=dict)
     assistant_kind: dict[Any, str] = field(default_factory=dict)
+    assistant_session: dict[Any, str] = field(default_factory=dict)
     result_by_callid: dict[str, ToolResult] = field(default_factory=dict)
     compactions: dict[Any, dict[str, Any]] = field(default_factory=dict)
     user_by_idempotency: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -483,17 +494,24 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
                     rid: Any = m.get("responseId")
                     if rid is None:
                         # No responseId (absent from service-sink captures). Key
-                        # by (timestamp, id-masked content) so the SAME turn
-                        # re-dumped across cumulative snapshots — including with
-                        # sanitizer-rewritten toolCall ids — collapses to one.
+                        # by (session, timestamp, id-masked content) so the SAME
+                        # turn re-dumped across cumulative snapshots — including
+                        # with sanitizer-rewritten toolCall ids — collapses to
+                        # one. Re-dumps always come from the turn's own session,
+                        # so the session in the key never blocks that collapse;
+                        # without it, two GENUINE turns from two concurrent
+                        # sessions coinciding on (timestamp, content) would
+                        # wrongly merge.
                         rid = (
                             "a",
+                            sk,
                             m.get("timestamp"),
                             _keyless_content_json(m.get("content")),
                         )
                     if rid not in out.assistant_by_id:
                         out.assistant_by_id[rid] = m
                         out.assistant_kind[rid] = kind
+                        out.assistant_session[rid] = sk
                     if is_orchestrator(kind):
                         # Advance the file-order anchor cursor: sub-agent
                         # sessions first seen after this point anchor here.

--- a/examples/sources/openclaw_telemetry_hal/parse.py
+++ b/examples/sources/openclaw_telemetry_hal/parse.py
@@ -16,7 +16,10 @@ JSONL, one event per line. Payload-bearing events:
   be deduped by ``responseId`` — or, when the capture carries none, by
   ``(timestamp, content)`` with toolCall ids masked, because OpenClaw's history
   sanitizer rewrites those ids between a turn's first snapshot and all later
-  ones (see :func:`_keyless_content_json`).
+  ones (see :func:`_keyless_content_json`). Snapshots may also carry scaffold
+  *roll-up* records — turn-finalization aggregates whose usage duplicates the
+  preceding per-call records; these are dropped (see
+  :func:`_drop_rollup_aggregates`).
 - ``tool.start`` / ``tool.end`` are individual tool calls (the only place
   schema-B sub-agent activity is recorded).
 - ``sessionKey`` is ``agent:<...>:<kind>:<uuid>`` with ``kind`` one of ``main``,
@@ -107,6 +110,12 @@ class SubagentSpan:
     ``turns`` are the sub-agent's own assistant turn messages (schema A);
     ``tool_calls`` are its ``tool.*`` calls (schema B). Both feed the
     reconstruction of the sub-agent's activity inside its agent span.
+
+    ``anchor_ts`` is the session's *file-order anchor*: the timestamp of the
+    latest orchestrator assistant turn seen before the session's first event.
+    A session with no linkable spawn call (``spawn_tool_call_id`` is None —
+    e.g. cron/system-spawned sub-agents) is placed in the timeline at this
+    anchor instead of being dropped; see :func:`events.build_content`.
     """
 
     session_key: str
@@ -118,6 +127,7 @@ class SubagentSpan:
     spawn_task: str | None  # the spawn's ``task`` arg (the delegated instruction)
     turns: list[dict[str, Any]]  # schema-A assistant turns (in file order)
     tool_calls: list[dict[str, Any]]  # schema-B tool.* calls (in file order)
+    anchor_ts: int = 0  # latest orchestrator turn ts before first activity
 
 
 @dataclass
@@ -177,6 +187,50 @@ def _primary_model(orchestrator_turns: list[dict[str, Any]]) -> str | None:
     return winner[0][0] if winner else None
 
 
+def _drop_rollup_aggregates(
+    orchestrator_turns: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop scaffold roll-up aggregate records from the assembled turns.
+
+    OpenClaw's turn-finalization bookkeeping appends an AGGREGATE assistant
+    record after a block of per-call records: no ``responseId``, stopReason
+    ``stop``, no toolCalls, and a ``totalTokens`` FROZEN at the previous
+    record's value (its usage restates the block it closes, not a new API
+    call). Keeping it double-counts every usage field — ~23M phantom
+    ``cache_read`` tokens on one real CRUX capture — so a record matching the
+    full signature against the previously KEPT turn is dropped, with an info
+    log of how many. The signature is deliberately conjunctive: a turn with a
+    ``responseId``, a non-``stop`` stopReason, any toolCall, or a moving
+    ``totalTokens`` is never touched.
+    """
+
+    def _is_rollup(turn: dict[str, Any], prev: dict[str, Any] | None) -> bool:
+        if prev is None or turn.get("responseId") is not None:
+            return False
+        if (turn.get("stopReason") or "stop") != "stop":
+            return False
+        if toolcalls_of(turn.get("content")):
+            return False
+        total = (turn.get("usage") or {}).get("totalTokens")
+        prev_total = (prev.get("usage") or {}).get("totalTokens")
+        return total is not None and total == prev_total
+
+    kept: list[dict[str, Any]] = []
+    n_rollups = 0
+    for turn in orchestrator_turns:
+        if _is_rollup(turn, kept[-1] if kept else None):
+            n_rollups += 1
+            continue
+        kept.append(turn)
+    if n_rollups:
+        logger.info(
+            "Dropped %d scaffold roll-up aggregate record(s) whose usage "
+            "duplicates the preceding per-call records",
+            n_rollups,
+        )
+    return kept
+
+
 def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
     """Parse raw OpenClaw telemetry events into the consolidated intermediate.
 
@@ -185,13 +239,15 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
     """
     c = _consolidate(raw_events)
 
-    orchestrator_turns = sorted(
-        (
-            c.assistant_by_id[rid]
-            for rid, kind in c.assistant_kind.items()
-            if is_orchestrator(kind)
-        ),
-        key=lambda m: int(m.get("timestamp") or 0),
+    orchestrator_turns = _drop_rollup_aggregates(
+        sorted(
+            (
+                c.assistant_by_id[rid]
+                for rid, kind in c.assistant_kind.items()
+                if is_orchestrator(kind)
+            ),
+            key=lambda m: int(m.get("timestamp") or 0),
+        )
     )
 
     # Keyed turns are canonical; a keyless turn whose text matches a keyed one is
@@ -241,6 +297,7 @@ def parse_telemetry(raw_events: Iterable[dict[str, Any]]) -> OpenClawTelemetry:
             spawn_task=(child_to_spawn_args.get(sk) or {}).get("task"),
             turns=s.get("turns", []),
             tool_calls=s.get("tool_calls", []),
+            anchor_ts=s.get("anchor_ts", 0),
         )
         for sk, s in c.sessions.items()
     ]
@@ -346,6 +403,7 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
        yields a real id.
     """
     out = _Consolidated()
+    orch_cursor = 0  # latest orchestrator assistant ts seen so far (file order)
     seen_subagent_rids: set[Any] = set()
     warned_compaction_sessions: set[str] = set()
     for ev in raw_events:
@@ -407,6 +465,12 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
                     if rid not in out.assistant_by_id:
                         out.assistant_by_id[rid] = m
                         out.assistant_kind[rid] = kind
+                    if is_orchestrator(kind):
+                        # Advance the file-order anchor cursor: sub-agent
+                        # sessions first seen after this point anchor here.
+                        turn_ts = int(m.get("timestamp") or 0)
+                        if turn_ts > orch_cursor:
+                            orch_cursor = turn_ts
                 elif role == "user" and is_orchestrator(kind):
                     # OpenClaw re-serializes a human prompt across snapshots: a
                     # transient first-snapshot form (no key, structured content)
@@ -461,7 +525,12 @@ def _consolidate(raw_events: Iterable[dict[str, Any]]) -> _Consolidated:
         # (2) sub-agent reconstruction.
         if kind != SUBAGENT_KIND:
             continue
-        s = out.sessions.setdefault(sk, _new_session())
+        if sk not in out.sessions:
+            out.sessions[sk] = _new_session()
+            # File-order anchor: where a session with no linkable spawn call
+            # (e.g. cron/system-spawned) is placed in the timeline.
+            out.sessions[sk]["anchor_ts"] = orch_cursor
+        s = out.sessions[sk]
         if is_agent:
             if t == "agent.start" and ev.get("prompt") and not s["prompt"]:
                 s["prompt"] = ev["prompt"]

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -1570,6 +1570,63 @@ class TestSpawnlessSubagents:
         span = next(e for e in events if isinstance(e, SpanBeginEvent))
         assert span.name == "Run the smaller grids first."
 
+    def test_mid_line_task_tag_detected(self) -> None:
+        # The tag can share its line with the timestamp preamble; prefix-only
+        # detection would skip the whole line as bracket boilerplate and name
+        # the span from a later body line.
+        raw = self._raw()
+        raw[1] = dict(
+            raw[1],
+            prompt=(
+                "[Fri 2026-03-06 13:08 PST] [Subagent Task]: Check the unread queue\n"
+                "\n"
+                "Report back with anything unread."
+            ),
+        )
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Check the unread queue"
+
+    def test_bare_tag_lookahead_skips_bracketed_lines(self) -> None:
+        # The task-on-next-line lookahead applies the same bracket/boilerplate
+        # skip as the fallback: an unrecognized bracket line (workspace tags,
+        # template placeholders) never becomes a span name.
+        raw = self._raw()
+        raw[1] = dict(
+            raw[1],
+            prompt=(
+                "[Subagent Task]\n"
+                "[workspace: /tmp/run-42]\n"
+                "Run the smaller grids first.\n"
+            ),
+        )
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Run the smaller grids first."
+
+    def test_bare_tag_defers_to_later_inline_tag(self) -> None:
+        # Real prompts repeat the tag — a bare heading first, the
+        # task-carrying tag line after (the dominant shape on both real
+        # captures). The bare tag's lookahead must stop at the next tag line
+        # and defer to it, not skip it as bracket noise and name the span
+        # from later body text.
+        raw = self._raw()
+        raw[1] = dict(
+            raw[1],
+            prompt=(
+                "[Subagent Context] You are running as a subagent.\n"
+                "\n"
+                "[Subagent Task]\n"
+                "\n"
+                "[Subagent Task]: Sweep the smaller grids\n"
+                "\n"
+                "Report back when done."
+            ),
+        )
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Sweep the smaller grids"
+
     def test_duplicate_spawn_claim_warns_and_places_by_anchor(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -1655,7 +1712,7 @@ class TestRollupAggregates:
         rid: str | None,
         ts: int,
         text: str,
-        usage: dict[str, int],
+        usage: dict[str, Any],
         stop: str = "stop",
         tool_call: bool = False,
     ) -> dict[str, Any]:
@@ -1949,6 +2006,45 @@ class TestRollupAggregates:
         assert sub_usage is not None
         assert sub_usage.total_tokens == 950
 
+    def test_string_total_tokens_coerced_not_identity_broken(self) -> None:
+        # totalTokens as a numeric string (raw-JSON hazard): "950" == "950"
+        # passes the frozen-total gate, and an un-coerced identity comparison
+        # (int sum != str total) would delete the second GENUINE turn. Totals
+        # are coerced before comparing, so the self-consistent turn is kept —
+        # while a real block-sum roll-up with string totals is still dropped.
+        genuine = {"input": 10, "output": 40, "cacheRead": 900, "totalTokens": "950"}
+        parse = self._parse(
+            [
+                self._turn(rid=None, ts=1000, text="A1", usage=dict(genuine)),
+                self._turn(rid=None, ts=1500, text="A2", usage=dict(genuine)),
+                self._turn(
+                    rid=None,
+                    ts=2000,
+                    text="A2",
+                    usage={
+                        "input": 20,
+                        "output": 80,
+                        "cacheRead": 1800,
+                        "totalTokens": "950",
+                    },
+                ),
+            ]
+        )
+        texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
+        assert texts == ["A1", "A2"]
+
+    def test_component_less_usage_is_unclassifiable_and_kept(self) -> None:
+        # A usage carrying ONLY totalTokens gives the identity nothing to
+        # classify (components sum to 0 on genuine turns of that shape too),
+        # so the record is kept rather than treated as identity-broken.
+        parse = self._parse(
+            [
+                self._turn(rid=None, ts=1000, text="A1", usage={"totalTokens": 950}),
+                self._turn(rid=None, ts=1500, text="A2", usage={"totalTokens": 950}),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+
     def test_moving_total_tokens_is_kept(self) -> None:
         # A rid-less 'stop' record whose totalTokens MOVED is a real turn
         # (service-sink captures have no responseId at all) — never dropped.
@@ -2234,6 +2330,57 @@ class TestOperatorChannel:
         aside = [m for m in messages if m.role == "user" and m.text == "secret aside"]
         assert len(aside) == 1
         assert aside[0].source == "operator"
+
+    def test_empty_send_does_not_stamp_media_only_turn(self) -> None:
+        # A content-less message.in (media-only send) flattens to "" — as
+        # does an image-only user turn. Empty text must not participate in
+        # the pairing join: the turn stays unstamped and the send surfaces
+        # standalone.
+        raw: list[dict[str, Any]] = [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "",
+                "timestamp": 900,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {
+                        "role": "user",
+                        "timestamp": 1000,
+                        "content": [{"type": "image", "data": "iVBORw0KGgo="}],
+                    },
+                ],
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 2
+        assert [m.source for m in users] == ["operator", None]
+
+    def test_ts_less_turn_still_matched_by_text(self) -> None:
+        # A user turn with no timestamp cannot fail the at-or-after check: it
+        # is always eligible (the pre-pairing set semantics matched it, and a
+        # standalone duplicate would be worse than a loose match).
+        raw: list[dict[str, Any]] = [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "hello",
+                "timestamp": 900,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 1
+        assert users[0].source == "operator"
 
     def test_fixture_prompts_carry_operator_source(
         self, raw_events: list[dict[str, Any]]

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -50,6 +50,7 @@ from ..extraction import (
 )
 from ..parse import (
     OpenClawTelemetry,
+    SubagentSpan,
     parse_telemetry,
 )
 
@@ -1274,6 +1275,20 @@ class TestSchemaBSubagents:
         tool = self._tool_event(events)
         assert tool.completed == tool.timestamp
 
+    def test_schema_b_malformed_duration_ms_survives(self) -> None:
+        # ``durationMs`` comes verbatim out of json.loads: a numeric string
+        # still yields a width; a non-numeric or negative value degrades to
+        # zero width — never a TypeError that aborts the whole import (and a
+        # negative never places ``completed`` before ``timestamp``).
+        for bad, width in (("250", 0.25), ("bogus", 0.0), (-500, 0.0)):
+            raw = self._raw(success=True, ts=False)
+            end = next(e for e in raw if e.get("type") == "tool.end")
+            end["durationMs"] = bad
+            events = build_events(parse_telemetry(raw))
+            tool = self._tool_event(events)
+            assert tool.completed is not None
+            assert (tool.completed - tool.timestamp).total_seconds() == width
+
     def test_schema_b_tool_failure_surfaced(self) -> None:
         # A tool.end with success=false is a real failure: the standard
         # failed/error fields are populated (not left None) and carry the
@@ -1358,10 +1373,13 @@ class TestSpawnlessSubagents:
         assert parse.subagents[0].anchor_ts == 2000
         with caplog.at_level(logging.INFO):
             events = build_events(parse)
-        # Placed between A1 and A3 — not dropped, and reported at info level.
+        # Placed immediately AFTER its anchor turn A2 (the latest orchestrator
+        # turn seen, in file order, before the session's first event): the
+        # orchestrator had already produced A2 when the session appeared, so
+        # the span belongs on A2's far side. Reported at info level.
         span = next(e for e in events if isinstance(e, SpanBeginEvent))
         roots = [e for e in events if isinstance(e, ModelEvent)]
-        assert events.index(roots[0]) < events.index(span) < events.index(roots[2])
+        assert events.index(span) == events.index(roots[1]) + 1
         assert any(
             "file-order anchor" in r.getMessage() and self.CHILD in r.getMessage()
             for r in caplog.records
@@ -1401,6 +1419,142 @@ class TestSpawnlessSubagents:
         span = next(e for e in events if isinstance(e, SpanBeginEvent))
         first_model = next(e for e in events if isinstance(e, ModelEvent))
         assert events.index(span) < events.index(first_model)
+
+    def test_anchor_flush_precedes_interleaved_compaction(self) -> None:
+        # The anchor flush runs on every timeline item, so a span anchored
+        # before a compaction is emitted before that compaction, not swept
+        # past it to the next assistant turn.
+        orch = "agent:main:cron:orchestrator"
+        raw = [
+            {
+                "type": "agent.start",
+                "sessionKey": orch,
+                "messages": [self._turn("r1", 1000, "A1")],
+            },
+            {"type": "agent.start", "sessionKey": self.CHILD, "prompt": self.PROMPT},
+            {
+                "type": "tool.start",
+                "sessionKey": self.CHILD,
+                "toolName": "exec",
+                "params": {},
+            },
+            {
+                "type": "agent.end",
+                "sessionKey": orch,
+                "messages": [
+                    self._turn("r1", 1000, "A1"),
+                    {
+                        "role": "compactionSummary",
+                        "timestamp": 1500,
+                        "tokensBefore": 100,
+                    },
+                    self._turn("r2", 2000, "A2"),
+                ],
+            },
+        ]
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        compaction = next(e for e in events if isinstance(e, CompactionEvent))
+        assert events.index(span) < events.index(compaction)
+
+    def test_span_named_from_inline_subagent_task_tag(self) -> None:
+        # The fixture-shaped prompt announces the task INLINE after the
+        # "[Subagent Task]:" tag. The tag is authoritative — it must not be
+        # skipped as bracket boilerplate (which named the span from the later
+        # report-back line instead).
+        raw = self._raw()
+        raw[1] = dict(
+            raw[1],
+            prompt=(
+                "[Fri 2026-03-06 13:08 PST] [Subagent Context] You are running "
+                "as a subagent (depth 1/1). Results auto-announce to your "
+                "requester; do not busy-poll for status.\n"
+                "\n"
+                "[Subagent Task]: Check the unread queue\n"
+                "\n"
+                "Report back with anything unread."
+            ),
+        )
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Check the unread queue"
+
+    def test_span_named_from_line_after_bare_task_tag(self) -> None:
+        # The tag alone on its line: the task is the next non-empty line.
+        raw = self._raw()
+        raw[1] = dict(
+            raw[1],
+            prompt=(
+                "[Subagent Context] You are running as a subagent.\n"
+                "[Subagent Task]\n"
+                "Run the smaller grids first.\n"
+                "Then report back."
+            ),
+        )
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Run the smaller grids first."
+
+    def test_duplicate_spawn_claim_warns_and_places_by_anchor(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A second session claiming an already-claimed spawn call violates the
+        # documented 1:1 spawn->session mapping (corrupt/ambiguous linkage).
+        # It is anchor-placed like a spawn-less session, but the anomaly must
+        # surface at WARNING level — the normal cron pattern stays at info.
+        turn = {
+            "role": "assistant",
+            "responseId": "r1",
+            "timestamp": 1000,
+            "model": "m",
+            "content": [
+                {"type": "text", "text": "spawning"},
+                {
+                    "type": "toolCall",
+                    "id": "tc1",
+                    "name": "sessions_spawn",
+                    "arguments": {"label": "one"},
+                },
+            ],
+        }
+        def span_for(key: str) -> SubagentSpan:
+            return SubagentSpan(
+                session_key=key,
+                prompt=None,
+                n_tool_calls=0,
+                n_assistant_turns=0,
+                spawn_tool_call_id="tc1",
+                spawn_label="one",
+                spawn_task=None,
+                turns=[],
+                tool_calls=[],
+                anchor_ts=1000,
+            )
+        parse = OpenClawTelemetry(
+            orchestrator_turns=[turn],
+            user_turns=[],
+            compactions=[],
+            result_by_callid={},
+            model_name="m",
+            subagents=[
+                span_for("agent:main:subagent:claim-1"),
+                span_for("agent:main:subagent:claim-2"),
+            ],
+            session_id="s",
+        )
+        with caplog.at_level(logging.WARNING):
+            events = build_events(parse)
+        spans = {e.id for e in events if isinstance(e, SpanBeginEvent)}
+        assert spans == {
+            "agent:main:subagent:claim-1",
+            "agent:main:subagent:claim-2",
+        }
+        assert any(
+            r.levelno == logging.WARNING
+            and "already claimed" in r.getMessage()
+            and "agent:main:subagent:claim-2" in r.getMessage()
+            for r in caplog.records
+        )
 
 
 class TestRollupAggregates:

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -1408,9 +1408,12 @@ class TestRollupAggregates:
 
     OpenClaw's turn-finalization bookkeeping appends an aggregate assistant
     record after a block of per-call records: no ``responseId``, stopReason
-    ``stop``, no toolCalls, and ``totalTokens`` frozen at the previous record's
-    value. Its usage restates the block it closes, so keeping it double-counts
-    every usage field (~23M phantom cache-read tokens on one real CRUX capture).
+    ``stop``, no toolCalls, ``totalTokens`` frozen at the previous record's
+    value, and usage components that SUM the block (breaking the per-call
+    identity ``input + output + cacheRead + cacheWrite == totalTokens``).
+    Keeping it double-counts every usage field (~23M phantom cache-read tokens
+    on one real CRUX capture). The filter runs per orchestrator surface and
+    per sub-agent session, so interleaving cannot mask the comparison.
     """
 
     ORCH = "agent:main:cron:orchestrator"
@@ -1448,13 +1451,29 @@ class TestRollupAggregates:
         )
 
     def test_rollup_dropped_and_usage_not_double_counted(self) -> None:
-        usage = {"input": 100, "output": 50, "cacheRead": 800, "totalTokens": 950}
         parse = self._parse(
             [
-                self._turn(rid="r1", ts=1000, text="A1", usage=usage),
+                self._turn(
+                    rid="r1",
+                    ts=1000,
+                    text="A1",
+                    usage={"input": 100, "output": 50, "cacheRead": 800, "totalTokens": 950},
+                ),
                 # The roll-up: rid-less, tool-less 'stop' record whose
-                # totalTokens is frozen at A1's value.
-                self._turn(rid=None, ts=1500, text="A1", usage=dict(usage)),
+                # totalTokens is frozen at A1's value while its components sum
+                # the block it closes (the shape observed on real captures).
+                self._turn(
+                    rid=None,
+                    ts=1500,
+                    text="A1",
+                    usage={
+                        "input": 105,
+                        "output": 220,
+                        "cacheRead": 1600,
+                        "cacheWrite": 40,
+                        "totalTokens": 950,
+                    },
+                ),
                 self._turn(
                     rid="r2",
                     ts=2000,
@@ -1471,9 +1490,160 @@ class TestRollupAggregates:
             if isinstance(e, ModelEvent) and e.output.usage is not None
         ]
         assert len(usages) == 2
-        # Without the drop these would be 1600 / 1915.
+        # Without the drop these would be 2400 / 1915.
         assert sum(u.input_tokens_cache_read or 0 for u in usages) == 800
         assert sum(u.total_tokens for u in usages) == 965
+
+    def test_genuine_turns_with_equal_totals_are_kept(self) -> None:
+        # On rid-less (service-sink) captures two consecutive genuine text-only
+        # replies can repeat a totalTokens value. A genuine per-call record is
+        # self-consistent (input + output + cacheRead + cacheWrite ==
+        # totalTokens), which a roll-up never is — so the frozen total alone
+        # must not delete the second real turn.
+        usage = {"input": 10, "output": 40, "cacheRead": 900, "totalTokens": 950}
+        parse = self._parse(
+            [
+                self._turn(rid=None, ts=1000, text="A1", usage=dict(usage)),
+                self._turn(rid=None, ts=1500, text="A2", usage=dict(usage)),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+
+    def test_adjacent_zero_usage_placeholders_are_kept(self) -> None:
+        # Adjacent provider-failure placeholders share totalTokens=0 but are
+        # self-consistent (0 == 0+0+0+0): both must survive the filter.
+        zero = {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "totalTokens": 0,
+        }
+        parse = self._parse(
+            [
+                self._turn(rid=None, ts=1000, text="[assistant turn failed]", usage=dict(zero)),
+                self._turn(rid=None, ts=1500, text="[assistant turn failed]", usage=dict(zero)),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+
+    def test_rollup_detected_across_interleaved_surfaces(self) -> None:
+        # A turn from another orchestrator surface lands between a block's
+        # closing per-call record and its roll-up (multi-surface captures are
+        # real). The filter runs per surface, so the interleaving must not
+        # mask the frozen-total comparison — and the other surface's genuine
+        # turn must survive.
+        telegram_turn = {
+            "role": "assistant",
+            "responseId": "t1",
+            "timestamp": 1200,
+            "model": "m",
+            "stopReason": "stop",
+            "content": [{"type": "text", "text": "T1"}],
+            "usage": {"input": 5, "output": 10, "cacheRead": 485, "totalTokens": 500},
+        }
+        parse = parse_telemetry(
+            [
+                {
+                    "type": "agent.start",
+                    "sessionKey": self.ORCH,
+                    "messages": [
+                        self._turn(
+                            rid="r1",
+                            ts=1000,
+                            text="A1",
+                            usage={
+                                "input": 100,
+                                "output": 50,
+                                "cacheRead": 800,
+                                "totalTokens": 950,
+                            },
+                        ),
+                        self._turn(
+                            rid=None,
+                            ts=1500,
+                            text="A1",
+                            usage={
+                                "input": 104,
+                                "output": 210,
+                                "cacheRead": 1650,
+                                "cacheWrite": 30,
+                                "totalTokens": 950,
+                            },
+                        ),
+                    ],
+                },
+                {
+                    "type": "agent.start",
+                    "sessionKey": "agent:main:telegram:chat-1",
+                    "messages": [telegram_turn],
+                },
+            ]
+        )
+        texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
+        assert texts == ["A1", "T1"]
+
+    def test_subagent_schema_a_rollup_dropped(self) -> None:
+        # Sub-agent sessions are finalized by the same scaffold, so a
+        # roll-up-shaped record inside a session's messages[] must not double
+        # the span's usage either.
+        sub = "agent:main:subagent:sub-roll"
+        per_call = {
+            "role": "assistant",
+            "responseId": "s1",
+            "timestamp": 1000,
+            "model": "m",
+            "stopReason": "stop",
+            "content": [{"type": "text", "text": "S1"}],
+            "usage": {"input": 20, "output": 40, "cacheRead": 890, "totalTokens": 950},
+        }
+        rollup = {
+            "role": "assistant",
+            "timestamp": 1500,
+            "model": "m",
+            "stopReason": "stop",
+            "content": [{"type": "text", "text": "S1"}],
+            "usage": {
+                "input": 22,
+                "output": 55,
+                "cacheRead": 1780,
+                "cacheWrite": 10,
+                "totalTokens": 950,
+            },
+        }
+        parse = parse_telemetry(
+            [
+                {
+                    "type": "agent.start",
+                    "sessionKey": self.ORCH,
+                    "messages": [
+                        self._turn(
+                            rid="r1",
+                            ts=500,
+                            text="A1",
+                            usage={"input": 1, "output": 4, "totalTokens": 5},
+                        )
+                    ],
+                },
+                {
+                    "type": "agent.start",
+                    "sessionKey": sub,
+                    "prompt": "do the thing",
+                    "messages": [per_call, rollup],
+                },
+            ]
+        )
+        assert len(parse.subagents) == 1
+        assert len(parse.subagents[0].turns) == 1
+        assert parse.subagents[0].n_assistant_turns == 1
+        events = build_events(parse)
+        sub_usages = [
+            e.output.usage
+            for e in events
+            if isinstance(e, ModelEvent) and e.span_id == sub
+        ]
+        assert len(sub_usages) == 1
+        assert sub_usages[0].total_tokens == 950
 
     def test_moving_total_tokens_is_kept(self) -> None:
         # A rid-less 'stop' record whose totalTokens MOVED is a real turn

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -1113,13 +1113,14 @@ class TestSchemaASubagents:
         assert len(exec_events) == 1
         assert exec_events[0].result == "file.txt"
 
-    def test_unlinked_subagent_dropped_with_warning(
+    def test_unlinked_subagent_placed_not_dropped(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         # A sub-agent whose spawn cannot be linked to a tool call (no
-        # childSessionKey resolvable to a spawn call) cannot be placed in the
-        # timeline, so it is dropped with a warning rather than guessed at. Not
-        # observed in the CRUX1 captures; this locks the fallback behaviour.
+        # childSessionKey resolvable to a spawn call) is placed by its
+        # file-order anchor with an info log, not dropped — cron/system-spawned
+        # sessions have no spawn call at all. Placement order and the
+        # no-fabricated-spawn invariant are locked in TestSpawnlessSubagents.
         child = "agent:run:subagent:orphan-1"
         raw = [
             {
@@ -1153,12 +1154,13 @@ class TestSchemaASubagents:
         parse = parse_telemetry(raw)
         assert len(parse.subagents) == 1
         assert parse.subagents[0].spawn_tool_call_id is None
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             events = build_events(parse)
-        # No span is emitted for the unlinked sub-agent, and it is reported.
-        assert not any(isinstance(e, SpanBeginEvent) for e in events)
+        # The unlinked sub-agent still gets its agent span, and is reported.
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.id == child
         assert any(
-            "no linkable spawn call" in r.getMessage() and child in r.getMessage()
+            "file-order anchor" in r.getMessage() and child in r.getMessage()
             for r in caplog.records
         )
 
@@ -1250,10 +1252,25 @@ class TestSchemaBSubagents:
         span_end = next(e for e in events if isinstance(e, SpanEndEvent))
         assert span_end.timestamp >= tool.completed
 
-    def test_schema_b_missing_ts_falls_back_to_spawn_time(self) -> None:
-        # Bare captures carry no ``ts``; the call is stamped with the spawn time
-        # (zero duration) rather than failing.
+    def test_schema_b_missing_ts_derives_width_from_duration_ms(self) -> None:
+        # Bare captures carry no ``ts``: the call is stamped at the spawn time,
+        # and ``durationMs`` (from tool.end) still gives it a real start->end
+        # width — downstream busy-time sums rely on it.
         events = build_events(parse_telemetry(self._raw(success=True, ts=False)))
+        tool = self._tool_event(events)
+        assert tool.completed is not None
+        assert (tool.completed - tool.timestamp).total_seconds() == 0.25
+        # The agent span still ends at the call's derived end time.
+        span_end = next(e for e in events if isinstance(e, SpanEndEvent))
+        assert span_end.timestamp >= tool.completed
+
+    def test_schema_b_missing_ts_and_duration_collapses_to_zero(self) -> None:
+        # Only a call with neither ``ts`` nor ``durationMs`` collapses to the
+        # spawn time (zero duration) rather than failing.
+        raw = self._raw(success=True, ts=False)
+        end = next(e for e in raw if e.get("type") == "tool.end")
+        del end["durationMs"]
+        events = build_events(parse_telemetry(raw))
         tool = self._tool_event(events)
         assert tool.completed == tool.timestamp
 
@@ -1273,6 +1290,222 @@ class TestSchemaBSubagents:
         tool = self._tool_event(events)
         assert tool.failed is False
         assert tool.error is None
+
+
+class TestSpawnlessSubagents:
+    """Sub-agent sessions with no linkable ``sessions_spawn`` call.
+
+    Cron/system-spawned sessions (a normal OpenClaw pattern on scheduled runs;
+    46 of 101 sub-agent sessions on a real cron-scheduled CRUX capture) appear
+    in the telemetry with no spawn tool call at all. They are placed at their
+    file-order anchor — the latest orchestrator turn seen before the session's
+    first event — with no spawn call fabricated, instead of being dropped.
+    """
+
+    CHILD = "agent:main:subagent:cron-child-1"
+    PROMPT = (
+        "[Subagent Context] You are a subagent spawned by the main agent.\n"
+        "You are running as a subagent. Report back when done.\n"
+        "Run the ablation sweep for setting X.\n"
+        "Include the smaller grids first."
+    )
+
+    def _turn(self, rid: str, ts: int, text: str) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "responseId": rid,
+            "timestamp": ts,
+            "model": "m",
+            "content": [{"type": "text", "text": text}],
+        }
+
+    def _raw(self) -> list[dict[str, Any]]:
+        orch = "agent:main:cron:orchestrator"
+        a1, a2, a3 = (
+            self._turn("r1", 1000, "A1"),
+            self._turn("r2", 2000, "A2"),
+            self._turn("r3", 3000, "A3"),
+        )
+        return [
+            # First snapshot: A1 + A2 precede the sub-agent in file order.
+            {"type": "agent.start", "sessionKey": orch, "messages": [a1, a2]},
+            {"type": "agent.start", "sessionKey": self.CHILD, "prompt": self.PROMPT},
+            {
+                "type": "tool.start",
+                "sessionKey": self.CHILD,
+                "toolName": "exec",
+                "params": {"command": "run sweep"},
+            },
+            {
+                "type": "tool.end",
+                "sessionKey": self.CHILD,
+                "toolName": "exec",
+                "durationMs": 100,
+                "success": True,
+            },
+            # Later cumulative snapshot appends A3 after the sub-agent appeared.
+            {"type": "agent.end", "sessionKey": orch, "messages": [a1, a2, a3]},
+        ]
+
+    def test_placed_at_file_order_anchor(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        parse = parse_telemetry(self._raw())
+        assert len(parse.subagents) == 1
+        assert parse.subagents[0].spawn_tool_call_id is None
+        # The anchor is A2's timestamp: the latest orchestrator turn seen (in
+        # file order) before the session's first event.
+        assert parse.subagents[0].anchor_ts == 2000
+        with caplog.at_level(logging.INFO):
+            events = build_events(parse)
+        # Placed between A1 and A3 — not dropped, and reported at info level.
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        roots = [e for e in events if isinstance(e, ModelEvent)]
+        assert events.index(roots[0]) < events.index(span) < events.index(roots[2])
+        assert any(
+            "file-order anchor" in r.getMessage() and self.CHILD in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_no_spawn_tool_call_fabricated(self) -> None:
+        events = build_events(parse_telemetry(self._raw()))
+        # No spawn call was recorded, so none is folded into the span — but the
+        # session's own activity is still reconstructed inside it.
+        folded = [
+            e
+            for e in events
+            if isinstance(e, ToolEvent) and e.agent_span_id == self.CHILD
+        ]
+        assert folded == []
+        inner = [
+            e for e in events if isinstance(e, ToolEvent) and e.span_id == self.CHILD
+        ]
+        assert [e.function for e in inner] == ["exec"]
+
+    def test_span_named_from_prompt_task_line(self) -> None:
+        # No spawn label exists, so the span is named from the first
+        # task-bearing line of the session's own prompt, skipping OpenClaw's
+        # "[Subagent Context] …" / "You are running as a subagent…" preamble.
+        events = build_events(parse_telemetry(self._raw()))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.name == "Run the ablation sweep for setting X."
+
+    def test_anchor_at_run_start_places_before_first_turn(self) -> None:
+        # A session first seen before ANY orchestrator turn anchors at 0 and is
+        # emitted ahead of the first turn rather than lost.
+        raw = self._raw()
+        raw.insert(0, raw.pop(1))  # move the sub-agent's agent.start first
+        parse = parse_telemetry(raw)
+        assert parse.subagents[0].anchor_ts == 0
+        events = build_events(parse)
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        first_model = next(e for e in events if isinstance(e, ModelEvent))
+        assert events.index(span) < events.index(first_model)
+
+
+class TestRollupAggregates:
+    """Scaffold roll-up aggregate records are dropped, not double-counted.
+
+    OpenClaw's turn-finalization bookkeeping appends an aggregate assistant
+    record after a block of per-call records: no ``responseId``, stopReason
+    ``stop``, no toolCalls, and ``totalTokens`` frozen at the previous record's
+    value. Its usage restates the block it closes, so keeping it double-counts
+    every usage field (~23M phantom cache-read tokens on one real CRUX capture).
+    """
+
+    ORCH = "agent:main:cron:orchestrator"
+
+    def _turn(
+        self,
+        *,
+        rid: str | None,
+        ts: int,
+        text: str,
+        usage: dict[str, int],
+        stop: str = "stop",
+        tool_call: bool = False,
+    ) -> dict[str, Any]:
+        content: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        if tool_call:
+            content.append(
+                {"type": "toolCall", "id": "tc1", "name": "exec", "arguments": {}}
+            )
+        turn: dict[str, Any] = {
+            "role": "assistant",
+            "timestamp": ts,
+            "model": "m",
+            "stopReason": stop,
+            "content": content,
+            "usage": usage,
+        }
+        if rid is not None:
+            turn["responseId"] = rid
+        return turn
+
+    def _parse(self, turns: list[dict[str, Any]]) -> OpenClawTelemetry:
+        return parse_telemetry(
+            [{"type": "agent.start", "sessionKey": self.ORCH, "messages": turns}]
+        )
+
+    def test_rollup_dropped_and_usage_not_double_counted(self) -> None:
+        usage = {"input": 100, "output": 50, "cacheRead": 800, "totalTokens": 950}
+        parse = self._parse(
+            [
+                self._turn(rid="r1", ts=1000, text="A1", usage=usage),
+                # The roll-up: rid-less, tool-less 'stop' record whose
+                # totalTokens is frozen at A1's value.
+                self._turn(rid=None, ts=1500, text="A1", usage=dict(usage)),
+                self._turn(
+                    rid="r2",
+                    ts=2000,
+                    text="A2",
+                    usage={"input": 10, "output": 5, "totalTokens": 15},
+                ),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+        events = build_events(parse)
+        usages = [
+            e.output.usage
+            for e in events
+            if isinstance(e, ModelEvent) and e.output.usage is not None
+        ]
+        assert len(usages) == 2
+        # Without the drop these would be 1600 / 1915.
+        assert sum(u.input_tokens_cache_read or 0 for u in usages) == 800
+        assert sum(u.total_tokens for u in usages) == 965
+
+    def test_moving_total_tokens_is_kept(self) -> None:
+        # A rid-less 'stop' record whose totalTokens MOVED is a real turn
+        # (service-sink captures have no responseId at all) — never dropped.
+        parse = self._parse(
+            [
+                self._turn(rid=None, ts=1000, text="A1", usage={"totalTokens": 950}),
+                self._turn(rid=None, ts=1500, text="A2", usage={"totalTokens": 990}),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+
+    def test_response_id_or_tool_calls_disqualify(self) -> None:
+        # The signature is conjunctive: a responseId, a toolCall, or a
+        # non-'stop' stopReason each mark a genuine turn even with frozen
+        # totals.
+        usage = {"totalTokens": 950}
+        parse = self._parse(
+            [
+                self._turn(rid="r1", ts=1000, text="A1", usage=dict(usage)),
+                self._turn(rid="r2", ts=1500, text="A2", usage=dict(usage)),
+                self._turn(
+                    rid=None,
+                    ts=2000,
+                    text="A3",
+                    usage=dict(usage),
+                    tool_call=True,
+                    stop="toolUse",
+                ),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 3
 
 
 class TestMessages:

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -437,6 +438,71 @@ class TestParse:
         # One agent span, and no stray root-level spawn event from the twin.
         assert sum(1 for e in events if isinstance(e, SpanBeginEvent)) == 1
         assert not [e for e in events if isinstance(e, ToolEvent) and e.span_id is None]
+
+    def test_keyless_turns_do_not_collapse_across_sessions(self) -> None:
+        # The keyless fallback exists to collapse a session's own cumulative
+        # re-dumps, which always share their sessionKey. Two GENUINE turns
+        # from two different sessions that coincide on (timestamp, content) —
+        # reachable on rid-less captures with many concurrent same-kind
+        # sessions — are distinct turns and must both survive.
+        def session(sk: str) -> dict[str, Any]:
+            return {
+                "type": "agent.start",
+                "sessionKey": sk,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "timestamp": 1000,
+                        "model": "m",
+                        "stopReason": "stop",
+                        "usage": {"input": 1, "output": 4, "totalTokens": 5},
+                        "content": [{"type": "text", "text": "on it"}],
+                    }
+                ],
+            }
+
+        parse = parse_telemetry(
+            [
+                session("agent:main:telegram:chat-1"),
+                session("agent:main:telegram:chat-2"),
+            ]
+        )
+        assert len(parse.orchestrator_turns) == 2
+
+    def test_equal_ts_ties_keep_file_order(self) -> None:
+        # Turns from different surfaces sharing a timestamp must merge in file
+        # order (the pre-grouping behavior), not surface-first-seen order —
+        # _primary_model's tie-break reads first-seen from this ordering.
+        def turn(rid: str, text: str) -> dict[str, Any]:
+            return {
+                "role": "assistant",
+                "responseId": rid,
+                "timestamp": 1000,
+                "model": "m",
+                "content": [{"type": "text", "text": text}],
+            }
+
+        parse = parse_telemetry(
+            [
+                {
+                    "type": "agent.start",
+                    "sessionKey": "agent:main:main:s1",
+                    "messages": [turn("r1", "M1")],
+                },
+                {
+                    "type": "agent.start",
+                    "sessionKey": "agent:main:telegram:chat-1",
+                    "messages": [turn("t1", "T1")],
+                },
+                {
+                    "type": "agent.end",
+                    "sessionKey": "agent:main:main:s1",
+                    "messages": [turn("r1", "M1"), turn("r2", "M2")],
+                },
+            ]
+        )
+        texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
+        assert texts == ["M1", "T1", "M2"]
 
     def test_user_prompt_transient_and_settled_collapse(self) -> None:
         # OpenClaw re-serializes a human prompt across snapshots: a transient
@@ -1380,6 +1446,15 @@ class TestSpawnlessSubagents:
         span = next(e for e in events if isinstance(e, SpanBeginEvent))
         roots = [e for e in events if isinstance(e, ModelEvent)]
         assert events.index(span) == events.index(roots[1]) + 1
+        # ...and STAMPED at the anchor's time, not the next timeline item's:
+        # the span (and its ts-less schema-B call, which falls back to the
+        # span time) must not report activity as starting at A3.
+        anchor_dt = datetime.fromtimestamp(2.0, tz=timezone.utc)  # A2 @ 2000ms
+        assert span.timestamp == anchor_dt
+        inner = next(
+            e for e in events if isinstance(e, ToolEvent) and e.span_id == self.CHILD
+        )
+        assert inner.timestamp == anchor_dt
         assert any(
             "file-order anchor" in r.getMessage() and self.CHILD in r.getMessage()
             for r in caplog.records
@@ -1747,6 +1822,68 @@ class TestRollupAggregates:
         )
         texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
         assert texts == ["A1", "T1"]
+
+    def test_rollup_detected_across_same_kind_sessions(self) -> None:
+        # Two concurrent sessions of the SAME kind (e.g. two telegram chats,
+        # or two cron runs — one real capture carries 419 orchestrator
+        # sessions): chat-2's turn interleaving between chat-1's closing
+        # record and its roll-up must not mask the comparison, so the filter
+        # groups by full sessionKey, not by kind.
+        def snapshot(sk: str, turns: list[dict[str, Any]]) -> dict[str, Any]:
+            return {"type": "agent.start", "sessionKey": sk, "messages": turns}
+
+        def turn(
+            rid: str | None, ts: int, text: str, usage: dict[str, int]
+        ) -> dict[str, Any]:
+            return {
+                "role": "assistant",
+                "responseId": rid,
+                "timestamp": ts,
+                "model": "m",
+                "stopReason": "stop",
+                "content": [{"type": "text", "text": text}],
+                "usage": usage,
+            }
+
+        chat1 = [
+            turn(
+                "r1",
+                1000,
+                "C1-A",
+                {"input": 100, "output": 50, "cacheRead": 800, "totalTokens": 950},
+            ),
+            # chat-1's roll-up (block-sum usage, frozen total)
+            {
+                "role": "assistant",
+                "timestamp": 1500,
+                "model": "m",
+                "stopReason": "stop",
+                "content": [{"type": "text", "text": "C1-A"}],
+                "usage": {
+                    "input": 104,
+                    "output": 210,
+                    "cacheRead": 1650,
+                    "cacheWrite": 30,
+                    "totalTokens": 950,
+                },
+            },
+        ]
+        chat2 = [
+            turn(
+                "r2",
+                1200,
+                "C2-A",
+                {"input": 5, "output": 10, "cacheRead": 485, "totalTokens": 500},
+            )
+        ]
+        parse = parse_telemetry(
+            [
+                snapshot("agent:main:telegram:chat-1", chat1),
+                snapshot("agent:main:telegram:chat-2", chat2),
+            ]
+        )
+        texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
+        assert texts == ["C1-A", "C2-A"]
 
     def test_subagent_schema_a_rollup_dropped(self) -> None:
         # Sub-agent sessions are finalized by the same scaffold, so a

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -504,6 +504,66 @@ class TestParse:
         texts = [content_to_text(t.get("content")) for t in parse.orchestrator_turns]
         assert texts == ["M1", "T1", "M2"]
 
+    def test_keyless_user_turns_do_not_collapse_across_sessions(self) -> None:
+        # Same rationale as the assistant-side key: re-dumps always come from
+        # the turn's own session, so two genuine keyless prompts from two
+        # concurrent sessions coinciding on (timestamp, content) — e.g.
+        # scheduler-stamped injections across cron sessions — are distinct
+        # turns and must both survive.
+        def session(sk: str) -> dict[str, Any]:
+            return {
+                "type": "agent.start",
+                "sessionKey": sk,
+                "messages": [
+                    {
+                        "role": "user",
+                        "timestamp": 60000,
+                        "content": "Run the scheduled sweep",
+                    },
+                    {
+                        "role": "assistant",
+                        "responseId": f"r-{sk[-1]}",
+                        "timestamp": 61000,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "ok"}],
+                    },
+                ],
+            }
+
+        parse = parse_telemetry(
+            [session("agent:main:cron:job-1"), session("agent:main:cron:job-2")]
+        )
+        assert len(parse.user_turns) == 2
+
+    def test_transient_twin_drop_is_session_scoped(self) -> None:
+        # The transient/settled collapse concerns one session re-serializing
+        # its OWN prompt. A genuinely keyless prompt in another session that
+        # happens to share text with a keyed prompt elsewhere is a separate
+        # turn and must not be text-dropped against it.
+        raw = [
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {
+                        "role": "user",
+                        "timestamp": 1000,
+                        "idempotencyKey": "m1",
+                        "content": "check the queue",
+                    },
+                ],
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:cron:job-1",
+                "messages": [
+                    {"role": "user", "timestamp": 5000, "content": "check the queue"},
+                ],
+            },
+        ]
+        parse = parse_telemetry(raw)
+        assert len(parse.user_turns) == 2
+
     def test_user_prompt_transient_and_settled_collapse(self) -> None:
         # OpenClaw re-serializes a human prompt across snapshots: a transient
         # first-snapshot form (no idempotencyKey, structured content) and a
@@ -1495,6 +1555,16 @@ class TestSpawnlessSubagents:
         first_model = next(e for e in events if isinstance(e, ModelEvent))
         assert events.index(span) < events.index(first_model)
 
+    def test_trailing_anchor_span_stamped_at_anchor(self) -> None:
+        # A session anchored at (or past) the last orchestrator turn is
+        # emitted by the trailing flush — it must stamp at the anchor time
+        # too, not at the last item's.
+        raw = self._raw()
+        raw.pop()  # drop the agent.end snapshot that appends A3
+        events = build_events(parse_telemetry(raw))
+        span = next(e for e in events if isinstance(e, SpanBeginEvent))
+        assert span.timestamp == datetime.fromtimestamp(2.0, tz=timezone.utc)
+
     def test_anchor_flush_precedes_interleaved_compaction(self) -> None:
         # The anchor flush runs on every timeline item, so a span anchored
         # before a compaction is emitted before that compaction, not swept
@@ -1700,8 +1770,9 @@ class TestRollupAggregates:
     value, and usage components that SUM the block (breaking the per-call
     identity ``input + output + cacheRead + cacheWrite == totalTokens``).
     Keeping it double-counts every usage field (~23M phantom cache-read tokens
-    on one real CRUX capture). The filter runs per orchestrator surface and
-    per sub-agent session, so interleaving cannot mask the comparison.
+    on one real CRUX capture). The filter runs per session — each orchestrator
+    session and each sub-agent session — so interleaving cannot mask the
+    comparison.
     """
 
     ORCH = "agent:main:cron:orchestrator"
@@ -2381,6 +2452,38 @@ class TestOperatorChannel:
         users = [m for m in messages if m.role == "user"]
         assert len(users) == 1
         assert users[0].source == "operator"
+
+    def test_ts_less_turn_does_not_steal_at_or_after_match(self) -> None:
+        # A ts-less turn is always-ELIGIBLE, not always-PREFERRED: when a turn
+        # satisfying at-or-after exists, it wins, and the ts-less turn is left
+        # for a send that has no such match — otherwise the greedy pick
+        # manufactures exactly the standalone duplicate it exists to avoid.
+        raw: list[dict[str, Any]] = [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "status?",
+                "timestamp": 1000,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {"role": "user", "content": "status?"},
+                    {"role": "user", "timestamp": 2000, "content": "status?"},
+                ],
+            },
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "status?",
+                "timestamp": 3000,
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 2  # both sends matched: no standalone duplicate
+        assert all(m.source == "operator" for m in users)
 
     def test_fixture_prompts_carry_operator_source(
         self, raw_events: list[dict[str, Any]]

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -242,7 +242,7 @@ class TestParse:
     def test_unrecognized_session_kind_fails_with_meaningful_error(
         self, event: dict[str, Any], expected_kind: str
     ) -> None:
-        # A kind outside main/telegram/dashboard/subagent on a consumed event
+        # A kind outside main/telegram/dashboard/cron/subagent on a consumed event
         # means a session whose turns would otherwise be silently discarded
         # (classified as neither orchestrator nor sub-agent), so the import
         # must fail loudly, naming the kind and the sessionKey.
@@ -297,16 +297,18 @@ class TestParse:
         assert [t["responseId"] for t in parse.orchestrator_turns] == ["r1", "r2"]
         assert parse.subagents == []
 
-    def test_message_events_without_session_key_are_ignored(self) -> None:
-        # message.* events carry no sessionKey and are intentionally not
-        # consumed; their missing kind must NOT trip the unrecognized-kind
-        # check.
+    def test_message_events_without_session_key_do_not_trip_kind_check(self) -> None:
+        # message.* events carry no sessionKey; their missing kind must NOT
+        # trip the unrecognized-kind check. message.in is consumed as the
+        # inbound operator channel; message.out stays unconsumed.
         raw = [
             {"type": "message.in", "channel": "telegram", "content": "hi"},
             *self._orch_raw("agent:main:main:s1"),
             {"type": "message.out", "channel": "telegram", "content": "bye"},
         ]
-        assert len(parse_telemetry(raw).orchestrator_turns) == 1
+        parse = parse_telemetry(raw)
+        assert len(parse.orchestrator_turns) == 1
+        assert [m["content"] for m in parse.operator_messages] == ["hi"]
 
     def _orch_raw(self, session_key: str) -> list[dict[str, Any]]:
         return [
@@ -351,14 +353,18 @@ class TestParse:
             "agent:main:main:s1",
             "agent:main:telegram:default:direct:5912046256",
             "agent:main:dashboard:e6746281-f3cd-4be5-9d0c-633772cdcace",
+            "agent:main:cron:5b3f2a10-9c7e-4d21-8e6a-2f1d0c9b8a76",
         ],
     )
     def test_orchestrator_kinds_yield_orchestrator_turns(
         self, session_key: str
     ) -> None:
-        # Every orchestrator surface (terminal, Telegram, web dashboard) must
-        # have its assistant turns classified as orchestrator turns; otherwise
-        # the transcript is silently dropped for having no turns.
+        # Every orchestrator surface (terminal, Telegram, web dashboard, and
+        # the cron scheduler — a cron-scheduled run's orchestrator session
+        # carries the ``cron`` kind) must have its assistant turns classified
+        # as orchestrator turns; otherwise the import fails on the
+        # unrecognized-kind check (or, if it were lenient, the transcript
+        # would be silently dropped for having no turns).
         parse = parse_telemetry(self._orch_raw(session_key))
         assert len(parse.orchestrator_turns) == 1
 
@@ -1306,6 +1312,93 @@ class TestMessages:
         }
         # Every tool message corresponds to an assistant tool call.
         assert tool_msg_ids <= tool_call_ids
+
+
+class TestOperatorChannel:
+    """Inbound operator messages (``message.in``) carry provenance.
+
+    A ``message.in`` whose text matches a user turn marks THAT turn
+    ``source="operator"`` (no duplicate message); one with no matching user
+    turn (it never entered the session thread, e.g. delivered while the agent
+    was busy) becomes its own operator-sourced user message, placed by its
+    timestamp.
+    """
+
+    def _raw(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "please check the baselines",
+                "timestamp": 900,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {
+                        "role": "user",
+                        "timestamp": 1000,
+                        "idempotencyKey": "m1",
+                        "content": "please check the baselines",
+                    },
+                    {
+                        "role": "user",
+                        "timestamp": 1500,
+                        "content": "[runtime context]",
+                    },
+                    {
+                        "role": "assistant",
+                        "responseId": "r1",
+                        "timestamp": 2000,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "on it"}],
+                    },
+                ],
+            },
+            # Delivered mid-run but never re-entered the session thread as a
+            # user turn: must become its own operator-sourced message.
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "actually, prioritise the ablation",
+                "timestamp": 2500,
+            },
+        ]
+
+    def test_matched_message_in_marks_user_turn_operator(self) -> None:
+        messages = build_messages(parse_telemetry(self._raw()))
+        by_text = {m.text: m for m in messages if m.role == "user"}
+        # The operator-delivered prompt is stamped; no duplicate is added.
+        assert by_text["please check the baselines"].source == "operator"
+        assert sum(1 for m in messages if m.text == "please check the baselines") == 1
+        # A user turn that did not arrive via the operator channel (runtime
+        # context) carries no source.
+        assert by_text["[runtime context]"].source is None
+
+    def test_unmatched_message_in_becomes_operator_message(self) -> None:
+        messages = build_messages(parse_telemetry(self._raw()))
+        unmatched = [
+            m
+            for m in messages
+            if m.role == "user" and m.text == "actually, prioritise the ablation"
+        ]
+        assert len(unmatched) == 1
+        assert unmatched[0].source == "operator"
+        # Placed by timestamp: after the assistant turn it interrupted.
+        roles = [m.role for m in messages]
+        assert roles.index("assistant") < messages.index(unmatched[0])
+
+    def test_fixture_prompts_carry_operator_source(
+        self, raw_events: list[dict[str, Any]]
+    ) -> None:
+        # The bundled fixture's three human Telegram prompts each arrive as a
+        # message.in and re-enter the thread as user turns: all three must be
+        # stamped, and no extra user message may appear.
+        messages = build_messages(parse_telemetry(raw_events))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 3
+        assert all(m.source == "operator" for m in users)
 
 
 class TestTranscript:

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -1425,7 +1425,7 @@ class TestSpawnlessSubagents:
         # before a compaction is emitted before that compaction, not swept
         # past it to the next assistant turn.
         orch = "agent:main:cron:orchestrator"
-        raw = [
+        raw: list[dict[str, Any]] = [
             {
                 "type": "agent.start",
                 "sessionKey": orch,
@@ -1517,6 +1517,7 @@ class TestSpawnlessSubagents:
                 },
             ],
         }
+
         def span_for(key: str) -> SubagentSpan:
             return SubagentSpan(
                 session_key=key,
@@ -1530,6 +1531,7 @@ class TestSpawnlessSubagents:
                 tool_calls=[],
                 anchor_ts=1000,
             )
+
         parse = OpenClawTelemetry(
             orchestrator_turns=[turn],
             user_turns=[],
@@ -1611,7 +1613,12 @@ class TestRollupAggregates:
                     rid="r1",
                     ts=1000,
                     text="A1",
-                    usage={"input": 100, "output": 50, "cacheRead": 800, "totalTokens": 950},
+                    usage={
+                        "input": 100,
+                        "output": 50,
+                        "cacheRead": 800,
+                        "totalTokens": 950,
+                    },
                 ),
                 # The roll-up: rid-less, tool-less 'stop' record whose
                 # totalTokens is frozen at A1's value while its components sum
@@ -1675,8 +1682,12 @@ class TestRollupAggregates:
         }
         parse = self._parse(
             [
-                self._turn(rid=None, ts=1000, text="[assistant turn failed]", usage=dict(zero)),
-                self._turn(rid=None, ts=1500, text="[assistant turn failed]", usage=dict(zero)),
+                self._turn(
+                    rid=None, ts=1000, text="[assistant turn failed]", usage=dict(zero)
+                ),
+                self._turn(
+                    rid=None, ts=1500, text="[assistant turn failed]", usage=dict(zero)
+                ),
             ]
         )
         assert len(parse.orchestrator_turns) == 2
@@ -1797,7 +1808,9 @@ class TestRollupAggregates:
             if isinstance(e, ModelEvent) and e.span_id == sub
         ]
         assert len(sub_usages) == 1
-        assert sub_usages[0].total_tokens == 950
+        sub_usage = sub_usages[0]
+        assert sub_usage is not None
+        assert sub_usage.total_tokens == 950
 
     def test_moving_total_tokens_is_kept(self) -> None:
         # A rid-less 'stop' record whose totalTokens MOVED is a real turn
@@ -1951,7 +1964,7 @@ class TestOperatorChannel:
         # the thread as a user turn. Occurrence-based reconciliation must
         # surface the second send as its own operator message — set-of-texts
         # semantics silently dropped it once the first occurrence matched.
-        raw = [
+        raw: list[dict[str, Any]] = [
             {
                 "type": "message.in",
                 "channel": "telegram",
@@ -1992,7 +2005,7 @@ class TestOperatorChannel:
         # Two user turns share the operator text; the send precedes only the
         # second. A message can only enter the thread at-or-after it arrives,
         # so the LATER twin is stamped and the earlier one left untouched.
-        raw = [
+        raw: list[dict[str, Any]] = [
             {
                 "type": "agent.start",
                 "sessionKey": "agent:main:main:s1",
@@ -2017,7 +2030,7 @@ class TestOperatorChannel:
         # A multi-line send re-enters the thread as a content-block list; both
         # sides must flatten identically (content_to_text) or the turn is left
         # unstamped AND the send duplicated as a standalone message.
-        raw = [
+        raw: list[dict[str, Any]] = [
             {
                 "type": "message.in",
                 "channel": "telegram",
@@ -2048,7 +2061,7 @@ class TestOperatorChannel:
         # An unmatched inbound message never entered the session thread — the
         # model never saw it. It belongs in the final message thread, but NOT
         # in later ModelEvents' input (the conversation the model was shown).
-        raw = [
+        raw: list[dict[str, Any]] = [
             {
                 "type": "agent.start",
                 "sessionKey": "agent:main:main:s1",

--- a/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
+++ b/examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py
@@ -1792,6 +1792,145 @@ class TestOperatorChannel:
         roles = [m.role for m in messages]
         assert roles.index("assistant") < messages.index(unmatched[0])
 
+    def test_repeated_operator_send_not_lost(self) -> None:
+        # The operator sends the same text twice; only one instance re-entered
+        # the thread as a user turn. Occurrence-based reconciliation must
+        # surface the second send as its own operator message — set-of-texts
+        # semantics silently dropped it once the first occurrence matched.
+        raw = [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "status?",
+                "timestamp": 900,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {"role": "user", "timestamp": 1000, "content": "status?"},
+                    {
+                        "role": "assistant",
+                        "responseId": "r1",
+                        "timestamp": 2000,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "working"}],
+                    },
+                ],
+            },
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "status?",
+                "timestamp": 2500,
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        status = [m for m in messages if m.role == "user" and m.text == "status?"]
+        assert len(status) == 2
+        assert all(m.source == "operator" for m in status)
+        # The unmatched second send is placed by its timestamp, after the
+        # assistant turn it followed.
+        roles = [m.role for m in messages]
+        assert roles.index("assistant") < messages.index(status[1])
+
+    def test_twin_text_matches_turn_at_or_after_send(self) -> None:
+        # Two user turns share the operator text; the send precedes only the
+        # second. A message can only enter the thread at-or-after it arrives,
+        # so the LATER twin is stamped and the earlier one left untouched.
+        raw = [
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {"role": "user", "timestamp": 500, "content": "ok"},
+                    {"role": "user", "timestamp": 1500, "content": "ok"},
+                ],
+            },
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "ok",
+                "timestamp": 1000,
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 2  # matched: no standalone duplicate added
+        assert [m.source for m in users] == [None, "operator"]
+
+    def test_multiline_send_matches_block_content_turn(self) -> None:
+        # A multi-line send re-enters the thread as a content-block list; both
+        # sides must flatten identically (content_to_text) or the turn is left
+        # unstamped AND the send duplicated as a standalone message.
+        raw = [
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "line1\nline2",
+                "timestamp": 900,
+            },
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {
+                        "role": "user",
+                        "timestamp": 1000,
+                        "content": [
+                            {"type": "text", "text": "line1"},
+                            {"type": "text", "text": "line2"},
+                        ],
+                    },
+                ],
+            },
+        ]
+        messages = build_messages(parse_telemetry(raw))
+        users = [m for m in messages if m.role == "user"]
+        assert len(users) == 1
+        assert users[0].source == "operator"
+
+    def test_unmatched_send_not_in_later_model_input(self) -> None:
+        # An unmatched inbound message never entered the session thread — the
+        # model never saw it. It belongs in the final message thread, but NOT
+        # in later ModelEvents' input (the conversation the model was shown).
+        raw = [
+            {
+                "type": "agent.start",
+                "sessionKey": "agent:main:main:s1",
+                "messages": [
+                    {"role": "user", "timestamp": 1000, "content": "start"},
+                    {
+                        "role": "assistant",
+                        "responseId": "r1",
+                        "timestamp": 2000,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "A1"}],
+                    },
+                    {
+                        "role": "assistant",
+                        "responseId": "r2",
+                        "timestamp": 3000,
+                        "model": "m",
+                        "content": [{"type": "text", "text": "A2"}],
+                    },
+                ],
+            },
+            {
+                "type": "message.in",
+                "channel": "telegram",
+                "content": "secret aside",
+                "timestamp": 2500,
+            },
+        ]
+        events, messages = build_content(parse_telemetry(raw))
+        models = [e for e in events if isinstance(e, ModelEvent)]
+        assert len(models) == 2
+        assert not any(m.text == "secret aside" for m in models[1].input)
+        aside = [m for m in messages if m.role == "user" and m.text == "secret aside"]
+        assert len(aside) == 1
+        assert aside[0].source == "operator"
+
     def test_fixture_prompts_carry_operator_source(
         self, raw_events: list[dict[str, Any]]
     ) -> None:


### PR DESCRIPTION
*Opened by Claude Code on behalf of @alexandraabbas; reviewed by @alexandraabbas.*

Upstream ports for the `examples/sources/openclaw_telemetry_hal` worked example, from patches we made to our vendored copy (per the example's stated copy-and-adapt purpose) while importing real CRUX research-agent telemetry — cron-scheduled, long-horizon OpenClaw runs. This is the "separate PR with some patches we've come across" promised in #560's filing, now carrying the whole vendored delta except the `explicit` session kind (see the heads-up at the end). Three groups: session-kind/provenance additions, reconstruction-fidelity fixes, and one deliberate design change called out separately for scrutiny.

## a. Session kinds + operator provenance

**`cron` is an orchestrator session kind.** OpenClaw runs can be cron-scheduled; the orchestrator session of such a run carries sessionKey kind `cron` (e.g. `agent:main:cron:<uuid>`). The importer's strict session classification refused these files outright (`unrecognized session kind 'cron'`). `detection.ORCH_KINDS` now includes `"cron"`, so a cron-scheduled run's orchestrator turns classify as orchestrator — the same treatment as `main`/`telegram`/`dashboard`. Our CRUX captures are all cron-scheduled runs, so without this the importer refuses the entire file.

**`message.in` becomes operator-sourced user-message provenance.** `message.in` events are the inbound operator channel: the full text of a message a human sent the agent mid-run. Previously all `message.*` events were unconsumed. This PR consumes `message.in` (only — outbound `message.sending`/`message.out` stay unconsumed, with the existing sub-agent-report-attribution rationale intact):

- an inbound message whose text matches a user turn stamps **that** turn `ChatMessageUser(source="operator")` — no duplicate message is added;
- an inbound message that never re-entered the session thread (e.g. delivered while the agent was busy) becomes its own operator-sourced user message, placed by its timestamp.

Why: for long-horizon autonomous runs, mid-run operator interventions are analytically load-bearing — downstream human-intervention analysis needs to distinguish "a human steered the agent here" from runtime-context injections and scaffold-generated user turns. `source="operator"` is a valid `ChatMessage.source` in current inspect_ai, and both bundled fixtures already contain `message.in` events, which now surface this provenance (the sample fixture's three Telegram prompts are stamped `operator`; message counts are unchanged).

## b. Reconstruction fidelity

**Scaffold roll-up usage aggregates are dropped.** OpenClaw's turn-finalization bookkeeping appends an AGGREGATE assistant record after a block of per-call records: no `responseId`, stopReason `stop`, no toolCalls, and a `totalTokens` FROZEN at the previous record's value — its usage restates the block it closes, not a new API call. Counting it double-counts every usage field: on one real capture, 9 such records added ~23M phantom cache-read tokens (~10% inflation of the headline billable total). `parse._drop_rollup_aggregates` drops records matching the full conjunctive signature against the previously kept turn, with an info log; a `responseId`, a toolCall, a non-`stop` stopReason, or a moving `totalTokens` each disqualify, so genuine turns are never touched.

**`durationMs`-derived tool-call width on bare captures.** Bare (non-service-sink) captures carry no `ts` envelope on `tool.*` events, so every schema-B sub-agent call collapsed to zero duration. `durationMs` (from `tool.end`) now gives such a call a real start→end span (`completed = timestamp + durationMs`); recorded `ts` pairs still win when present, and only a call with neither collapses to zero. Downstream busy-time sums rely on these widths. (The related `success=false` → `failed`/`error` surfacing already landed with the original example in #490 — no change here, existing tests still lock it.)

**Task-line span naming.** A sub-agent span with no spawn `label` was named the generic `"subagent"`. It now falls back to the first task-bearing line of the sub-agent's own prompt, skipping OpenClaw's `[Subagent Context] You are running…` scaffold preamble — so spans stay identifiable in the viewer even when no spawn arguments exist (which is every spawn-less session in group c).

## c. Design change, flagged for scrutiny: spawn-less sub-agent sessions are placed, not dropped

This one **changes an upstream design choice** (drop-with-warning for sub-agents with no linkable spawn call), so calling it out separately rather than folding it quietly into (b).

The original rationale ("not observed in practice — every sub-agent links via its spawn result's `childSessionKey`") held for the captures the example was built against, but doesn't survive cron-scheduled runs: cron/system-spawned sub-agent sessions have **no `sessions_spawn` call in the telemetry at all**, and they are common — on one real cron-scheduled CRUX capture, **46 of 101 sub-agent sessions** have no linkable spawn call. Drop-with-warning silently loses roughly half the delegated activity on such a run.

The change: an unlinked session is **placed at its file-order anchor** — its agent span is emitted next to the latest orchestrator turn seen (in file order) before the session's first event — with an info log listing the placed sessions. **No spawn tool call is fabricated**: the span simply has no folded `sessions_spawn` child, and the README documents the placement as a file-order heuristic ("the orchestrator was here when this session started"), not a recorded parent link. Genuinely-unknown session kinds are still refused loudly; that check is untouched.

If you'd rather keep drop-with-warning as the upstream default, or want the placement behind an option, happy to split this commit's placement portion into its own PR for separate discussion — the (a)/(b) items stand on their own without it.

## Tests

Extended `tests/test_telemetry_hal.py` (81 pass, from 73):

- `cron` in the orchestrator-kinds parametrize; a new `TestOperatorChannel` class (matched `message.in` stamps without duplication, unmatched becomes a standalone operator-sourced message, fixture prompts carry `source="operator"`);
- a new `TestRollupAggregates` class: roll-up dropped and usage sums no longer double-counted, plus negative controls (moving `totalTokens`, `responseId`/toolCall/stopReason each disqualify);
- schema-B timing: missing-`ts` calls derive width from `durationMs`; only calls with neither collapse to zero;
- a new `TestSpawnlessSubagents` class: placement between the correct orchestrator turns (anchor asserted), no fabricated spawn child, span named from the prompt's task line (boilerplate skipped), anchor-at-run-start placement; the old drop test is now `test_unlinked_subagent_placed_not_dropped`;
- unrecognized-session-kind refusal unchanged and still covered.

`ruff check` / `ruff format` / `mypy` clean on the example; `pytest examples/sources/openclaw_telemetry_hal/tests/` → 81 passed (against inspect_ai@main per CONTRIBUTING). Verified end-to-end on a real 120MB cron-scheduled CRUX capture (previously refused at the `cron` kind check; now imports with all sub-agent sessions represented).

## Not included / heads-up

- **#565's `explicit` session kind landed separately (merged)** — this branch is rebased on top of it; `ORCH_KINDS` here carries the union (`cron` + `explicit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

