### PR TITLE
feat: typed parsed answers on scanner results

### DIFF
--- a/docs/llm_scanner.qmd
+++ b/docs/llm_scanner.qmd
@@ -257,8 +257,10 @@ Scanners produce results which ultimately carry a specific `value`. There are tw
     class ToolErrors(BaseModel):
         tool_errors: int = Field(alias="value", description="The number of tool errors encountered.")
 
-        causes: str = Field(description="What were the most common causes of tool errors.") 
+        causes: str = Field(description="What were the most common causes of tool errors.")
     ```
+
+In addition to the serialized `value`, results carry an in-memory `parsed` field with the validated instance of your `BaseModel` type — useful when working with `generate_answer()` directly in a custom scanner (see [Scanner Tools](scanner_tools.qmd#answer-generation)). Note that `parsed` is not stored in the results database.
 
 ### Labels and Explanations
 

--- a/docs/llm_scanner.qmd
+++ b/docs/llm_scanner.qmd
@@ -260,8 +260,6 @@ Scanners produce results which ultimately carry a specific `value`. There are tw
         causes: str = Field(description="What were the most common causes of tool errors.")
     ```
 
-In addition to the serialized `value`, results carry an in-memory `parsed` field with the validated instance of your `BaseModel` type — useful when working with `generate_answer()` directly in a custom scanner (see [Scanner Tools](scanner_tools.qmd#answer-generation)). Note that `parsed` is not stored in the results database.
-
 ### Labels and Explanations
 
 We've noted the special `alias="value"` field annotation that promotes one of your `BaseModel` fields to be the main `value` for the returned result. In addition, there are two other special field annotations:

--- a/docs/scanner_tools.qmd
+++ b/docs/scanner_tools.qmd
@@ -209,7 +209,7 @@ result = await generate_answer(
 
 : {tbl-colwidths=\[25,75\]}
 
-In addition to the serialized `value`, the returned `Result` carries an in-memory `parsed` field with the typed parsed answer — `bool` for `"boolean"`, `float` for `"numeric"`, `str` for `"string"` and single-label answers, `list[str]` for multi-label answers, and validated instances of your Pydantic type for `AnswerStructured` (where the return type is inferred from the answer specification, e.g. `Result[Detection]` from `AnswerStructured(Detection)`). It is `None` whenever the response could not be parsed, and is excluded from serialization, so it does not survive storage of results.
+In addition to the serialized `value`, the returned `Result` carries an in-memory `parsed` field with the typed parsed answer — `bool` for `"boolean"`, `float` for `"numeric"`, `str` for `"string"` and single-label answers, `list[str]` for multi-label answers, and validated instances of your Pydantic type for `AnswerStructured` (where the return type is inferred from the answer specification, e.g. `Result[Detection]` from `AnswerStructured(Detection)`). It is `None` whenever the response could not be parsed, and is excluded from serialization and pickling, so it does not survive storage of results or crossing process boundaries.
 
 ## Answer Parsing
 
@@ -240,7 +240,7 @@ result = parse_answer(
 
 : {tbl-colwidths=\[25,75\]}
 
-Like `generate_answer()`, the returned `Result` carries the typed parsed answer in its in-memory `parsed` field (see [Answer Generation](#answer-generation)).
+Like `generate_answer()`, the returned `Result` carries the typed parsed answer in its in-memory `parsed` field (see [Answer Generation](#answer-generation)). One difference: for `AnswerStructured` answers, `parse_answer()` raises `ValidationError` on output that does not conform to the answer type, rather than returning `parsed=None`.
 
 ## Answer Types {#answer-types}
 

--- a/docs/scanner_tools.qmd
+++ b/docs/scanner_tools.qmd
@@ -209,7 +209,23 @@ result = await generate_answer(
 
 : {tbl-colwidths=\[25,75\]}
 
-In addition to the serialized `value`, the returned `Result` carries an in-memory `parsed` field with the typed parsed answer — `bool` for `"boolean"`, `float` for `"numeric"`, `str` for `"string"` and single-label answers, `list[str]` for multi-label answers, and validated instances of your Pydantic type for `AnswerStructured` (where the return type is inferred from the answer specification, e.g. `Result[Detection]` from `AnswerStructured(Detection)`). It is `None` whenever the response could not be parsed, and is excluded from serialization and pickling, so it does not survive storage of results or crossing process boundaries.
+In addition to the serialized `value`, the returned `Result` carries the typed parsed answer in its `parsed` field. For `AnswerStructured` this is the validated instance of your Pydantic type, with the result typed accordingly:
+
+``` python
+from pydantic import BaseModel, Field
+from inspect_scout import AnswerStructured, generate_answer
+
+class Detection(BaseModel):
+    behavior: str = Field(description="Behavior observed.")
+    confidence: float = Field(description="Confidence from 0 to 1.")
+
+# Result[Detection]
+result = await generate_answer(prompt, answer=AnswerStructured(Detection))
+if result.parsed is not None:
+    print(result.parsed.confidence)
+```
+
+Note that `parsed` is in-memory only: it is `None` when the response could not be parsed, and it is not stored with results.
 
 ## Answer Parsing
 
@@ -240,7 +256,7 @@ result = parse_answer(
 
 : {tbl-colwidths=\[25,75\]}
 
-Like `generate_answer()`, the returned `Result` carries the typed parsed answer in its in-memory `parsed` field (see [Answer Generation](#answer-generation)). One difference: for `AnswerStructured` answers, `parse_answer()` raises `ValidationError` on output that does not conform to the answer type, rather than returning `parsed=None`.
+As with `generate_answer()`, the returned `Result` carries the typed parsed answer in its `parsed` field (though for `AnswerStructured` answers, `parse_answer()` raises `ValidationError` on non-conforming output rather than returning `parsed=None`).
 
 ## Answer Types {#answer-types}
 

--- a/docs/scanner_tools.qmd
+++ b/docs/scanner_tools.qmd
@@ -209,6 +209,7 @@ result = await generate_answer(
 
 : {tbl-colwidths=\[25,75\]}
 
+In addition to the serialized `value`, the returned `Result` carries an in-memory `parsed` field with the typed parsed answer — `bool` for `"boolean"`, `float` for `"numeric"`, `str` for `"string"` and single-label answers, `list[str]` for multi-label answers, and validated instances of your Pydantic type for `AnswerStructured` (where the return type is inferred from the answer specification, e.g. `Result[Detection]` from `AnswerStructured(Detection)`). It is `None` whenever the response could not be parsed, and is excluded from serialization, so it does not survive storage of results.
 
 ## Answer Parsing
 
@@ -238,6 +239,8 @@ result = parse_answer(
 | `value_to_float` | Optional function to convert the parsed value to a float. |
 
 : {tbl-colwidths=\[25,75\]}
+
+Like `generate_answer()`, the returned `Result` carries the typed parsed answer in its in-memory `parsed` field (see [Answer Generation](#answer-generation)).
 
 ## Answer Types {#answer-types}
 

--- a/docs/scanner_tools.qmd
+++ b/docs/scanner_tools.qmd
@@ -225,7 +225,7 @@ if result.parsed is not None:
     print(result.parsed.confidence)
 ```
 
-Note that `parsed` is in-memory only: it is `None` when the response could not be parsed, and it is not stored with results.
+Note that `parsed` is `None` when the response could not be parsed. It is also dropped whenever the `Result` is serialized, so it does not appear in stored results.
 
 ## Answer Parsing
 

--- a/src/inspect_scout/_llm_scanner/answer.py
+++ b/src/inspect_scout/_llm_scanner/answer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, Literal, Protocol, Sequence, runtime_checkable
+from typing import Any, Callable, Literal, Protocol, Sequence, cast, runtime_checkable
 
 from inspect_ai._util.pattern import ANSWER_PATTERN_WORD
 from inspect_ai._util.text import (
@@ -98,7 +98,7 @@ def answer_from_argument(
     answer: Literal["boolean", "numeric", "string"]
     | list[str]
     | AnswerMultiLabel
-    | AnswerStructured,
+    | AnswerStructured[Any],
 ) -> Answer:
     match answer:
         case "boolean":
@@ -123,7 +123,7 @@ def answer_type(
     answer: Literal["boolean", "numeric", "string"]
     | list[str]
     | AnswerMultiLabel
-    | AnswerStructured,
+    | AnswerStructured[Any],
 ) -> Answer:
     """Resolve an answer specification into an Answer object.
 
@@ -172,6 +172,7 @@ class _BoolAnswer(Answer):
                 case "yes":
                     return Result(
                         value=True if value_to_float is None else value_to_float(True),
+                        parsed=True,
                         answer="Yes",
                         explanation=explanation,
                         references=references,
@@ -181,6 +182,7 @@ class _BoolAnswer(Answer):
                         value=False
                         if value_to_float is None
                         else value_to_float(False),
+                        parsed=False,
                         answer="No",
                         explanation=explanation,
                         references=references,
@@ -219,6 +221,7 @@ class _NumberAnswer(Answer):
 
                 return Result(
                     value=value,
+                    parsed=answer,
                     answer=str(answer),
                     explanation=explanation,
                     references=references,
@@ -290,8 +293,10 @@ class _LabelsAnswer(Answer):
             if self.multi_classification:
                 # "NONE" means no labels apply (only when allow_none is set)
                 if answer_text.upper() == "NONE" and self.allow_none:
+                    no_labels: list[str] = []
                     return Result(
-                        value=[],
+                        value=cast(JsonValue, no_labels),
+                        parsed=no_labels,
                         answer=answer_text,
                         explanation=explanation,
                         references=references,
@@ -312,12 +317,13 @@ class _LabelsAnswer(Answer):
 
                 # Return result if at least one valid letter found
                 if valid_letters:
-                    answer_labels: JsonValue = [
+                    answer_labels = [
                         self.labels[valid_characters.index(letter)]
                         for letter in valid_letters
                     ]
                     return Result(
-                        value=answer_labels,
+                        value=cast(JsonValue, answer_labels),
+                        parsed=answer_labels,
                         answer=answer_text,
                         explanation=explanation,
                         references=references,
@@ -331,6 +337,7 @@ class _LabelsAnswer(Answer):
                         value=value_to_float(answer_letter)
                         if value_to_float
                         else answer_letter,
+                        parsed=self.labels[index],
                         answer=self.labels[index],
                         explanation=explanation,
                         references=references,
@@ -369,6 +376,7 @@ class _StrAnswer(Answer):
 
             return Result(
                 value=value_to_float(answer_text) if value_to_float else answer_text,
+                parsed=answer_text,
                 answer=answer_text,
                 explanation=explanation,
                 references=references,
@@ -410,7 +418,7 @@ def _answer_character(index: int) -> str:
 
 
 class _StructuredAnswer(Answer):
-    def __init__(self, answer: AnswerStructured):
+    def __init__(self, answer: AnswerStructured[Any]):
         self.answer = answer
 
     @property

--- a/src/inspect_scout/_llm_scanner/generate.py
+++ b/src/inspect_scout/_llm_scanner/generate.py
@@ -111,16 +111,11 @@ def parse_answer(
             to a float.
 
     Returns:
-        A Result with value, answer, explanation, and references. The
-        result's ``parsed`` field carries the typed parsed answer —
-        ``bool`` for ``"boolean"``, ``float`` for ``"numeric"``, ``str``
-        for ``"string"`` and single-label answers, ``list[str]`` for
-        multi-label answers, and the validated instance(s) of the answer
-        type for :class:`AnswerStructured` — or ``None`` when the
-        response could not be parsed. Note that for
-        :class:`AnswerStructured` answers, output that does not conform
-        to the answer type raises ``ValidationError`` rather than
-        returning ``parsed=None``.
+        A Result with value, answer, explanation, and references. Its
+        ``parsed`` field carries the typed parsed answer, or ``None`` if
+        the output could not be parsed (except for
+        :class:`AnswerStructured`, where non-conforming output raises
+        ``ValidationError`` instead).
     """
     resolved = answer_from_argument(answer)
     return resolved.result_for_answer(output, extract_refs, value_to_float)
@@ -279,11 +274,8 @@ async def generate_answer(
     Returns:
         A :class:`Result` when ``parse=True``, or a :class:`ModelOutput`
         when ``parse=False``. The result's ``parsed`` field carries the
-        typed parsed answer — ``bool`` for ``"boolean"``, ``float`` for
-        ``"numeric"``, ``str`` for ``"string"`` and single-label answers,
-        ``list[str]`` for multi-label answers, and the validated
-        instance(s) of the answer type for :class:`AnswerStructured` —
-        or ``None`` when the model's response could not be parsed.
+        typed parsed answer, or ``None`` when the response could not be
+        parsed.
     """
     if isinstance(answer, AnswerStructured):
         value, _, model_output = await structured_generate(

--- a/src/inspect_scout/_llm_scanner/generate.py
+++ b/src/inspect_scout/_llm_scanner/generate.py
@@ -117,7 +117,10 @@ def parse_answer(
         for ``"string"`` and single-label answers, ``list[str]`` for
         multi-label answers, and the validated instance(s) of the answer
         type for :class:`AnswerStructured` — or ``None`` when the
-        response could not be parsed.
+        response could not be parsed. Note that for
+        :class:`AnswerStructured` answers, output that does not conform
+        to the answer type raises ``ValidationError`` rather than
+        returning ``parsed=None``.
     """
     resolved = answer_from_argument(answer)
     return resolved.result_for_answer(output, extract_refs, value_to_float)

--- a/src/inspect_scout/_llm_scanner/generate.py
+++ b/src/inspect_scout/_llm_scanner/generate.py
@@ -26,8 +26,68 @@ from .._util.jinja import StrictOnUseUndefined
 from .._util.refusal import generate_retry_refusals
 from .answer import Answer, answer_from_argument
 from .prompt import DEFAULT_SCANNER_TEMPLATE
-from .structured import structured_generate, structured_schema
-from .types import AnswerSpec, AnswerStructured, _TextualAnswerSpec
+from .structured import structured_generate, structured_result, structured_schema
+from .types import (
+    AnswerMultiLabel,
+    AnswerSpec,
+    AnswerStructured,
+    StructuredT,
+    _TextualAnswerSpec,
+)
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: AnswerStructured[StructuredT],
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result[StructuredT]: ...
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: Literal["boolean"],
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result[bool]: ...
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: Literal["numeric"],
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result[float]: ...
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: Literal["string"] | list[str],
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result[str]: ...
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: AnswerMultiLabel,
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result[list[str]]: ...
+
+
+@overload
+def parse_answer(
+    output: ModelOutput,
+    answer: AnswerSpec,
+    extract_refs: Callable[[str], list[Reference]],
+    value_to_float: ValueToFloat | None = None,
+) -> Result: ...
 
 
 def parse_answer(
@@ -51,10 +111,91 @@ def parse_answer(
             to a float.
 
     Returns:
-        A Result with value, answer, explanation, and references.
+        A Result with value, answer, explanation, and references. The
+        result's ``parsed`` field carries the typed parsed answer —
+        ``bool`` for ``"boolean"``, ``float`` for ``"numeric"``, ``str``
+        for ``"string"`` and single-label answers, ``list[str]`` for
+        multi-label answers, and the validated instance(s) of the answer
+        type for :class:`AnswerStructured` — or ``None`` when the
+        response could not be parsed.
     """
     resolved = answer_from_argument(answer)
     return resolved.result_for_answer(output, extract_refs, value_to_float)
+
+
+@overload
+async def generate_answer(
+    prompt: str | list[ChatMessage],
+    answer: AnswerStructured[StructuredT],
+    *,
+    model: str | Model | None = None,
+    config: GenerateConfig | None = None,
+    context_tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] = (),
+    retry_refusals: int = 3,
+    parse: Literal[True] = True,
+    extract_refs: Callable[[str], list[Reference]] | None = None,
+    value_to_float: ValueToFloat | None = None,
+) -> Result[StructuredT]: ...
+
+
+@overload
+async def generate_answer(
+    prompt: str | list[ChatMessage],
+    answer: Literal["boolean"],
+    *,
+    model: str | Model | None = None,
+    config: GenerateConfig | None = None,
+    context_tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] = (),
+    retry_refusals: int = 3,
+    parse: Literal[True] = True,
+    extract_refs: Callable[[str], list[Reference]] | None = None,
+    value_to_float: ValueToFloat | None = None,
+) -> Result[bool]: ...
+
+
+@overload
+async def generate_answer(
+    prompt: str | list[ChatMessage],
+    answer: Literal["numeric"],
+    *,
+    model: str | Model | None = None,
+    config: GenerateConfig | None = None,
+    context_tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] = (),
+    retry_refusals: int = 3,
+    parse: Literal[True] = True,
+    extract_refs: Callable[[str], list[Reference]] | None = None,
+    value_to_float: ValueToFloat | None = None,
+) -> Result[float]: ...
+
+
+@overload
+async def generate_answer(
+    prompt: str | list[ChatMessage],
+    answer: Literal["string"] | list[str],
+    *,
+    model: str | Model | None = None,
+    config: GenerateConfig | None = None,
+    context_tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] = (),
+    retry_refusals: int = 3,
+    parse: Literal[True] = True,
+    extract_refs: Callable[[str], list[Reference]] | None = None,
+    value_to_float: ValueToFloat | None = None,
+) -> Result[str]: ...
+
+
+@overload
+async def generate_answer(
+    prompt: str | list[ChatMessage],
+    answer: AnswerMultiLabel,
+    *,
+    model: str | Model | None = None,
+    config: GenerateConfig | None = None,
+    context_tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] = (),
+    retry_refusals: int = 3,
+    parse: Literal[True] = True,
+    extract_refs: Callable[[str], list[Reference]] | None = None,
+    value_to_float: ValueToFloat | None = None,
+) -> Result[list[str]]: ...
 
 
 @overload
@@ -134,10 +275,13 @@ async def generate_answer(
 
     Returns:
         A :class:`Result` when ``parse=True``, or a :class:`ModelOutput`
-        when ``parse=False``.
+        when ``parse=False``. The result's ``parsed`` field carries the
+        typed parsed answer — ``bool`` for ``"boolean"``, ``float`` for
+        ``"numeric"``, ``str`` for ``"string"`` and single-label answers,
+        ``list[str]`` for multi-label answers, and the validated
+        instance(s) of the answer type for :class:`AnswerStructured` —
+        or ``None`` when the model's response could not be parsed.
     """
-    resolved_answer = answer_from_argument(answer)
-
     if isinstance(answer, AnswerStructured):
         value, _, model_output = await structured_generate(
             input=prompt,
@@ -156,9 +300,7 @@ async def generate_answer(
                 metadata={"stop_reason": model_output.stop_reason},
             )
         refs_fn = extract_refs or _no_references
-        result = resolved_answer.result_for_answer(
-            model_output, refs_fn, value_to_float
-        )
+        result = structured_result(answer, model_output, refs_fn, value_to_float)
         result.metadata = {
             **(result.metadata or {}),
             "stop_reason": model_output.stop_reason,
@@ -169,7 +311,7 @@ async def generate_answer(
         return await _text_generate(
             get_model(model),
             prompt,
-            resolved_answer,
+            answer_from_argument(answer),
             config,
             context_tools,
             retry_refusals,

--- a/src/inspect_scout/_llm_scanner/generate.py
+++ b/src/inspect_scout/_llm_scanner/generate.py
@@ -31,7 +31,7 @@ from .types import (
     AnswerMultiLabel,
     AnswerSpec,
     AnswerStructured,
-    StructuredT,
+    StructuredAnswerT,
     _TextualAnswerSpec,
 )
 
@@ -39,10 +39,10 @@ from .types import (
 @overload
 def parse_answer(
     output: ModelOutput,
-    answer: AnswerStructured[StructuredT],
+    answer: AnswerStructured[StructuredAnswerT],
     extract_refs: Callable[[str], list[Reference]],
     value_to_float: ValueToFloat | None = None,
-) -> Result[StructuredT]: ...
+) -> Result[StructuredAnswerT]: ...
 
 
 @overload
@@ -126,7 +126,7 @@ def parse_answer(
 @overload
 async def generate_answer(
     prompt: str | list[ChatMessage],
-    answer: AnswerStructured[StructuredT],
+    answer: AnswerStructured[StructuredAnswerT],
     *,
     model: str | Model | None = None,
     config: GenerateConfig | None = None,
@@ -135,7 +135,7 @@ async def generate_answer(
     parse: Literal[True] = True,
     extract_refs: Callable[[str], list[Reference]] | None = None,
     value_to_float: ValueToFloat | None = None,
-) -> Result[StructuredT]: ...
+) -> Result[StructuredAnswerT]: ...
 
 
 @overload

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -184,7 +184,7 @@ def _context_tool_stub(
 ST = TypeVar("ST", bound=BaseModel)
 
 
-def structured_schema(answer: AnswerStructured) -> JSONSchema:
+def structured_schema(answer: AnswerStructured[Any]) -> JSONSchema:
     # Augment the type with an explanation field if it doesn't have one
     answer_type, result_set = structured_answer_type(answer)
     augmented_type = augment_type_with_explanation(answer_type)
@@ -228,7 +228,9 @@ def structured_schema(answer: AnswerStructured) -> JSONSchema:
         return JSONSchema.model_validate(item_schema)
 
 
-def structured_answer_type(answer: AnswerStructured) -> tuple[type[BaseModel], bool]:
+def structured_answer_type(
+    answer: AnswerStructured[Any],
+) -> tuple[type[BaseModel], bool]:
     if get_origin(answer.type) is list:
         args = get_args(answer.type)
         if not args or not issubclass(args[0], BaseModel):
@@ -242,7 +244,7 @@ def structured_answer_type(answer: AnswerStructured) -> tuple[type[BaseModel], b
 
 
 def structured_result(
-    answer: AnswerStructured,
+    answer: AnswerStructured[Any],
     output: ModelOutput,
     extract_references_fn: Callable[[str], list[Reference]],
     value_to_float: ValueToFloat | None = None,
@@ -256,13 +258,28 @@ def structured_result(
         value_to_float: Optional function to convert result values to float
 
     Returns:
-        A Result object
+        A Result whose ``parsed`` field carries the validated answer
+        instance(s), typed by the declared answer type.
     """
     # parse out type info
     answer_type, result_set = structured_answer_type(answer)
 
     # Augment the type with an explanation field if it doesn't have one
     augmented_type = augment_type_with_explanation(answer_type)
+
+    def as_declared_type(obj: BaseModel) -> BaseModel:
+        """Return ``obj`` as an instance of the declared answer type.
+
+        When the type was augmented with an explanation field, re-validate
+        into the declared type: the explanation is carried on
+        ``Result.explanation``, and augmented types are created dynamically
+        so their instances are not picklable.
+        """
+        if type(obj) is answer_type:
+            return obj
+        return answer_type.model_validate(
+            obj.model_dump(exclude={"explanation"}), by_name=True
+        )
 
     # For single results, parse directly into the type
     # For result sets, we need to extract the list from the synthesized wrapper
@@ -360,6 +377,7 @@ def structured_result(
 
         return Result(
             value=value,
+            parsed=as_declared_type(obj),
             explanation=explanation_value,
             label=label_value,
             metadata=metadata if metadata else None,
@@ -379,7 +397,9 @@ def structured_result(
         results = [create_result_from_parsed(item) for item in parsed_items]
 
         # Return as a result set
-        return as_resultset(results)
+        resultset = as_resultset(results)
+        resultset.parsed = [as_declared_type(item) for item in parsed_items]
+        return resultset
     else:
         # Handle single result
         assert parsed is not None  # parsed is always set for single results

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -251,6 +251,12 @@ def structured_answer_type(
     return answer_type, result_set
 
 
+class _InjectedExplanation(BaseModel):
+    """Validates the explanation field injected into augmented answer schemas."""
+
+    explanation: str
+
+
 def structured_result(
     answer: AnswerStructured[Any],
     output: ModelOutput,
@@ -304,15 +310,13 @@ def structured_result(
         Validation runs exactly once, on the wire-format data, so
         ``mode="before"`` validators and ``model_post_init`` see it exactly
         once. An injected explanation field is lifted out before validation
-        (the declared type may forbid extra fields).
+        (the declared type may forbid extra fields) and validated separately,
+        raising ``ValidationError`` when missing or malformed — models violate
+        the answer schema often enough that callers rely on catching it.
         """
         if augmented:
-            if not isinstance(data, dict) or "explanation" not in data:
-                raise ValueError("Missing required 'explanation' field")
-            data = dict(data)
-            explanation = data.pop("explanation")
-            if not isinstance(explanation, str):
-                raise ValueError("'explanation' field must be a string")
+            explanation = _InjectedExplanation.model_validate(data).explanation
+            data = {k: v for k, v in data.items() if k != "explanation"}
             return answer_type.model_validate(data, by_name=True), explanation
         else:
             instance = answer_type.model_validate(data, by_name=True)

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -266,8 +266,7 @@ def structured_result(
         value_to_float: Optional function to convert result values to float
 
     Returns:
-        A Result whose ``parsed`` field carries the validated answer
-        instance(s), typed by the declared answer type.
+        A Result with ``parsed`` set to the validated answer instance(s).
     """
     # parse out type info
     answer_type, result_set = structured_answer_type(answer)
@@ -302,12 +301,10 @@ def structured_result(
     def parse_answer_data(data: Any) -> tuple[BaseModel, Any]:
         """Validate answer data, returning the instance and its explanation.
 
-        Validation runs exactly once, on the wire-format data, so field
-        validators (e.g. ``mode="before"`` parsers) see the input they
-        expect and side effects like ``model_post_init`` happen once. When
-        the explanation field was injected into the generation schema, it
-        is lifted out before validation (the declared type may forbid
-        extra fields); otherwise it is read from the validated instance.
+        Validation runs exactly once, on the wire-format data, so
+        ``mode="before"`` validators and ``model_post_init`` see it exactly
+        once. An injected explanation field is lifted out before validation
+        (the declared type may forbid extra fields).
         """
         if augmented:
             if not isinstance(data, dict) or "explanation" not in data:
@@ -324,15 +321,7 @@ def structured_result(
 
     # Helper: Create a Result from a parsed object
     def create_result_from_parsed(obj: BaseModel, explanation_value: Any) -> Result:
-        """Create a Result from a validated answer instance.
-
-        Args:
-            obj: The validated instance of the declared answer type.
-            explanation_value: The explanation extracted by ``parse_answer_data``.
-
-        Returns:
-            A Result object.
-        """
+        """Create a Result from a validated answer instance and its explanation."""
         # Fields lifted out of value/metadata: the declared type's own
         # explanation field (when present), label, and any value-aliased field
         exclude_from_metadata: set[str] = set()

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -273,13 +273,15 @@ def structured_result(
         When the type was augmented with an explanation field, re-validate
         into the declared type: the explanation is carried on
         ``Result.explanation``, and augmented types are created dynamically
-        so their instances are not picklable.
+        so their instances are not picklable. Validation is from the
+        already-validated field values (not ``model_dump()``, whose custom
+        field serializers and excluded fields need not round-trip).
         """
         if type(obj) is answer_type:
             return obj
-        return answer_type.model_validate(
-            obj.model_dump(exclude={"explanation"}), by_name=True
-        )
+        fields = dict(obj)
+        fields.pop("explanation", None)
+        return answer_type.model_validate(fields, by_name=True)
 
     # For single results, parse directly into the type
     # For result sets, we need to extract the list from the synthesized wrapper
@@ -398,7 +400,7 @@ def structured_result(
 
         # Return as a result set
         resultset = as_resultset(results)
-        resultset.parsed = [as_declared_type(item) for item in parsed_items]
+        resultset.parsed = [result.parsed for result in results]
         return resultset
     else:
         # Handle single result

--- a/src/inspect_scout/_llm_scanner/structured.py
+++ b/src/inspect_scout/_llm_scanner/structured.py
@@ -231,12 +231,20 @@ def structured_schema(answer: AnswerStructured[Any]) -> JSONSchema:
 def structured_answer_type(
     answer: AnswerStructured[Any],
 ) -> tuple[type[BaseModel], bool]:
-    if get_origin(answer.type) is list:
+    origin = get_origin(answer.type)
+    if origin is list:
         args = get_args(answer.type)
         if not args or not issubclass(args[0], BaseModel):
             raise ValueError("List must be parameterized with BaseModel subclass")
         answer_type = args[0]
         result_set = True
+    elif origin is not None:
+        # e.g. tuple[Model, ...] — statically admitted by the Sequence bound
+        # but only list is supported
+        raise ValueError(
+            f"AnswerStructured type must be a BaseModel subclass or a "
+            f"list of BaseModel, not {answer.type}"
+        )
     else:
         answer_type = answer.type
         result_set = False
@@ -264,46 +272,9 @@ def structured_result(
     # parse out type info
     answer_type, result_set = structured_answer_type(answer)
 
-    # Augment the type with an explanation field if it doesn't have one
-    augmented_type = augment_type_with_explanation(answer_type)
-
-    def as_declared_type(obj: BaseModel) -> BaseModel:
-        """Return ``obj`` as an instance of the declared answer type.
-
-        When the type was augmented with an explanation field, re-validate
-        into the declared type: the explanation is carried on
-        ``Result.explanation``, and augmented types are created dynamically
-        so their instances are not picklable. Validation is from the
-        already-validated field values (not ``model_dump()``, whose custom
-        field serializers and excluded fields need not round-trip).
-        """
-        if type(obj) is answer_type:
-            return obj
-        fields = dict(obj)
-        fields.pop("explanation", None)
-        return answer_type.model_validate(fields, by_name=True)
-
-    # For single results, parse directly into the type
-    # For result sets, we need to extract the list from the synthesized wrapper
-    if result_set is False:
-        parsed = augmented_type.model_validate_json(output.completion, by_name=True)
-    else:
-        # Parse as a generic dict first to extract the list
-        wrapper_data = json.loads(output.completion)
-
-        # Determine the field name
-        field_name = "results" if result_set is True else result_set
-
-        # Extract the list from the wrapper
-        if field_name not in wrapper_data:
-            raise ValueError(f"Expected field '{field_name}' in result set wrapper")
-
-        list_data = wrapper_data[field_name]
-        if not isinstance(list_data, list):
-            raise ValueError(f"Field '{field_name}' must be a list")
-
-        # We'll handle this list below, so set parsed to None for now
-        parsed = None
+    # Whether an explanation field was injected into the generation schema
+    # (i.e. the declared type has none of its own)
+    augmented = augment_type_with_explanation(answer_type) is not answer_type
 
     # Helper: Find field value by name or alias
     def get_field_by_name_or_alias(
@@ -327,28 +298,50 @@ def structured_result(
 
         return None, None
 
+    # Helper: Validate one answer object into the declared type.
+    def parse_answer_data(data: Any) -> tuple[BaseModel, Any]:
+        """Validate answer data, returning the instance and its explanation.
+
+        Validation runs exactly once, on the wire-format data, so field
+        validators (e.g. ``mode="before"`` parsers) see the input they
+        expect and side effects like ``model_post_init`` happen once. When
+        the explanation field was injected into the generation schema, it
+        is lifted out before validation (the declared type may forbid
+        extra fields); otherwise it is read from the validated instance.
+        """
+        if augmented:
+            if not isinstance(data, dict) or "explanation" not in data:
+                raise ValueError("Missing required 'explanation' field")
+            data = dict(data)
+            explanation = data.pop("explanation")
+            if not isinstance(explanation, str):
+                raise ValueError("'explanation' field must be a string")
+            return answer_type.model_validate(data, by_name=True), explanation
+        else:
+            instance = answer_type.model_validate(data, by_name=True)
+            _, explanation = get_field_by_name_or_alias(instance, "explanation")
+            return instance, explanation
+
     # Helper: Create a Result from a parsed object
-    def create_result_from_parsed(obj: BaseModel) -> Result:
-        """Create a Result from a parsed BaseModel object.
+    def create_result_from_parsed(obj: BaseModel, explanation_value: Any) -> Result:
+        """Create a Result from a validated answer instance.
 
         Args:
-            obj: The parsed BaseModel instance.
+            obj: The validated instance of the declared answer type.
+            explanation_value: The explanation extracted by ``parse_answer_data``.
 
         Returns:
             A Result object.
         """
-        # Extract explanation (required)
-        explanation_field, explanation_value = get_field_by_name_or_alias(
-            obj, "explanation"
-        )
-        if explanation_field is None:
-            raise ValueError("Missing required 'explanation' field")
+        # Fields lifted out of value/metadata: the declared type's own
+        # explanation field (when present), label, and any value-aliased field
+        exclude_from_metadata: set[str] = set()
+        explanation_field, _ = get_field_by_name_or_alias(obj, "explanation")
+        if explanation_field:
+            exclude_from_metadata.add(explanation_field)
 
         # Extract label (optional - can be used to distinguish results in a result set)
         label_field, label_value = get_field_by_name_or_alias(obj, "label")
-
-        # Determine the value
-        exclude_from_metadata = {explanation_field}
         if label_field:
             exclude_from_metadata.add(label_field)
 
@@ -379,7 +372,7 @@ def structured_result(
 
         return Result(
             value=value,
-            parsed=as_declared_type(obj),
+            parsed=obj,
             explanation=explanation_value,
             label=label_value,
             metadata=metadata if metadata else None,
@@ -390,13 +383,19 @@ def structured_result(
 
     # Handle result set (multiple results)
     if result_set is not False:
-        # Parse each item in the list as an instance of the augmented type
-        parsed_items = [
-            augmented_type.model_validate(item, by_name=True) for item in list_data
-        ]
+        # Extract the list of answer objects from the synthesized wrapper
+        wrapper_data = json.loads(output.completion)
+        field_name = "results" if result_set is True else result_set
+        if field_name not in wrapper_data:
+            raise ValueError(f"Expected field '{field_name}' in result set wrapper")
+        list_data = wrapper_data[field_name]
+        if not isinstance(list_data, list):
+            raise ValueError(f"Field '{field_name}' must be a list")
 
-        # Create a Result for each parsed item
-        results = [create_result_from_parsed(item) for item in parsed_items]
+        # Create a Result for each answer object
+        results = [
+            create_result_from_parsed(*parse_answer_data(item)) for item in list_data
+        ]
 
         # Return as a result set
         resultset = as_resultset(results)
@@ -404,8 +403,9 @@ def structured_result(
         return resultset
     else:
         # Handle single result
-        assert parsed is not None  # parsed is always set for single results
-        return create_result_from_parsed(parsed)
+        return create_result_from_parsed(
+            *parse_answer_data(json.loads(output.completion))
+        )
 
 
 def extract_references(

--- a/src/inspect_scout/_llm_scanner/types.py
+++ b/src/inspect_scout/_llm_scanner/types.py
@@ -6,7 +6,9 @@ from pydantic import BaseModel
 # stdlib NamedTuple only supports Generic from Python 3.11
 from typing_extensions import NamedTuple
 
-StructuredT = TypeVar("StructuredT", bound="BaseModel | Sequence[BaseModel]")
+StructuredAnswerT = TypeVar(
+    "StructuredAnswerT", bound="BaseModel | Sequence[BaseModel]"
+)
 """Type of a structured answer: a Pydantic model or a list of Pydantic models."""
 
 
@@ -23,7 +25,7 @@ class AnswerMultiLabel(NamedTuple):
     """Allow the model to respond with NONE when no labels apply."""
 
 
-class AnswerStructured(NamedTuple, Generic[StructuredT]):
+class AnswerStructured(NamedTuple, Generic[StructuredAnswerT]):
     """Answer with structured output.
 
     Structured answers are objects that conform to a JSON Schema.
@@ -35,7 +37,7 @@ class AnswerStructured(NamedTuple, Generic[StructuredT]):
     ``parse_answer()``.
     """
 
-    type: type[StructuredT]
+    type: type[StructuredAnswerT]
     """Pydantic BaseModel that defines the type of the answer.
 
     Can be a single Pydantic model result or a list of results.

--- a/src/inspect_scout/_llm_scanner/types.py
+++ b/src/inspect_scout/_llm_scanner/types.py
@@ -1,6 +1,13 @@
-from typing import Literal, NamedTuple, TypeAlias
+from collections.abc import Sequence
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import BaseModel
+
+# stdlib NamedTuple only supports Generic from Python 3.11
+from typing_extensions import NamedTuple
+
+StructuredT = TypeVar("StructuredT", bound="BaseModel | Sequence[BaseModel]")
+"""Type of a structured answer: a Pydantic model or a list of Pydantic models."""
 
 
 class AnswerMultiLabel(NamedTuple):
@@ -16,13 +23,19 @@ class AnswerMultiLabel(NamedTuple):
     """Allow the model to respond with NONE when no labels apply."""
 
 
-class AnswerStructured(NamedTuple):
+class AnswerStructured(NamedTuple, Generic[StructuredT]):
     """Answer with structured output.
 
     Structured answers are objects that conform to a JSON Schema.
+
+    Generic in the answer type: ``AnswerStructured(MyModel)`` is an
+    ``AnswerStructured[MyModel]`` and ``AnswerStructured(list[MyModel])``
+    is an ``AnswerStructured[list[MyModel]]``, which types the ``parsed``
+    field of the :class:`Result` returned by ``generate_answer()`` and
+    ``parse_answer()``.
     """
 
-    type: type[BaseModel] | type[list]  # type: ignore[type-arg]
+    type: type[StructuredT]
     """Pydantic BaseModel that defines the type of the answer.
 
     Can be a single Pydantic model result or a list of results.
@@ -53,7 +66,7 @@ class AnswerStructured(NamedTuple):
 _TextualAnswerSpec: TypeAlias = (
     Literal["boolean", "numeric", "string"] | list[str] | AnswerMultiLabel
 )
-AnswerSpec: TypeAlias = _TextualAnswerSpec | AnswerStructured
+AnswerSpec: TypeAlias = _TextualAnswerSpec | AnswerStructured[Any]
 """Specification of the answer format for an LLM scanner.
 
 Pass ``"boolean"``, ``"numeric"``, or ``"string"`` for a simple answer;

--- a/src/inspect_scout/_llm_scanner/types.py
+++ b/src/inspect_scout/_llm_scanner/types.py
@@ -28,13 +28,9 @@ class AnswerMultiLabel(NamedTuple):
 class AnswerStructured(NamedTuple, Generic[StructuredAnswerT]):
     """Answer with structured output.
 
-    Structured answers are objects that conform to a JSON Schema.
-
-    Generic in the answer type: ``AnswerStructured(MyModel)`` is an
-    ``AnswerStructured[MyModel]`` and ``AnswerStructured(list[MyModel])``
-    is an ``AnswerStructured[list[MyModel]]``, which types the ``parsed``
-    field of the :class:`Result` returned by ``generate_answer()`` and
-    ``parse_answer()``.
+    Structured answers are objects that conform to a JSON Schema. The answer
+    type parameter flows through to the type of ``Result.parsed`` in
+    ``generate_answer()`` and ``parse_answer()``.
     """
 
     type: type[StructuredAnswerT]

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -34,15 +34,9 @@ class Reference(BaseModel):
     """Reference id (message or event id)"""
 
 
-ParsedT = TypeVar(
-    "ParsedT",
-    bound="bool | float | str | list[str] | BaseModel | Sequence[BaseModel]",
-    default=Any,
-)
-"""Type of a parsed answer: ``bool`` ("boolean"), ``float`` ("numeric"),
-``str`` ("string" and single-label), ``list[str]`` (multi-label), or the
-structured answer type. Defaults to ``Any`` so that bare ``Result``
-annotations remain valid."""
+ParsedT = TypeVar("ParsedT", default=Any)
+"""Type of the parsed answer carried by ``Result.parsed``. Defaults to
+``Any`` so that bare ``Result`` annotations remain valid."""
 
 
 class Result(BaseModel, Generic[ParsedT]):
@@ -83,9 +77,19 @@ class Result(BaseModel, Generic[ParsedT]):
     be parsed, and on results not built by these functions (e.g.
     aggregated or reduced multi-segment scan results).
 
-    In-memory only: excluded from serialization and the JSON schema, so it
-    does not survive storage of results. Extract and store it separately if
-    you need it beyond the scan."""
+    In-memory only: excluded from serialization and the JSON schema, and
+    dropped when pickled (so results that cross process boundaries — e.g.
+    multiprocess scans — carry ``parsed=None``). Extract and store it
+    separately if you need it beyond the scan."""
+
+    def __getstate__(self) -> dict[Any, Any]:
+        # parsed is in-memory only and may hold instances of classes that
+        # pickle cannot resolve by reference (e.g. defined in __main__ or in
+        # a function body). Drop it so results always survive pickling —
+        # notably the multiprocess scan queues, whose feeder threads would
+        # otherwise silently discard the whole result.
+        state = super().__getstate__()
+        return {**state, "__dict__": {**state["__dict__"], "parsed": None}}
 
 
 def as_resultset(results: list[Result]) -> Result:

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -75,10 +75,13 @@ class Result(BaseModel, Generic[ParsedT]):
     parsed: SkipJsonSchema[ParsedT | None] = Field(default=None, exclude=True)
     """The typed parsed answer (optional; set by ``generate_answer()`` and
     ``parse_answer()``): ``bool`` for "boolean" answers, ``float`` for
-    "numeric", ``str`` for "string" and single-label answers, ``list[str]``
-    for multi-label answers, and the validated instance(s) of the answer
-    type for ``AnswerStructured`` answers — prior to any ``value_to_float``
-    conversion. ``None`` when the model's response could not be parsed.
+    "numeric", ``str`` for "string" answers, the label text for
+    single-label answers, ``list[str]`` of label texts for multi-label
+    answers, and the validated instance(s) of the answer type for
+    ``AnswerStructured`` answers. Unaffected by ``value_to_float``, which
+    converts ``value`` only. ``None`` when the model's response could not
+    be parsed, and on results not built by these functions (e.g.
+    aggregated or reduced multi-segment scan results).
 
     In-memory only: excluded from serialization and the JSON schema, so it
     does not survive storage of results. Extract and store it separately if

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -35,8 +35,7 @@ class Reference(BaseModel):
 
 
 ParsedT = TypeVar("ParsedT", default=Any)
-"""Type of the parsed answer carried by ``Result.parsed``. Defaults to
-``Any`` so that bare ``Result`` annotations remain valid."""
+"""Type of `Result.parsed` (defaults to `Any` so bare `Result` annotations remain valid)."""
 
 
 class Result(BaseModel, Generic[ParsedT]):
@@ -67,20 +66,10 @@ class Result(BaseModel, Generic[ParsedT]):
     """Type to designate contents of 'value' (used in `value_type` field in result data frames)."""
 
     parsed: SkipJsonSchema[ParsedT | None] = Field(default=None, exclude=True)
-    """The typed parsed answer (optional; set by ``generate_answer()`` and
-    ``parse_answer()``): ``bool`` for "boolean" answers, ``float`` for
-    "numeric", ``str`` for "string" answers, the label text for
-    single-label answers, ``list[str]`` of label texts for multi-label
-    answers, and the validated instance(s) of the answer type for
-    ``AnswerStructured`` answers. Unaffected by ``value_to_float``, which
-    converts ``value`` only. ``None`` when the model's response could not
-    be parsed, and on results not built by these functions (e.g.
-    aggregated or reduced multi-segment scan results).
-
-    In-memory only: excluded from serialization and the JSON schema, and
-    dropped when pickled (so results that cross process boundaries — e.g.
-    multiprocess scans — carry ``parsed=None``). Extract and store it
-    separately if you need it beyond the scan."""
+    """Typed parsed answer set by `generate_answer()`/`parse_answer()`
+    (unaffected by `value_to_float`; `None` when parsing failed or the result
+    was built elsewhere). In-memory only: excluded from serialization and
+    dropped when pickled, so it survives neither storage nor process boundaries."""
 
     def __getstate__(self) -> dict[Any, Any]:
         # parsed is in-memory only and may hold instances of classes that

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -1,13 +1,15 @@
 import json
 from logging import getLogger
-from typing import Any, Literal, Sequence, cast
+from typing import Any, Generic, Literal, Sequence, cast
 
 from inspect_ai._util.json import jsonable_python
 from inspect_ai.event._event import Event
 from inspect_ai.log import condense_events
 from inspect_ai.model import ModelUsage
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic.json_schema import SkipJsonSchema
 from shortuuid import uuid
+from typing_extensions import TypeVar
 
 from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
 from inspect_scout._transcript.types import Transcript
@@ -32,7 +34,18 @@ class Reference(BaseModel):
     """Reference id (message or event id)"""
 
 
-class Result(BaseModel):
+ParsedT = TypeVar(
+    "ParsedT",
+    bound="bool | float | str | list[str] | BaseModel | Sequence[BaseModel]",
+    default=Any,
+)
+"""Type of a parsed answer: ``bool`` ("boolean"), ``float`` ("numeric"),
+``str`` ("string" and single-label), ``list[str]`` (multi-label), or the
+structured answer type. Defaults to ``Any`` so that bare ``Result``
+annotations remain valid."""
+
+
+class Result(BaseModel, Generic[ParsedT]):
     """Scan result."""
 
     uuid: str | None = Field(default_factory=uuid)
@@ -58,6 +71,18 @@ class Result(BaseModel):
 
     type: str | None = Field(default=None)
     """Type to designate contents of 'value' (used in `value_type` field in result data frames)."""
+
+    parsed: SkipJsonSchema[ParsedT | None] = Field(default=None, exclude=True)
+    """The typed parsed answer (optional; set by ``generate_answer()`` and
+    ``parse_answer()``): ``bool`` for "boolean" answers, ``float`` for
+    "numeric", ``str`` for "string" and single-label answers, ``list[str]``
+    for multi-label answers, and the validated instance(s) of the answer
+    type for ``AnswerStructured`` answers — prior to any ``value_to_float``
+    conversion. ``None`` when the model's response could not be parsed.
+
+    In-memory only: excluded from serialization and the JSON schema, so it
+    does not survive storage of results. Extract and store it separately if
+    you need it beyond the scan."""
 
 
 def as_resultset(results: list[Result]) -> Result:

--- a/tests/llm_scanner/test_generate.py
+++ b/tests/llm_scanner/test_generate.py
@@ -56,6 +56,7 @@ async def test_generate_normal_dispatch() -> None:
     mock_gen.assert_awaited_once()
     assert isinstance(result, Result)
     assert result.value is True
+    assert result.parsed is True
 
 
 @pytest.mark.anyio
@@ -159,6 +160,8 @@ async def test_generate_structured_dispatch() -> None:
         )
 
     assert isinstance(result, Result)
+    assert type(result.parsed) is MyAnswer
+    assert result.parsed.score == 5
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +268,7 @@ async def test_generate_structured_null_value() -> None:
 
     assert isinstance(result, Result)
     assert result.value is None
+    assert result.parsed is None
     assert result.answer == "Could not determine."
 
 

--- a/tests/llm_scanner/test_parse_answer.py
+++ b/tests/llm_scanner/test_parse_answer.py
@@ -544,7 +544,7 @@ def test_parse_value_to_float(
     expected_value: float,
 ) -> None:
     output = ModelOutput(model="test", completion=completion)
-    result = parse_answer(output, answer_spec, _no_refs, value_to_float=value_to_float)  # type: ignore[arg-type]
+    result = parse_answer(output, answer_spec, _no_refs, value_to_float=value_to_float)  # type: ignore[call-overload]
     assert result.value == expected_value
 
 

--- a/tests/llm_scanner/test_parsed.py
+++ b/tests/llm_scanner/test_parsed.py
@@ -13,7 +13,13 @@ import pytest
 from inspect_ai.model import ModelOutput
 from inspect_scout import AnswerMultiLabel, AnswerSpec, AnswerStructured, parse_answer
 from inspect_scout._scanner.result import Reference, Result
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_serializer,
+    field_validator,
+)
 
 
 def _no_refs(_text: str) -> list[Reference]:
@@ -159,6 +165,28 @@ def test_parsed_structured_keeps_own_explanation_type() -> None:
     )
     assert type(result.parsed) is DetectionWithExplanation
     assert result.parsed.explanation == "mine"
+
+
+@pytest.mark.parametrize(
+    "completion",
+    [
+        pytest.param('{"behavior": "b", "confidence": 0.9}', id="missing"),
+        pytest.param(
+            '{"behavior": "b", "confidence": 0.9, "explanation": 42}',
+            id="non-string",
+        ),
+        pytest.param("[1, 2]", id="non-object"),
+    ],
+)
+def test_parsed_structured_invalid_injected_explanation(completion: str) -> None:
+    """Missing/malformed injected explanations raise ValidationError.
+
+    Models violate the answer schema often enough that callers rely on
+    catching pydantic's ValidationError (as raised on validation against
+    the augmented type) rather than a plain ValueError.
+    """
+    with pytest.raises(ValidationError):
+        parse_answer(_output(completion), AnswerStructured(Detection), _no_refs)
 
 
 def test_parsed_structured_resultset() -> None:

--- a/tests/llm_scanner/test_parsed.py
+++ b/tests/llm_scanner/test_parsed.py
@@ -13,7 +13,7 @@ import pytest
 from inspect_ai.model import ModelOutput
 from inspect_scout import AnswerMultiLabel, AnswerSpec, AnswerStructured, parse_answer
 from inspect_scout._scanner.result import Reference, Result
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 
 def _no_refs(_text: str) -> list[Reference]:
@@ -61,6 +61,8 @@ def test_parsed_textual(
 ) -> None:
     result = parse_answer(_output(completion), answer_spec, _no_refs)
     assert result.parsed == expected_parsed
+    # pin the type too: bool/float and int/float compare equal in python
+    assert type(result.parsed) is type(expected_parsed)
 
 
 @pytest.mark.parametrize(
@@ -70,6 +72,17 @@ def test_parsed_textual(
         pytest.param("numeric", "ANSWER: not-a-number", id="numeric"),
         pytest.param("string", "nothing", id="string"),
         pytest.param(["cat", "dog"], "Hmm.\n\nANSWER: Z", id="label-single"),
+        pytest.param(
+            AnswerMultiLabel(["cat", "dog"]),
+            "Hmm.\n\nANSWER: Z",
+            id="label-multi-invalid",
+        ),
+        pytest.param(
+            # NONE is only a valid answer with allow_none
+            AnswerMultiLabel(["cat", "dog"]),
+            "Hmm.\n\nANSWER: NONE",
+            id="label-multi-none-disallowed",
+        ),
     ],
 )
 def test_parsed_none_on_parse_failure(answer_spec: AnswerSpec, completion: str) -> None:
@@ -77,7 +90,7 @@ def test_parsed_none_on_parse_failure(answer_spec: AnswerSpec, completion: str) 
     assert result.parsed is None
 
 
-def test_parsed_precedes_value_to_float() -> None:
+def test_parsed_unaffected_by_value_to_float() -> None:
     result = parse_answer(
         _output("Reason.\n\nANSWER: Yes"),
         "boolean",
@@ -94,13 +107,10 @@ def test_parsed_structured_is_declared_type() -> None:
         AnswerStructured(Detection),
         _no_refs,
     )
-    # exactly the declared type (not the augmented explanation subclass),
-    # so instances are picklable for multiprocess scanning
+    # exactly the declared type (not the augmented explanation subclass)
     assert type(result.parsed) is Detection
     assert result.parsed.confidence == 0.9
     assert result.explanation == "e"
-    roundtripped = pickle.loads(pickle.dumps(result))
-    assert roundtripped.parsed == result.parsed
 
 
 def test_parsed_structured_with_non_roundtripping_serializer() -> None:
@@ -166,6 +176,86 @@ def test_parsed_structured_resultset() -> None:
     assert [item.behavior for item in result.parsed or []] == ["a", "b"]
 
 
+def test_parsed_structured_validators_run_once() -> None:
+    """Field validators see wire-format input exactly once.
+
+    A mode="before" validator that parses a wire format is not idempotent:
+    constructing ``parsed`` from a second validation pass would crash it.
+    """
+
+    class Coords(BaseModel):
+        point: list[int] = Field(description="comma separated x,y")
+
+        @field_validator("point", mode="before")
+        @classmethod
+        def _parse_point(cls, value: str) -> list[int]:
+            return [int(part) for part in value.split(",")]
+
+    result = parse_answer(
+        _output('{"point": "1,2", "explanation": "e"}'),
+        AnswerStructured(Coords),
+        _no_refs,
+    )
+    assert type(result.parsed) is Coords
+    assert result.parsed.point == [1, 2]
+    assert result.value == {"point": [1, 2]}
+
+
+def test_parsed_structured_non_idempotent_validator_consistency() -> None:
+    """An after-validator runs once, so parsed and value agree."""
+
+    class Tagged(BaseModel):
+        name: str = Field(description="name")
+
+        @field_validator("name")
+        @classmethod
+        def _prefix(cls, value: str) -> str:
+            return "prefix:" + value
+
+    result = parse_answer(
+        _output('{"name": "x", "explanation": "e"}'),
+        AnswerStructured(Tagged),
+        _no_refs,
+    )
+    assert result.parsed is not None
+    assert result.parsed.name == "prefix:x"
+    assert result.value == {"name": "prefix:x"}
+
+
+def test_parsed_structured_post_init_runs_once_per_item() -> None:
+    calls: list[int] = []
+
+    class Counted(BaseModel):
+        x: int = Field(description="x")
+
+        def model_post_init(self, context: Any) -> None:
+            calls.append(self.x)
+
+    parse_answer(
+        _output('{"x": 1, "explanation": "e"}'), AnswerStructured(Counted), _no_refs
+    )
+    assert calls == [1]
+
+    calls.clear()
+    parse_answer(
+        _output(
+            '{"results": [{"x": 1, "explanation": "a"}, {"x": 2, "explanation": "b"}]}'
+        ),
+        AnswerStructured(list[Counted]),
+        _no_refs,
+    )
+    assert calls == [1, 2]
+
+
+def test_structured_rejects_non_list_generic_alias() -> None:
+    with pytest.raises(ValueError, match="list of BaseModel"):
+        parse_answer(
+            _output('{"behavior": "b", "confidence": 0.9, "explanation": "e"}'),
+            AnswerStructured(tuple[Detection, ...]),
+            _no_refs,
+        )
+
+
 def test_parsed_excluded_from_serialization() -> None:
     result = parse_answer(
         _output('{"behavior": "b", "confidence": 0.9, "explanation": "e"}'),
@@ -177,3 +267,24 @@ def test_parsed_excluded_from_serialization() -> None:
     assert "parsed" not in Result.model_json_schema()["properties"]
     # absent on deserialization (in-memory only)
     assert Result.model_validate(result.model_dump()).parsed is None
+
+
+def test_parsed_dropped_when_pickled() -> None:
+    """Pickling drops parsed so results always cross process boundaries.
+
+    Answer models are commonly defined in __main__ or a function body,
+    where pickle cannot resolve their class by reference; carrying such an
+    instance through the multiprocess scan queues would otherwise silently
+    discard the whole result.
+    """
+
+    class LocalAnswer(BaseModel):  # not resolvable by pickle by reference
+        x: int = Field(description="x")
+
+    result = Result(value=1, answer="one", parsed=LocalAnswer(x=1))
+    roundtripped = pickle.loads(pickle.dumps(result))
+    assert roundtripped.parsed is None
+    assert roundtripped.value == 1
+    assert roundtripped.answer == "one"
+    # the original is untouched
+    assert result.parsed is not None

--- a/tests/llm_scanner/test_parsed.py
+++ b/tests/llm_scanner/test_parsed.py
@@ -1,0 +1,140 @@
+"""Tests for the ``parsed`` field populated by parse_answer()/generate_answer().
+
+Complements test_parse_answer.py (which covers ``value``/``answer``
+extraction): here we verify the typed ``parsed`` answer, its absence on
+parse failures, and that it never leaks into serialized output.
+"""
+
+import pickle
+from typing import Any
+
+import pytest
+from inspect_ai.model import ModelOutput
+from inspect_scout import AnswerMultiLabel, AnswerSpec, AnswerStructured, parse_answer
+from inspect_scout._scanner.result import Reference, Result
+from pydantic import BaseModel, Field
+
+
+def _no_refs(_text: str) -> list[Reference]:
+    return []
+
+
+def _output(completion: str) -> ModelOutput:
+    return ModelOutput(model="test", completion=completion)
+
+
+class Detection(BaseModel):
+    behavior: str = Field(description="behavior observed")
+    confidence: float = Field(description="confidence 0-1")
+
+
+class DetectionWithExplanation(BaseModel):
+    behavior: str = Field(description="behavior observed")
+    explanation: str = Field(description="why")
+
+
+@pytest.mark.parametrize(
+    ("answer_spec", "completion", "expected_parsed"),
+    [
+        pytest.param("boolean", "Reason.\n\nANSWER: Yes", True, id="bool-yes"),
+        pytest.param("boolean", "Reason.\n\nANSWER: No", False, id="bool-no"),
+        pytest.param("numeric", "Count.\n\nANSWER: 7", 7.0, id="numeric"),
+        pytest.param("string", "Why.\n\nANSWER: hello", "hello", id="string"),
+        pytest.param(["cat", "dog"], "Hmm.\n\nANSWER: B", "dog", id="label-single"),
+        pytest.param(
+            AnswerMultiLabel(["cat", "dog"]),
+            "X.\n\nANSWER: A,B",
+            ["cat", "dog"],
+            id="label-multi",
+        ),
+        pytest.param(
+            AnswerMultiLabel(["cat", "dog"], allow_none=True),
+            "X.\n\nANSWER: NONE",
+            [],
+            id="label-multi-none",
+        ),
+    ],
+)
+def test_parsed_textual(
+    answer_spec: AnswerSpec, completion: str, expected_parsed: Any
+) -> None:
+    result = parse_answer(_output(completion), answer_spec, _no_refs)
+    assert result.parsed == expected_parsed
+
+
+@pytest.mark.parametrize(
+    ("answer_spec", "completion"),
+    [
+        pytest.param("boolean", "no marker here", id="bool"),
+        pytest.param("numeric", "ANSWER: not-a-number", id="numeric"),
+        pytest.param("string", "nothing", id="string"),
+        pytest.param(["cat", "dog"], "Hmm.\n\nANSWER: Z", id="label-single"),
+    ],
+)
+def test_parsed_none_on_parse_failure(answer_spec: AnswerSpec, completion: str) -> None:
+    result = parse_answer(_output(completion), answer_spec, _no_refs)
+    assert result.parsed is None
+
+
+def test_parsed_precedes_value_to_float() -> None:
+    result = parse_answer(
+        _output("Reason.\n\nANSWER: Yes"),
+        "boolean",
+        _no_refs,
+        value_to_float=lambda v: 1.0 if v else 0.0,
+    )
+    assert result.value == 1.0
+    assert result.parsed is True
+
+
+def test_parsed_structured_is_declared_type() -> None:
+    result = parse_answer(
+        _output('{"behavior": "b", "confidence": 0.9, "explanation": "e"}'),
+        AnswerStructured(Detection),
+        _no_refs,
+    )
+    # exactly the declared type (not the augmented explanation subclass),
+    # so instances are picklable for multiprocess scanning
+    assert type(result.parsed) is Detection
+    assert result.parsed.confidence == 0.9
+    assert result.explanation == "e"
+    roundtripped = pickle.loads(pickle.dumps(result))
+    assert roundtripped.parsed == result.parsed
+
+
+def test_parsed_structured_keeps_own_explanation_type() -> None:
+    result = parse_answer(
+        _output('{"behavior": "b", "explanation": "mine"}'),
+        AnswerStructured(DetectionWithExplanation),
+        _no_refs,
+    )
+    assert type(result.parsed) is DetectionWithExplanation
+    assert result.parsed.explanation == "mine"
+
+
+def test_parsed_structured_resultset() -> None:
+    result = parse_answer(
+        _output(
+            '{"results": ['
+            '{"behavior": "a", "confidence": 0.1, "explanation": "x"},'
+            '{"behavior": "b", "confidence": 0.2, "explanation": "y"}]}'
+        ),
+        AnswerStructured(list[Detection]),
+        _no_refs,
+    )
+    assert result.type == "resultset"
+    assert [type(item) for item in result.parsed or []] == [Detection, Detection]
+    assert [item.behavior for item in result.parsed or []] == ["a", "b"]
+
+
+def test_parsed_excluded_from_serialization() -> None:
+    result = parse_answer(
+        _output('{"behavior": "b", "confidence": 0.9, "explanation": "e"}'),
+        AnswerStructured(Detection),
+        _no_refs,
+    )
+    assert "parsed" not in result.model_dump()
+    assert "parsed" not in result.model_dump_json()
+    assert "parsed" not in Result.model_json_schema()["properties"]
+    # absent on deserialization (in-memory only)
+    assert Result.model_validate(result.model_dump()).parsed is None

--- a/tests/llm_scanner/test_parsed.py
+++ b/tests/llm_scanner/test_parsed.py
@@ -5,6 +5,7 @@ extraction): here we verify the typed ``parsed`` answer, its absence on
 parse failures, and that it never leaks into serialized output.
 """
 
+import datetime
 import pickle
 from typing import Any
 
@@ -12,7 +13,7 @@ import pytest
 from inspect_ai.model import ModelOutput
 from inspect_scout import AnswerMultiLabel, AnswerSpec, AnswerStructured, parse_answer
 from inspect_scout._scanner.result import Reference, Result
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 def _no_refs(_text: str) -> list[Reference]:
@@ -100,6 +101,44 @@ def test_parsed_structured_is_declared_type() -> None:
     assert result.explanation == "e"
     roundtripped = pickle.loads(pickle.dumps(result))
     assert roundtripped.parsed == result.parsed
+
+
+def test_parsed_structured_with_non_roundtripping_serializer() -> None:
+    """``parsed`` construction must not go through a serialization round trip.
+
+    Custom field serializers whose output does not re-validate (and
+    required excluded fields, below) would break a model_dump() ->
+    model_validate() round trip even though the completion is valid.
+    """
+
+    class WithSerializer(BaseModel):
+        when: datetime.date = Field(description="when it happened")
+
+        @field_serializer("when")
+        def _format_when(self, value: datetime.date) -> str:
+            return value.strftime("%B %d, %Y")
+
+    result = parse_answer(
+        _output('{"when": "2026-01-02", "explanation": "e"}'),
+        AnswerStructured(WithSerializer),
+        _no_refs,
+    )
+    assert type(result.parsed) is WithSerializer
+    assert result.parsed.when == datetime.date(2026, 1, 2)
+
+
+def test_parsed_structured_with_required_excluded_field() -> None:
+    class WithExcluded(BaseModel):
+        shown: str = Field(description="shown")
+        hidden: str = Field(exclude=True, description="hidden")
+
+    result = parse_answer(
+        _output('{"shown": "s", "hidden": "h", "explanation": "e"}'),
+        AnswerStructured(WithExcluded),
+        _no_refs,
+    )
+    assert type(result.parsed) is WithExcluded
+    assert result.parsed.hidden == "h"
 
 
 def test_parsed_structured_keeps_own_explanation_type() -> None:

--- a/tests/llm_scanner/test_parsed_typing.py
+++ b/tests/llm_scanner/test_parsed_typing.py
@@ -1,0 +1,68 @@
+"""Static guards for the typed generate_answer()/parse_answer() overloads.
+
+``assert_type()`` is verified by mypy (which runs over tests/) and is a
+no-op at runtime, so these calls double as smoke tests of the overloads'
+runtime dispatch.
+"""
+
+from typing import Any
+
+from inspect_ai.model import ModelOutput
+from inspect_scout import AnswerMultiLabel, AnswerSpec, AnswerStructured, parse_answer
+from inspect_scout._scanner.result import Reference, Result
+from pydantic import BaseModel, Field
+from typing_extensions import assert_type
+
+
+class Detection(BaseModel):
+    behavior: str = Field(description="behavior observed")
+    explanation: str = Field(description="why")
+
+
+def _no_refs(_text: str) -> list[Reference]:
+    return []
+
+
+def _output(completion: str) -> ModelOutput:
+    return ModelOutput(model="test", completion=completion)
+
+
+def test_overload_types() -> None:
+    text = _output("Reason.\n\nANSWER: Yes")
+    detection = _output('{"behavior": "b", "explanation": "e"}')
+    detections = _output('{"results": [{"behavior": "b", "explanation": "e"}]}')
+
+    result_bool = parse_answer(text, "boolean", _no_refs)
+    assert_type(result_bool, Result[bool])
+    assert_type(result_bool.parsed, bool | None)
+
+    assert_type(
+        parse_answer(_output("R.\n\nANSWER: 1"), "numeric", _no_refs), Result[float]
+    )
+    assert_type(
+        parse_answer(_output("R.\n\nANSWER: x"), "string", _no_refs), Result[str]
+    )
+    assert_type(parse_answer(text, ["yes", "no"], _no_refs), Result[str])
+    assert_type(
+        parse_answer(text, AnswerMultiLabel(["yes", "no"]), _no_refs),
+        Result[list[str]],
+    )
+
+    result_detection = parse_answer(detection, AnswerStructured(Detection), _no_refs)
+    assert_type(result_detection, Result[Detection])
+    assert_type(result_detection.parsed, Detection | None)
+
+    result_detections = parse_answer(
+        detections, AnswerStructured(list[Detection]), _no_refs
+    )
+    assert_type(result_detections, Result[list[Detection]])
+
+    # a union-typed spec falls back to Result[Any], and typed results are
+    # assignable wherever a bare Result is expected
+    assert_type(parse_answer(text, _union_spec(), _no_refs), Result[Any])
+    bare: Result = result_detection
+    assert bare.parsed is not None
+
+
+def _union_spec() -> AnswerSpec:
+    return "boolean"


### PR DESCRIPTION
## What

`Result` gains a `parsed` field carrying the typed parsed answer, and `generate_answer()` / `parse_answer()` type it based on the answer spec you pass:

| answer spec | return type | `.parsed` |
|---|---|---|
| `AnswerStructured(Detection)` | `Result[Detection]` | `Detection \| None` |
| `AnswerStructured(list[Detection])` | `Result[list[Detection]]` | `list[Detection] \| None` |
| `"boolean"` / `"numeric"` / `"string"` | `Result[bool/float/str]` | `bool/float/str \| None` |
| `list[str]` (single label) | `Result[str]` | chosen label text |
| `AnswerMultiLabel` | `Result[list[str]]` | chosen labels |

`parsed` is the pre-`value_to_float` answer and is `None` whenever the response could not be parsed. For `AnswerStructured`, instances are of the exact declared class (not the internal explanation-augmented subclass), so they are picklable for multiprocess scanning. `AnswerStructured` is now generic in its answer type, which also makes invalid specs like `AnswerStructured(int)` or `AnswerStructured(list[str])` type-check errors instead of runtime errors.

## Backward compatibility

- `Result`'s type parameter defaults to `Any` (PEP 696 via `typing_extensions.TypeVar`), so bare `Result` annotations everywhere — including user scanners — are unchanged under strict mypy.
- `parsed` is `Field(exclude=True)` + `SkipJsonSchema`: it never appears in `model_dump`/JSON/stored results, and `openapi.json` is byte-identical (no TS regeneration needed).
- All existing parse behavior is preserved exactly, including failure values (`value=False` for boolean/numeric failures, `value=None` elsewhere). Verified with a differential battery of 18 parse cases producing byte-identical serialized output vs `main`.

## Testing

- New `tests/llm_scanner/test_parsed.py`: parsed values for every answer kind, `None` on parse failures, pre-`value_to_float` semantics, declared-type instances + pickling, resultsets, and serialization/schema exclusion.
- Full suite green locally (3,197 passed / 0 failed), strict mypy clean on `src`/`examples`/`tests`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)