### PR TITLE
chore(types): sync sandbox_unavailable tool error type from inspect_ai

### DIFF
--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-DhjT1SMu.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-DhjT1SMu.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5ef1f37c0896673809ce54bcc74f416210ead4a5811b894e5785ccc956308c5
-size 187123

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-I5MEHNFG.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-I5MEHNFG.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2696f5594c9383692d4fe240d17b5e06a8b9cad3b615c35bf41b0e52cd649db
+size 186840

--- a/src/inspect_scout/_view/dist/assets/dist-DBV84SvE.js
+++ b/src/inspect_scout/_view/dist/assets/dist-DBV84SvE.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cd27791ae13aa3f402d2a3560a4e90776bf44b7e5f72c378487d4ad8b4d5086
-size 4096

--- a/src/inspect_scout/_view/dist/assets/dist-DYxQMA91.js
+++ b/src/inspect_scout/_view/dist/assets/dist-DYxQMA91.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66a1919aca06f485d2e7a48051a62bb414bb615098c80cf6f9175bbce6784df4
+size 4096

--- a/src/inspect_scout/_view/dist/assets/index-5wb6-0Ly.css
+++ b/src/inspect_scout/_view/dist/assets/index-5wb6-0Ly.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:666a281258f24386912b4f8a2bb97c3b9f954404c227fcc2cf92034a25e96d76
-size 542477

--- a/src/inspect_scout/_view/dist/assets/index-CImCiLLK.css
+++ b/src/inspect_scout/_view/dist/assets/index-CImCiLLK.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c50b1293de3bef20938bf24014fc5f67e01f166fb6b19f3d4502d189b203db2
+size 540232

--- a/src/inspect_scout/_view/dist/assets/index-D80ER2_Z.js
+++ b/src/inspect_scout/_view/dist/assets/index-D80ER2_Z.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e5ad14e3e33357cad1e221680d66b94770b5bd878b44a7ea779fcc7d07074b5
-size 2930082

--- a/src/inspect_scout/_view/dist/assets/index-E4vzhVCA.js
+++ b/src/inspect_scout/_view/dist/assets/index-E4vzhVCA.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a92697095ecea482db6d544c13fefba17cbceda8f09f18ac516accad3dea28c8
+size 2871233

--- a/src/inspect_scout/_view/dist/assets/jsx-runtime-BpzPEenQ.js
+++ b/src/inspect_scout/_view/dist/assets/jsx-runtime-BpzPEenQ.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63437167d8270efbe026cd956b446c6f09220f8fcbd674ce29b3479a9a5abfcc
+size 7948

--- a/src/inspect_scout/_view/dist/assets/jsx-runtime-CEpd2cAX.js
+++ b/src/inspect_scout/_view/dist/assets/jsx-runtime-CEpd2cAX.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4f693944050d8898dba83a9fc2a9c4da6f7f6791d4e08aff5e5e6eb179b2ce1
-size 7948

--- a/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-Dc0Y_co_.js
+++ b/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-Dc0Y_co_.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:462e7b6c50a8116bee63c74dbb20fd1b3c7c9ff678098927290f10b3db079c2e
-size 59873

--- a/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-qfi-c9CZ.js
+++ b/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-qfi-c9CZ.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4cd97621e34b889c17c77071b50c580082e771490c1e8a9d0a5acf59b0e16e3
+size 59857

--- a/src/inspect_scout/_view/dist/assets/rolldown-runtime-Dd_uD5pT.js
+++ b/src/inspect_scout/_view/dist/assets/rolldown-runtime-Dd_uD5pT.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f0356f5d0918a3137e4e811fd18950efe8ac8f6bf84d1d4da7811c477a24d8
+size 1106

--- a/src/inspect_scout/_view/dist/assets/rolldown-runtime-aKtaBQYM.js
+++ b/src/inspect_scout/_view/dist/assets/rolldown-runtime-aKtaBQYM.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb2fb01f2064eb36487466778d2ffc4c97ad86af89be1635209de18f0b5b2236
-size 1084

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-BN-yaT14.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-BN-yaT14.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e5486458aa62b281b44a8555d0d821750d4dd167f74a4e0e9861cb6be60469
+size 2233766

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-OLOEhTfE.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-OLOEhTfE.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbccaa63029141b11ff8b6a4ce9b47dec2f30165e823e99cd3b5c818c2fe1fd9
-size 2233826

--- a/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DcCuyqt0.js
+++ b/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DcCuyqt0.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:294857b997ff00aa8140bd4976daacd0589b9cbd630b5781447af370a2610975
+size 350434

--- a/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-Y89e3oku.js
+++ b/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-Y89e3oku.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc4fd074a7d573c6bc9525e6cc23231d7507c2a93548a5a69e23afd58f447809
-size 350456

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae38a26722753e14078bba21ef9933b84e7e9012a05bbba6dcc6ad7c18eb426a
+oid sha256:f793c255a429881bf7b148c10d68d4d630b5aadf8a570b3b2b52d82a7706a3f6
 size 3807

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -10344,6 +10344,7 @@
               "limit",
               "approval",
               "cancelled",
+              "sandbox_unavailable",
               "unknown",
               "output_limit"
             ],


### PR DESCRIPTION
inspect_ai added a `sandbox_unavailable` `ToolCallError` type (UKGovernmentBEIS/inspect_ai#4740, merged today). Scout CI installs inspect_ai from git main, so without this sync the schema-drift check goes red on the next nightly and on every PR.

- `openapi.json` regenerated against inspect_ai main (`4056d7e94`) — one-line diff, the enum member only
- ts-mono bumped to main `932dbc44` (meridianlabs-ai/ts-mono#538), which carries the matching `apps/scout` generated types; regen at that pin reproduces them exactly (no drift)
- viewer dist rebuilt at the new pin (the bump rides along 28 ts-mono main commits, hence the wide dist diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)