### PR TITLE
chore: migrate to anthropic 1.0 SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ dev = [
     # zipfile-zstd patches zipfile to support zstd compression (for creating test fixtures)
     "zipfile-zstd>=0.0.4; python_version < '3.14'",
     "pytest-xdist",
-    "anthropic>=0.80.0",
+    # >=1.0.0: anthropic 1.x types its exceptions against httpx2, which the
+    # tests construct directly (httpx2 arrives transitively via anthropic)
+    "anthropic>=1.0.0",
     "arize-phoenix-client",
     "google-genai>=1.69.0",
     # harbor (for the atif source tests): >=0.6.0 is the first release with the
@@ -97,7 +99,9 @@ dev = [
     "ruff",
     "pytest",
     "pytest-xdist",
-    "anthropic",
+    # >=1.0.0: anthropic 1.x types its exceptions against httpx2, which the
+    # tests construct directly (httpx2 arrives transitively via anthropic)
+    "anthropic>=1.0.0",
     "arize-phoenix-client",
     "google-genai",
     # harbor (for the atif source tests): >=0.6.0 is the first release with the

--- a/tests/observe/test_observe_stream_errors.py
+++ b/tests/observe/test_observe_stream_errors.py
@@ -13,7 +13,6 @@ end-to-end happy path is covered by ``test_observe_providers.py``.
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Callable, Iterator
 
-import httpx
 import httpx2
 import pytest
 
@@ -88,7 +87,7 @@ def _anthropic_error() -> Exception:
     import anthropic
 
     return anthropic.APIConnectionError(
-        message="overloaded_error", request=httpx.Request("POST", "http://test")
+        message="overloaded_error", request=httpx2.Request("POST", "http://test")
     )
 
 

--- a/tests/view/test_api_v2_search.py
+++ b/tests/view/test_api_v2_search.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import anthropic
-import httpx
 import httpx2
 import openai
 import pytest
@@ -21,10 +20,6 @@ from inspect_scout._view._api_v2 import v2_api_app
 from inspect_scout._view._api_v2_search import LLM_SEARCH_TEMPLATE
 from inspect_scout._view._api_v2_types import SearchRequest
 from pydantic import TypeAdapter
-
-
-def _fake_httpx_response(status_code: int) -> httpx.Response:
-    return httpx.Response(status_code, request=httpx.Request("POST", "https://test"))
 
 
 def _fake_httpx2_response(status_code: int) -> httpx2.Response:
@@ -349,7 +344,7 @@ class TestSearchEndpoint:
             (
                 anthropic.NotFoundError(
                     "model: claude-haiku-4.5",
-                    response=_fake_httpx_response(404),
+                    response=_fake_httpx2_response(404),
                     body=None,
                 ),
                 "model: claude-haiku-4.5",


### PR DESCRIPTION
Fixes #573

Bump the dev dependency floor to anthropic>=1.0.0 and update the two
tests that construct anthropic exceptions to pass httpx2 request and
response objects, matching how the 1.x SDK types its exceptions
(mirrors the existing openai>=3.0.0 handling).

Fixes #573

Co-authored-by: Eric Patey <769548+epatey@users.noreply.github.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>