### PR TITLE
fix: resolve attachments in pooled event messages

### DIFF
--- a/src/inspect_scout/_transcript/json/load_filtered.py
+++ b/src/inspect_scout/_transcript/json/load_filtered.py
@@ -300,7 +300,10 @@ async def _parse_and_filter(
     )
     events_coro = event_item_coroutine(state, events_config) if events_config else None
     timelines_coro = timeline_item_coroutine(state)
-    attachments_coro = attachments_coroutine(state)
+    # Event message pools are stored after attachments in eval-log JSON. Their
+    # attachment references therefore are not known while the attachment section
+    # is streaming past, so retain every attachment whenever events are requested.
+    attachments_coro = attachments_coroutine(state, retain_all=events_coro is not None)
     metadata_coro = metadata_coroutine(state)
     target_coro = target_coroutine(state)
     scores_coro = scores_coroutine(state)

--- a/src/inspect_scout/_transcript/json/reducer.py
+++ b/src/inspect_scout/_transcript/json/reducer.py
@@ -184,7 +184,9 @@ def call_pool_item_coroutine(state: ParseState, item_prefix: str) -> CoroutineGe
 
 
 @_ijson_coroutine  # type: ignore
-def attachments_coroutine(state: ParseState) -> CoroutineGen:  # pragma: no cover
+def attachments_coroutine(
+    state: ParseState, *, retain_all: bool = False
+) -> CoroutineGen:  # pragma: no cover
     attachments_prefix_len = len(ATTACHMENTS_PREFIX)
     while True:
         prefix, event, value = yield
@@ -198,7 +200,7 @@ def attachments_coroutine(state: ParseState) -> CoroutineGen:  # pragma: no cove
             if end == -1
             else prefix[attachments_prefix_len:end]
         )
-        if attachment_id in state.attachment_refs:
+        if retain_all or attachment_id in state.attachment_refs:
             state.attachments[attachment_id] = value
 
 

--- a/tests/scanner/test_load_filtered.py
+++ b/tests/scanner/test_load_filtered.py
@@ -1124,6 +1124,56 @@ async def test_pool_resolution_events_data_schema() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pool_resolution_resolves_event_message_attachments() -> None:
+    """Attachments referenced only by the later event pool are retained."""
+    attachment_id = "0123456789abcdef0123456789abcdef"
+    sample_data = {
+        "id": "test-pool-attachment",
+        "target": "expected",
+        "messages": [],
+        "scores": {},
+        "metadata": {},
+        "events": [
+            {
+                "span_id": "s1",
+                "timestamp": "2022-01-01T00:00:00+00:00",
+                "event": "model",
+                "model": "test-model",
+                "input": [],
+                "input_refs": [[0, 1]],
+                "output": {"model": "test-model", "choices": []},
+                "tools": [],
+                "tool_choice": "auto",
+                "config": {},
+            },
+        ],
+        # Eval logs store attachments before events_data, so the streaming loader
+        # encounters this value before it sees the reference below.
+        "attachments": {attachment_id: "resolved pooled prompt"},
+        "events_data": {
+            "messages": [{"role": "user", "content": f"attachment://{attachment_id}"}],
+            "calls": [],
+        },
+    }
+    result = await load_filtered_transcript(
+        create_json_stream(sample_data),
+        TranscriptInfo(
+            transcript_id="test-pool-attachment",
+            source_type="test",
+            source_id="source-pool-attachment",
+            source_uri="/test-pool-attachment.json",
+            metadata={},
+        ),
+        "all",
+        "all",
+    )
+    assert len(result.events) == 1
+    model_event = result.events[0]
+    assert isinstance(model_event, ModelEvent)
+    assert model_event.input[0].content == "resolved pooled prompt"
+
+
+@pytest.mark.asyncio
 async def test_pool_resolution_events_data_json5_fallback() -> None:
     """events_data pools resolve through the json5 fallback path too."""
     # A bare NaN value is invalid JSON but accepted by the json5 fallback,


### PR DESCRIPTION
## Summary

- retain attachments while streaming whenever events are requested
- resolve attachment references that appear only in later `events_data.messages` pools
- add an end-to-end regression test for eval-log field ordering

## Root cause

Eval-log JSON stores `attachments` before `events_data`. The streaming loader selectively retained only attachment IDs already observed, but references inside the later event message pool were not known until after the attachment section had passed. Pool expansion therefore produced unresolved `attachment://...` content.

## Validation

- `tests/scanner/test_load_filtered.py`: 32 passed, 1 skipped
- Ruff lint and format checks pass for all touched files
- validated against a real affected eval log: both transcript messages and the first agent `ModelEvent.input` now contain resolved prompt text rather than attachment URIs