### PR TITLE
fix: deliver the final metrics update synchronously at strategy teardown

### DIFF
--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -136,14 +136,22 @@ def single_process_strategy(
         def _scanner_job_info(item: ScannerJob) -> str:
             return f"{item.union_transcript.transcript_id, item.scanner_name}"
 
-        @throttle(1)
-        def _update_metrics() -> None:
-            if update_metrics:
+        # the finally at the end of the_func delivers the final zeroed update
+        # itself, and sets this so a trailing-edge fire still pending in the
+        # throttle does not deliver a duplicate of it after teardown
+        final_metrics_delivered = False
+
+        def _update_metrics_now() -> None:
+            if update_metrics and not final_metrics_delivered:
                 # USS - Unique Set Size
                 metrics.memory_usage = process.memory_full_info().uss
                 # print(f"{diag_prefix} CPU {metrics.cpu_use}")
                 metrics.buffered_scanner_jobs = len(scanner_job_deque)
                 update_metrics(metrics)
+
+        @throttle(1)
+        def _update_metrics() -> None:
+            _update_metrics_now()
 
         def _choose_next_action() -> Literal["parse", "scan", "wait"]:
             """Decide what action this worker should take: 'parse', 'scan', or 'wait'."""
@@ -347,6 +355,10 @@ def single_process_strategy(
             metrics.tasks_parsing = 0
             metrics.tasks_scanning = 0
             metrics.tasks_idle = 0
-            _update_metrics()
+            # deliver synchronously, since a throttled call would defer to a
+            # trailing-edge fire that may not survive teardown (#569). nothing
+            # awaits between the delivery and the flag, so no fire interleaves
+            _update_metrics_now()
+            final_metrics_delivered = True
 
     return the_func

--- a/src/inspect_scout/_concurrency/single_process.py
+++ b/src/inspect_scout/_concurrency/single_process.py
@@ -138,11 +138,13 @@ def single_process_strategy(
 
         # the finally at the end of the_func delivers the final zeroed update
         # itself, and sets this so a trailing-edge fire still pending in the
-        # throttle does not deliver a duplicate of it after teardown
+        # throttle does not deliver a duplicate of it after teardown. the guard
+        # lives in the throttled wrapper, so the suppression holds regardless of
+        # the order of the delivery and the flag in that finally
         final_metrics_delivered = False
 
         def _update_metrics_now() -> None:
-            if update_metrics and not final_metrics_delivered:
+            if update_metrics:
                 # USS - Unique Set Size
                 metrics.memory_usage = process.memory_full_info().uss
                 # print(f"{diag_prefix} CPU {metrics.cpu_use}")
@@ -151,7 +153,8 @@ def single_process_strategy(
 
         @throttle(1)
         def _update_metrics() -> None:
-            _update_metrics_now()
+            if not final_metrics_delivered:
+                _update_metrics_now()
 
         def _choose_next_action() -> Literal["parse", "scan", "wait"]:
             """Decide what action this worker should take: 'parse', 'scan', or 'wait'."""
@@ -356,8 +359,8 @@ def single_process_strategy(
             metrics.tasks_scanning = 0
             metrics.tasks_idle = 0
             # deliver synchronously, since a throttled call would defer to a
-            # trailing-edge fire that may not survive teardown (#569). nothing
-            # awaits between the delivery and the flag, so no fire interleaves
+            # trailing-edge fire that may not survive teardown (#569). the flag
+            # suppresses any such fire that is still pending
             _update_metrics_now()
             final_metrics_delivered = True
 

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -892,7 +892,12 @@ def init_scan_model_context(
 async def handle_scan_interrupted(
     message_or_exc: str | Exception, spec: ScanSpec, recorder: ScanRecorder
 ) -> Status:
-    scan_status = await recorder.sync(await recorder.location(), complete=False)
+    # on interrupt this runs inside an already-cancelled scope, where an
+    # unshielded await re-raises the cancellation before the sync can
+    # complete (#578) -- shield it so the interrupted status gets written
+    # and reported rather than tripping the not-None assert upstream
+    with anyio.CancelScope(shield=True):
+        scan_status = await recorder.sync(await recorder.location(), complete=False)
     display().scan_interrupted(message_or_exc, scan_status)
     return scan_status
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,10 +3,14 @@
 import secrets
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Callable, ContextManager, Iterator
 from unittest.mock import patch
 
 from inspect_ai._util.kvstore import inspect_kvstore
+from inspect_scout._recorder.active_scans_store import (
+    ActiveScansStore,
+    active_scans_store,
+)
 
 
 @contextmanager
@@ -35,3 +39,28 @@ def temp_active_scans_store() -> Iterator[str]:
     with temp_kvstore() as name:
         with patch("inspect_scout._recorder.active_scans_store._STORE_NAME", name):
             yield name
+
+
+def active_scans_store_spy(
+    method_name: str, on_call: Callable[..., None]
+) -> Callable[[], ContextManager[ActiveScansStore]]:
+    """Store factory whose store calls on_call(store, *args) after method_name.
+
+    Install with monkeypatch.setattr(scan_module, "active_scans_store", ...),
+    patching the name where _scan.py looks it up rather than where it lives.
+    """
+
+    @contextmanager
+    def spying_store() -> Iterator[ActiveScansStore]:
+        with active_scans_store() as store:
+            real = getattr(store, method_name)
+
+            def spied(*args: Any, **kwargs: Any) -> Any:
+                result = real(*args, **kwargs)
+                on_call(store, *args, **kwargs)
+                return result
+
+            setattr(store, method_name, spied)
+            yield store
+
+    return spying_store

--- a/tests/scan/test_active_scan_cleanup.py
+++ b/tests/scan/test_active_scan_cleanup.py
@@ -1,7 +1,6 @@
 import time
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Iterator
+from typing import Any, Callable
 
 import anyio
 import inspect_scout._scan as scan_module
@@ -17,7 +16,7 @@ from inspect_scout._recorder.file import FileRecorder
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
 
-from tests.helpers import temp_active_scans_store
+from tests.helpers import active_scans_store_spy, temp_active_scans_store
 
 LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
 
@@ -92,19 +91,14 @@ def test_interrupted_scan_survives_a_late_metrics_write(
     # record when the scan deletes its active-scans entry
     deleted_at: list[float] = []
 
-    @contextmanager
-    def tracking_store() -> Iterator[ActiveScansStore]:
-        with active_scans_store() as store:
-            real_delete = store.delete_current
+    def record_delete(store: ActiveScansStore) -> None:
+        deleted_at.append(time.monotonic())
 
-            def tracked_delete() -> None:
-                deleted_at.append(time.monotonic())
-                real_delete()
-
-            store.delete_current = tracked_delete  # type: ignore[method-assign]
-            yield store
-
-    monkeypatch.setattr(scan_module, "active_scans_store", tracking_store)
+    monkeypatch.setattr(
+        scan_module,
+        "active_scans_store",
+        active_scans_store_spy("delete_current", record_delete),
+    )
 
     # hold the interrupted-path sync open past the throttle window
     real_sync = FileRecorder.sync

--- a/tests/scan/test_final_metrics_delivery.py
+++ b/tests/scan/test_final_metrics_delivery.py
@@ -1,0 +1,94 @@
+"""Final metrics delivery at strategy teardown (issue #569).
+
+A strategy zeroes its counts and issues one last metrics update as it
+finishes. These tests pin down that the update lands in the store.
+"""
+
+from pathlib import Path
+
+import inspect_scout._scan as scan_module
+import pytest
+from inspect_ai.util import throttle
+from inspect_scout import Result, Scanner, scan, scanner
+from inspect_scout._concurrency import single_process
+from inspect_scout._concurrency.common import ScanMetrics
+from inspect_scout._recorder.active_scans_store import ActiveScansStore
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+from tests.helpers import active_scans_store_spy, temp_active_scans_store
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+
+@scanner(name="final_metrics_scanner", messages="all")
+def final_metrics_scanner() -> Scanner[Transcript]:
+    async def scan_transcript(transcript: Transcript) -> Result:
+        return Result(value=True)
+
+    return scan_transcript
+
+
+def _run_scan_recording_metrics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, max_processes: int
+) -> list[int | None]:
+    # read back what the store kept, not what the callback was handed, so a
+    # write swallowed by a closed store cannot pass for a delivered one
+    process_counts: list[int | None] = []
+
+    def record(store: ActiveScansStore, scan_id: str, metrics: ScanMetrics) -> None:
+        info = store.read_all().get(scan_id)
+        process_counts.append(info.metrics.process_count if info else None)
+
+    monkeypatch.setattr(
+        scan_module, "active_scans_store", active_scans_store_spy("put_metrics", record)
+    )
+
+    with temp_active_scans_store():
+        status = scan(
+            scanners=[final_metrics_scanner()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=str(tmp_path),
+            limit=2,
+            max_processes=max_processes,
+            display="none",
+        )
+
+    assert status.complete
+    return process_counts
+
+
+def test_completed_scan_delivers_final_metrics_single_process(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The strategy's zeroed teardown update reaches the store.
+
+    A widened throttle window leaves every later call pending, so the final
+    update is only observed if the strategy delivers it synchronously.
+    """
+    monkeypatch.setattr(single_process, "throttle", lambda _seconds: throttle(3600))
+
+    process_counts = _run_scan_recording_metrics(monkeypatch, tmp_path, 1)
+
+    assert process_counts, "no metrics updates reached the store"
+    assert process_counts[-1] == 0, (
+        "final zeroed metrics update was dropped. the last delivered update "
+        f"still reported process_count={process_counts[-1]}"
+    )
+
+
+def test_completed_scan_delivers_final_metrics_multiprocess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Each MP worker's final zeroed metrics snapshot reaches the parent.
+
+    Spawned workers keep the real 1s window, so the update is only observed if
+    the worker delivers it synchronously and the upstream queue has room.
+    """
+    process_counts = _run_scan_recording_metrics(monkeypatch, tmp_path, 2)
+
+    assert process_counts, "no metrics updates reached the store"
+    assert process_counts[-1] == 0, (
+        "final zeroed worker metrics never reached the parent. the last "
+        f"combined update still reported process_count={process_counts[-1]}"
+    )

--- a/tests/scan/test_scan_interrupted.py
+++ b/tests/scan/test_scan_interrupted.py
@@ -1,0 +1,69 @@
+"""Interrupted-scan teardown (issue #578).
+
+Ctrl-C cancels the scan's task group, so `handle_scan_interrupted` runs
+inside an already-cancelled scope. Its recorder sync must be shielded to
+complete there; otherwise the first await re-raises the cancellation, no
+status is ever produced, and the scan trips the "scan async did not return
+a result" assertion instead of reporting an interrupted status.
+"""
+
+from pathlib import Path
+
+import anyio
+import pytest
+from inspect_scout import Result, Scanner, Status, scanner
+from inspect_scout._scan import top_level_sync_init
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+from inspect_scout.aio import scan_async
+
+from tests.helpers import temp_active_scans_store
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+# set by the test before scanning; lets it cancel only once a scanner is
+# genuinely awaiting, which is where a real Ctrl-C lands
+_scanning_started: anyio.Event | None = None
+
+
+@scanner(name="blocking_probe_scanner", messages="all")
+def blocking_probe_scanner() -> Scanner[Transcript]:
+    async def scan_transcript(transcript: Transcript) -> Result:
+        assert _scanning_started is not None
+        _scanning_started.set()
+        await anyio.sleep_forever()
+        raise RuntimeError("unreachable: the scan is expected to be cancelled")
+
+    return scan_transcript
+
+
+@pytest.mark.asyncio
+async def test_cancelled_scan_returns_interrupted_status(tmp_path: Path) -> None:
+    """Cancelling a running scan yields an interrupted status, not a crash."""
+    global _scanning_started
+    _scanning_started = anyio.Event()
+
+    top_level_sync_init("none")
+
+    statuses: list[Status] = []
+
+    async def run_scan() -> None:
+        statuses.append(
+            await scan_async(
+                scanners=[blocking_probe_scanner()],
+                transcripts=transcripts_from(LOGS_DIR),
+                scans=str(tmp_path),
+                limit=1,
+                max_processes=1,
+            )
+        )
+
+    with temp_active_scans_store():
+        with anyio.fail_after(60):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(run_scan)
+                await _scanning_started.wait()
+                tg.cancel_scope.cancel()
+
+    assert statuses, "cancelled scan did not return a status"
+    assert not statuses[0].complete


### PR DESCRIPTION
Fixes #569.
Fixes #578.

fix: complete the interrupted-status sync under Ctrl-C (#578)

**What happens**

The final zeroed metrics update goes out through the same `@throttle(1)` callback as every other update, so when it lands inside the throttle window it becomes a pending trailing-edge fire that has to survive teardown. It does not. In a worker subprocess there is no background task group, so the fire is a bare `asyncio.create_task` that dies when the worker's loop exits after `WorkerComplete`, and the parent goes on counting that worker's last non zero snapshot in its sum for the rest of the run. Scanning 4 transcripts with 2 workers where one takes much longer, the first worker finished about 2 seconds in and the display kept reporting 2 processes and 1 transcript parsing for the remaining 12 seconds, 3 of 3 runs. The single process path drops the update too, invisibly, since the store entry is deleted right after.

**The fix**

The `finally` now delivers the final update by calling the callback directly instead of through the throttle, then sets a flag so a pending fire cannot deliver a duplicate afterwards. One choke point covers both paths.

Calling `set_background_task_group` in the worker instead would give the fire somewhere to live, but it makes the worker task group wait out the throttle window on every exit and leaves the single process path unfixed.

**Verification**

Two tests through the public `scan()` API, red 3 of 3 on main and green 3 of 3 each. The multiprocess one runs the real throttle window, so its red direction depends on teardown landing inside that window. The green direction does not, because the delivery is synchronous and ordered ahead of `WorkerComplete`. #564's tests still pass, and so does the full suite.

The diff also lifts the store spying helper that #564's test had inline into `tests/helpers.py`, so both use one copy.

cc @epatey


