### PR TITLE
ci: speed up py-test job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,14 +65,20 @@ jobs:
         python-version: *python-versions
     steps:
       - uses: actions/checkout@v4
+      # setup-python (not uv's managed python): uv 0.9.4 resolves "3.14" to
+      # CPython 3.14.0, where a string member in a runtime `|` union raises
+      # TypeError (fixed in a later 3.14 patch; hostedtoolcache has 3.14.7).
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "0.9.4"
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          uv venv
+          uv venv --python "$(which python)"
           # Track inspect_ai main everywhere EXCEPT the release PR, where we
           # validate against the pinned/shipped version pulled in via .[dev] below.
           if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,28 +65,28 @@ jobs:
         python-version: *python-versions
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
         with:
+          version: "0.9.4"
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          uv venv
           # Track inspect_ai main everywhere EXCEPT the release PR, where we
           # validate against the pinned/shipped version pulled in via .[dev] below.
           if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
-            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+            uv pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
           fi
-          python -m pip install .[dev]
+          uv pip install .[dev]
       - name: Run tests
-        run: pytest
+        # .venv/bin directly, not `uv run`: scout is not a uv-managed project
+        # (no uv.lock), so `uv run` would lock + sync and could replace the
+        # git-installed inspect_ai above with a registry resolution.
+        run: .venv/bin/pytest
+      - name: Minimize uv cache
+        if: ${{ !cancelled() }}
+        run: uv cache prune --ci
 
   py-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,25 +38,25 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          version: "0.9.4"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          uv venv --python "$(which python)"
           # Track inspect_ai main everywhere EXCEPT the release PR, where we
           # validate against the pinned/shipped version pulled in via .[dev] below.
           if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
-            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+            uv pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
           fi
-          python -m pip install .[dev]
+          uv pip install .[dev]
       - name: Run mypy
         run: |
-          mypy src examples tests --python-executable $(which python)
+          .venv/bin/mypy src examples tests
+      - name: Minimize uv cache
+        if: ${{ !cancelled() }}
+        run: uv cache prune --ci
 
   py-test:
     runs-on: ubuntu-latest
@@ -105,21 +105,28 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "0.9.4"
       - name: Install build dependencies
         run: |
-          python -m pip install --upgrade pip
+          uv venv --python "$(which python)"
           # Track inspect_ai main everywhere EXCEPT the release PR, where we
           # validate against the pinned/shipped version pulled in via . below.
           if [ "${{ github.head_ref }}" != "release-please--branches--main" ]; then
-            python -m pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
+            uv pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
           fi
-          python -m pip install build
+          uv pip install build
       - name: Build package
-        run: python -m build
+        run: .venv/bin/python -m build
       - name: Verify package
         run: |
-          python -m pip install dist/*.whl
-          python -c "import inspect_scout; print('Package imported successfully')"
+          uv pip install dist/*.whl
+          .venv/bin/python -c "import inspect_scout; print('Package imported successfully')"
+      - name: Minimize uv cache
+        if: ${{ !cancelled() }}
+        run: uv cache prune --ci
 
   check-schema-and-types:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,13 @@ convention = "google"
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-addopts = "-n auto"
+# -n logical, not auto: auto means physical cores when psutil is importable
+# (it always is — an inspect_ai runtime dependency), which uses only 2 of the
+# 4 vCPUs on ubuntu-latest CI runners. --dist worksteal lets an idle worker
+# take pending tests off a straggler (xdist's default load hands out large
+# contiguous slices, so slow e2e files can strand one worker). Both measured
+# in inspect_ai (design/ci-perf/report.md there).
+addopts = "-n logical --dist worksteal"
 
 [tool.mypy]
 strict = true

--- a/tests/concurrency/test_model_pickling.py
+++ b/tests/concurrency/test_model_pickling.py
@@ -79,7 +79,9 @@ def test_model_survives_cloudpickle_roundtrip_in_subprocess() -> None:
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        timeout=15,
+        # Hang guard only. The subprocess cold-imports inspect_ai/inspect_scout,
+        # which can take >15s on a CI runner whose cores are saturated by xdist.
+        timeout=60,
         check=False,
     )
     if result.returncode != 0:
@@ -165,7 +167,9 @@ def _unpickle_callable_in_subprocess(pickled: bytes) -> bool:
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        timeout=15,
+        # Hang guard only. The subprocess cold-imports inspect_ai/inspect_scout,
+        # which can take >15s on a CI runner whose cores are saturated by xdist.
+        timeout=60,
         check=False,
     )
     if result.returncode != 0:

--- a/tests/sources/langsmith_source/test_client.py
+++ b/tests/sources/langsmith_source/test_client.py
@@ -4,6 +4,7 @@ Tests get_langsmith_client(), _is_retryable_error(), and retry_api_call()
 functions that handle client setup and transient error retries.
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -153,6 +154,11 @@ class TestIsRetryableError:
 
 class TestRetryApiCall:
     """Tests for retry_api_call function."""
+
+    @pytest.fixture(autouse=True)
+    def no_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Zero out the retry backoff (tenacity sleeps via time.sleep)."""
+        monkeypatch.setattr(time, "sleep", lambda _: None)
 
     def test_successful_call_returns_result(self) -> None:
         """Successful call returns result without retry."""

--- a/tests/sources/weave_source/test_client.py
+++ b/tests/sources/weave_source/test_client.py
@@ -1,5 +1,6 @@
 """Tests for W&B Weave client management."""
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,6 +40,11 @@ class TestGetWeaveClient:
 
 class TestRetryApiCall:
     """Tests for retry_api_call function."""
+
+    @pytest.fixture(autouse=True)
+    def no_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Zero out the retry backoff (tenacity sleeps via time.sleep)."""
+        monkeypatch.setattr(time, "sleep", lambda _: None)
 
     def test_successful_call(self) -> None:
         """Successful call returns result without retry."""


### PR DESCRIPTION
Diagnosis: the py-test step ran 3298 tests in 252.7s using only **2 of the runner's 4 vCPUs** (xdist \`-n auto\` = physical cores when psutil is importable, and it always is — inspect_ai runtime dep). inspect_ai hit and fixed the same issues (see its \`design/ci-perf/report.md\`: \`-n logical\` measured 449s→334s; \`--dist worksteal\` took worker efficiency from 68–88% to 97–99%).

Changes:
- \`addopts = "-n logical --dist worksteal"\` — use all 4 vCPUs; let idle workers steal from stragglers (slow e2e files cluster under the default \`load\` dist)
- **py-test, py-mypy, and py-build install via uv** instead of pip (the pip path was 13–29s cache restore + 59–73s install per job; uv does it in ~30s total). The interpreter still comes from setup-python: uv 0.9.4 resolves "3.14" to CPython 3.14.0, where a string member in a runtime \`|\` union (\`_scanjob.py:54\`'s \`| "ScanJob"\`) raises TypeError — fixed in the 3.14.7 that setup-python provides. Jobs run \`.venv/bin/<tool>\` directly, not \`uv run\` — scout has no uv.lock, so \`uv run\` would lock + sync and could replace the git-installed inspect_ai with a registry resolution
- retry tests (langsmith/weave \`TestRetryApiCall\`): zero out tenacity's backoff via a \`monkeypatch\` autouse fixture — they were sleeping through real 1–30s exponential backoff, ~19s of wall per leg
- \`test_model_pickling.py\`: subprocess hang-guard timeouts 15s → 60s. The child process cold-imports inspect_ai/inspect_scout, which can exceed 15s now that xdist saturates all 4 vCPUs (observed once on the 3.10 leg)

Not done (proposed as "make the batch size injectable in \`test_scan_processes_all_transcripts_beyond_1000\`"): **no batch size exists in the source anymore.** The 1000 was a duckdb \`fetchmany(1000)\` page deleted by the very fix that test guards (#157, \`fetchall()\`). Profiled the test: insert of 1500 transcripts is 0.2s; the cost is per-transcript scan overhead (~7ms each). Shrinking the count would gut the >1000 regression coverage to save a few seconds, and adding a knob to production code just for the test isn't worth it. Left as is.

Measured on this PR's CI (3.14 leg, vs the reference run):
- job total 364s → 256s; install 95s → 31s; test step 261s → 212s (pytest 252.7s → 203.7s, header confirms \`created: 4/4 workers\`)
- the parallelism gain is sub-linear (total worker-seconds grew ~505 → ~800): the suite is CPU-contended at 4 workers and pays the import cost per worker. Worksteal keeps the workers balanced regardless

Console output note: scout's pytest config has no \`-rA\` (inspect_ai's flag that prints a summary line for every passing test) and no \`log_cli\`, so passing tests emit nothing — the whole test step logs ~120 lines. This PR keeps it that way.