### PR TITLE
fix: conform to inspect_ai model-role lists and regenerate schema/types

### DIFF
--- a/src/inspect_scout/_cli/scan.py
+++ b/src/inspect_scout/_cli/scan.py
@@ -14,7 +14,12 @@ from inspect_ai._util.config import resolve_args
 from inspect_ai._util.constants import DEFAULT_CACHE_DAYS
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once
-from inspect_ai.model import BatchConfig, CachePolicy, GenerateConfig, Model
+from inspect_ai.model import (
+    BatchConfig,
+    CachePolicy,
+    GenerateConfig,
+    ModelRoles,
+)
 from typing_extensions import Unpack
 
 from inspect_scout._project._project import read_project
@@ -572,7 +577,7 @@ def scan_command(
         scanjob.model_args,
     )
     scan_model_roles = cast(
-        dict[str, str | Model] | None,
+        ModelRoles | None,
         resolve_scan_option(
             ctx,
             "model_role",

--- a/src/inspect_scout/_concurrency/_mp_common.py
+++ b/src/inspect_scout/_concurrency/_mp_common.py
@@ -319,7 +319,7 @@ class IPCContext:
     model_config: ModelConfig
     """Configuration specifying which model provider and settings to use."""
 
-    model_roles: dict[str, ModelConfig] | None
+    model_roles: dict[str, ModelConfig | list[ModelConfig]] | None
     """Optional mapping of role names to serializable ModelConfig instances."""
 
     generate_config: GenerateConfig

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -21,7 +21,13 @@ from inspect_ai._util.path import pretty_path
 from inspect_ai._util.platform import platform_init as init_platform
 from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.model._generate_config import GenerateConfig
-from inspect_ai.model._model import Model, init_model_usage, model_usage, resolve_models
+from inspect_ai.model._model import (
+    Model,
+    ModelRoles,
+    init_model_usage,
+    model_usage,
+    resolve_models,
+)
 from inspect_ai.model._model_config import (
     model_config_to_model,
     model_roles_config_to_model_roles,
@@ -100,7 +106,7 @@ def scan(
     model_config: GenerateConfig | None = None,
     model_base_url: str | None = None,
     model_args: dict[str, Any] | str | None = None,
-    model_roles: dict[str, str | Model] | None = None,
+    model_roles: ModelRoles | None = None,
     max_transcripts: int | None = None,
     max_processes: int | None = None,
     limit: int | None = None,
@@ -192,7 +198,7 @@ async def scan_async(
     model_config: GenerateConfig | None = None,
     model_base_url: str | None = None,
     model_args: dict[str, Any] | str | None = None,
-    model_roles: dict[str, str | Model] | None = None,
+    model_roles: ModelRoles | None = None,
     max_transcripts: int | None = None,
     max_processes: int | None = None,
     limit: int | None = None,
@@ -859,8 +865,8 @@ def init_scan_model_context(
     model_config: GenerateConfig | None = None,
     model_base_url: str | None = None,
     model_args: dict[str, Any] | str | None = None,
-    model_roles: Mapping[str, str | Model] | None = None,
-) -> tuple[Model, dict[str, Any], dict[str, Model] | None]:
+    model_roles: ModelRoles | None = None,
+) -> tuple[Model, dict[str, Any], dict[str, Model | list[Model]] | None]:
     # resolve from inspect eval model env var if rquired
     if model is None:
         model = os.getenv("SCOUT_SCAN_MODEL", None)

--- a/src/inspect_scout/_scanjob.py
+++ b/src/inspect_scout/_scanjob.py
@@ -32,7 +32,7 @@ from inspect_ai._util.registry import (
     registry_tag,
     registry_unqualified_name,
 )
-from inspect_ai.model import GenerateConfig, Model, get_model
+from inspect_ai.model import GenerateConfig, Model, ModelRoles, get_model
 from inspect_ai.model._util import resolve_model_roles
 from jsonschema import Draft7Validator
 from typing_extensions import Unpack
@@ -79,7 +79,7 @@ class ScanJob:
         model_base_url: str | None = None,
         model_args: dict[str, Any] | None = None,
         generate_config: GenerateConfig | None = None,
-        model_roles: dict[str, str | Model] | None = None,
+        model_roles: ModelRoles | None = None,
         max_transcripts: int | None = None,
         max_processes: int | None = None,
         limit: int | None = None,
@@ -251,7 +251,7 @@ class ScanJob:
         return self._generate_config
 
     @property
-    def model_roles(self) -> dict[str, Model] | None:
+    def model_roles(self) -> dict[str, Model | list[Model]] | None:
         """Named roles for use in `get_model()`."""
         return self._model_roles
 

--- a/src/inspect_scout/_scanspec.py
+++ b/src/inspect_scout/_scanspec.py
@@ -182,7 +182,7 @@ class ScanSpec(BaseModel):
     model: ModelConfig | None = Field(default=None)
     """Model used for eval."""
 
-    model_roles: dict[str, ModelConfig] | None = Field(default=None)
+    model_roles: dict[str, ModelConfig | list[ModelConfig]] | None = Field(default=None)
     """Model roles."""
 
     revision: ScanRevision | None = Field(default=None)

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-C5MESMvN.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-C5MESMvN.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10f0547f739f91d669d77e263876d44a2bbdb3c6f8e0ecd93969e6eb854e27f1
+size 187264

--- a/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-I5MEHNFG.js
+++ b/src/inspect_scout/_view/dist/assets/AsciinemaPlayerImpl-I5MEHNFG.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2696f5594c9383692d4fe240d17b5e06a8b9cad3b615c35bf41b0e52cd649db
-size 186840

--- a/src/inspect_scout/_view/dist/assets/compiler-runtime-Jj4tSG5H.js
+++ b/src/inspect_scout/_view/dist/assets/compiler-runtime-Jj4tSG5H.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:022e33b386ccbbecd632651876ed70d7cdc4dc8bb958c79121456936606996ea
+size 8125

--- a/src/inspect_scout/_view/dist/assets/dist-CntVD12C.js
+++ b/src/inspect_scout/_view/dist/assets/dist-CntVD12C.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a5d5e565a7b3f92c2c15bcf93864520b8ac4761e90b26d4339527d0eab68e9f
+size 4096

--- a/src/inspect_scout/_view/dist/assets/dist-DYxQMA91.js
+++ b/src/inspect_scout/_view/dist/assets/dist-DYxQMA91.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66a1919aca06f485d2e7a48051a62bb414bb615098c80cf6f9175bbce6784df4
-size 4096

--- a/src/inspect_scout/_view/dist/assets/index-2ckSjoWG.css
+++ b/src/inspect_scout/_view/dist/assets/index-2ckSjoWG.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64acad5fccfa0af6d898be5136063cb037250a58246387c0c37030ab6eaa994c
+size 536575

--- a/src/inspect_scout/_view/dist/assets/index-CImCiLLK.css
+++ b/src/inspect_scout/_view/dist/assets/index-CImCiLLK.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c50b1293de3bef20938bf24014fc5f67e01f166fb6b19f3d4502d189b203db2
-size 540232

--- a/src/inspect_scout/_view/dist/assets/index-Cy-7lZbO.js
+++ b/src/inspect_scout/_view/dist/assets/index-Cy-7lZbO.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:178fa519fae7e37c46f97c143bc5b38f80c7b16cef67630481bee00c3e855d12
+size 3162740

--- a/src/inspect_scout/_view/dist/assets/index-E4vzhVCA.js
+++ b/src/inspect_scout/_view/dist/assets/index-E4vzhVCA.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a92697095ecea482db6d544c13fefba17cbceda8f09f18ac516accad3dea28c8
-size 2871233

--- a/src/inspect_scout/_view/dist/assets/jsx-runtime-BpzPEenQ.js
+++ b/src/inspect_scout/_view/dist/assets/jsx-runtime-BpzPEenQ.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63437167d8270efbe026cd956b446c6f09220f8fcbd674ce29b3479a9a5abfcc
-size 7948

--- a/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-EzaRqvmB.js
+++ b/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-EzaRqvmB.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ee89048c9280904bc6aa7c1cb13b945a7e9eeb4b2ffba99e9d0cbdd7e9f8f5f
+size 59859

--- a/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-qfi-c9CZ.js
+++ b/src/inspect_scout/_view/dist/assets/lib-CBtriEt5-qfi-c9CZ.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b4cd97621e34b889c17c77071b50c580082e771490c1e8a9d0a5acf59b0e16e3
-size 59857

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CuwwUZTn.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-CuwwUZTn.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c49983ecee10cf525fe942714d24b6834820e1426678ab7a87a615b281118ed
+size 22570

--- a/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-kYMOFspM.js
+++ b/src/inspect_scout/_view/dist/assets/liteDOM-Cp0aN3bP-kYMOFspM.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac9c16e395b2839b27b7e6fcc70ad25933e154fb89a838e65da63e212df932d4
-size 22569

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-BN-yaT14.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-BN-yaT14.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0e5486458aa62b281b44a8555d0d821750d4dd167f74a4e0e9861cb6be60469
-size 2233766

--- a/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-DF1gZY-p.js
+++ b/src/inspect_scout/_view/dist/assets/tex-svg-full-BI3fonbT-DF1gZY-p.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2c81c555cecf8ed4d0deedae5c5c6e5cc317f0968912193e7c0e1fb5f64d5bc
+size 2233795

--- a/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-BtzjAh1k.js
+++ b/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-BtzjAh1k.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b2b60bd0d53a45a981c5d42a8f064d27a781b9bd5acfc0885af4a36c7e6f8d
+size 27981

--- a/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-CDsunDZs.js
+++ b/src/inspect_scout/_view/dist/assets/wgxpath.install-node-Csk64Aj9-CDsunDZs.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ab7bf74faf00232a4cc3843a61fcfdcb8f30c6b031c8cf93714273a3255a584
-size 27969

--- a/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DD_c75wG.js
+++ b/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DD_c75wG.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b69f2073e9b2e8affdb2fab6928db8d0701e764d300baa685e206f2cbb6e5b2
+size 350435

--- a/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DcCuyqt0.js
+++ b/src/inspect_scout/_view/dist/assets/xypic-DrMJn58R-DcCuyqt0.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:294857b997ff00aa8140bd4976daacd0589b9cbd630b5781447af370a2610975
-size 350434

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f793c255a429881bf7b148c10d68d4d630b5aadf8a570b3b2b52d82a7706a3f6
-size 3807
+oid sha256:f91ec5ac73dc345bbc7fc3b6c8d5525ba0a47d01956e721db7ac7a49ba7b4b35
+size 3812

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -660,6 +660,22 @@
         "title": "ApprovalEvent",
         "type": "object"
       },
+      "ArchiveSnapshots": {
+        "description": "One complete compressed tar archive per checkpoint.\n\nCaptures with tools already present in effectively every image\n(tar, dd, sha256sum, zstd or gzip) \u2014 nothing is injected into the\nsandbox. Each checkpoint's archive is self-contained, so restore\nreads a single file. Best choice when restic injection is\nimpractical, or when the captured data is dominated by large,\nhigh-entropy, frequently-rewritten files where incremental backup\nstores roughly the full dataset again at every checkpoint anyway.\n\nUnlike restic (which encrypts its repository with a per-sample\npassword), archives are written unencrypted: checkpoint data \u2014\nincluding any credentials or keys the agent wrote into captured\npaths \u2014 lands in the checkpoint storage location (possibly S3) as\nplaintext tar archives.",
+        "properties": {
+          "name": {
+            "const": "archive",
+            "default": "archive",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ArchiveSnapshots",
+        "type": "object"
+      },
       "BatchConfig": {
         "description": "Batch processing configuration.",
         "properties": {
@@ -1517,7 +1533,7 @@
         "type": "object"
       },
       "CheckpointSampleConfig": {
-        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task).\n\nThe fields excluded from this base class \u2014 ``checkpoints_location``\nand ``retention`` \u2014 are eval-wide concerns that the sample layer must\nnot influence. They live only on the derived :class:`CheckpointConfig`,\nwhich is the type used at the task and eval layers.",
+        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task). Capture\nconfiguration \u2014 what to snapshot and with which strategy \u2014 is a\nproperty of the sample's workload, so it lives here.\n\nExcluded from the sample layer: ``checkpoints_location`` and\n``retention``. These are eval-wide storage-policy concerns that the\nsample layer must not influence; they live only on\n:class:`CheckpointConfig`, the subclass used at the task and eval\nlayers.",
         "properties": {
           "max_consecutive_failures": {
             "anyOf": [
@@ -1534,10 +1550,17 @@
             "anyOf": [
               {
                 "additionalProperties": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SandboxSnapshotConfig"
+                    }
+                  ]
                 },
                 "type": "object"
               },
@@ -6799,6 +6822,22 @@
         "title": "ResponseSchema",
         "type": "object"
       },
+      "ResticSnapshots": {
+        "description": "Incremental restic-based sandbox snapshots (the default).\n\nEach checkpoint stores only data changed since the previous one.\nBest choice when most files are stable across checkpoints. Requires\ninjecting a restic binary into the sandbox.",
+        "properties": {
+          "name": {
+            "const": "restic-incremental",
+            "default": "restic-incremental",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ResticSnapshots",
+        "type": "object"
+      },
       "Result": {
         "description": "Scan result.",
         "properties": {
@@ -7382,6 +7421,52 @@
           "action"
         ],
         "title": "SandboxEvent",
+        "type": "object"
+      },
+      "SandboxSnapshotConfig": {
+        "description": "Per-sandbox snapshot configuration: what to capture and how.\n\nUsed as a ``sandbox_paths`` value in place of a bare path list when\na sandbox needs a non-default snapshot strategy. The ``paths``\nfield carries the same semantics as a bare path-list value\n(``None`` = the sandbox default user's home directory; an empty\nlist opts the sandbox out entirely).",
+        "properties": {
+          "paths": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paths"
+          },
+          "strategy": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "archive": "#/components/schemas/ArchiveSnapshots",
+                    "restic-incremental": "#/components/schemas/ResticSnapshots"
+                  },
+                  "propertyName": "name"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ResticSnapshots"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ArchiveSnapshots"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strategy"
+          }
+        },
+        "title": "SandboxSnapshotConfig",
         "type": "object"
       },
       "ScanJobConfig": {
@@ -8052,7 +8137,17 @@
             "anyOf": [
               {
                 "additionalProperties": {
-                  "$ref": "#/components/schemas/ModelConfig-Output"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ModelConfig-Output"
+                    },
+                    {
+                      "items": {
+                        "$ref": "#/components/schemas/ModelConfig-Output"
+                      },
+                      "type": "array"
+                    }
+                  ]
                 },
                 "type": "object"
               },
@@ -8831,6 +8926,27 @@
             ],
             "title": "Metadata"
           },
+          "reason": {
+            "anyOf": [
+              {
+                "enum": [
+                  "invalid_response_format",
+                  "refusal",
+                  "no_response",
+                  "grader_failed",
+                  "scoring_failed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
           "value": {
             "anyOf": [
               {
@@ -8955,6 +9071,32 @@
                 "type": "null"
               }
             ]
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "enum": [
+                  "invalid_response_format",
+                  "refusal",
+                  "no_response",
+                  "grader_failed",
+                  "scoring_failed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "const": "UNCHANGED",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "UNCHANGED",
+            "title": "Reason"
           },
           "value": {
             "anyOf": [

--- a/tests/concurrency/test_model_pickling.py
+++ b/tests/concurrency/test_model_pickling.py
@@ -127,7 +127,7 @@ def test_model_roles_config_is_picklable() -> None:
         "mockllm/model",
         custom_outputs=[ModelOutput.from_content("mockllm/model", content="hello")],
     )
-    roles = {"scanner": model}
+    roles: dict[str, Model | list[Model]] = {"scanner": model}
     roles_config = model_roles_to_model_roles_config(roles)
     # This is what happens when IPCContext crosses process boundary
     pickled = cloudpickle.dumps(roles_config)


### PR DESCRIPTION
Fixes the failing Nightly CI run https://github.com/meridianlabs-ai/inspect_scout/actions/runs/33067365391 (`check-schema-and-types` and `py-mypy` red against inspect_ai git main).

## Root cause: upstream drift

Three inspect_ai PRs landed on its main Aug 26–27:

- UKGovernmentBEIS/inspect_ai#4991 — a model role may now bind a **list** of models. This widened `resolve_model_roles`, `model_roles_to_model_roles_config`, `model_roles_config_to_model_roles`, and `init_model_context` to `dict[str, Model | list[Model]]` / `dict[str, ModelConfig | list[ModelConfig]]` → the 11 mypy errors.
- UKGovernmentBEIS/inspect_ai#4624 — sandbox snapshot strategies → new `SandboxSnapshotConfig`/`ArchiveSnapshots`/`ResticSnapshots` schemas.
- UKGovernmentBEIS/inspect_ai#4629 — first-class `Score.reason` → new `reason` field in score schemas.

The latter two show up in the regenerated `openapi.json` via embedded inspect_ai types (structural drift, not tolerated as docstring-only).

## Fix

- Widen scout's `model_roles` plumbing to match upstream: public params take `ModelRoles` (inspect_ai's alias, a supertype of the old `dict[str, str | Model]`), `ScanJob.model_roles` / `init_scan_model_context` return `dict[str, Model | list[Model]]`, and `ScanSpec.model_roles` / `IPCContext.model_roles` hold `ModelConfig | list[ModelConfig]`. Scout only plumbs roles through to inspect_ai (resolution and `get_model(role=...)` live upstream), so list roles work through scout with no behavior change for existing callers.
- Regenerate `openapi.json` and `generated.ts` against inspect_ai main.
- Bump the ts-mono gitlink and rebuild the viewer `dist` (verified the old pinned commit rebuilds byte-identically locally before trusting the new build).

Paired ts-mono PR: meridianlabs-ai/ts-mono#587 (two-phase landing: `submodule-on-main` stays red here until that merges).

## Verification

Local venv with inspect_ai @ git main:
- `mypy src examples tests` — clean (was 11 errors, exact repro of CI)
- `.github/scripts/check_openapi_drift.py` — passes
- `pytest` — 3041 passed, 107 skipped
- ts-mono `pnpm typecheck` — clean; `pnpm test` has a pre-existing failure in `@tsmono/inspect-components` timeline fixtures that reproduces on clean ts-mono main locally (ts-mono CI on the same SHA is green — environmental, unrelated to this change)