### PR TITLE
feat!: exclude heavy columns by default when reading scan results

### DIFF
--- a/docs/_results-data-frame.md
+++ b/docs/_results-data-frame.md
@@ -29,7 +29,7 @@ Note that by default the results data frame will include an individual row for e
 
 The data frame includes the following fields (note that some fields included embedded JSON data, these are all noted below).
 
-Note that the heavy JSON columns (`input` and `scan_events`) are excluded by default as they dominate file size and memory usage—pass `exclude_columns=[]` to include all columns, or an explicit list to exclude exactly those columns.
+Note that the heavy JSON columns (`input` and `scan_events`) are excluded by default as they dominate file size and memory usage—pass `exclude_columns=[]` to include all columns, or an explicit list to exclude exactly those columns (the default exclusions are available as the `HEAVY_COLUMNS` constant, e.g. `exclude_columns=[*HEAVY_COLUMNS, "metadata"]`).
 
 | Field | Type | Description |
 |-------------------|-------------------|----------------------------------|

--- a/docs/_results-data-frame.md
+++ b/docs/_results-data-frame.md
@@ -27,7 +27,7 @@ Note that by default the results data frame will include an individual row for e
 
 #### Available Fields
 
-The data frame includes the following fields (note that some fields included embedded JSON data, these are all noted below).
+The data frame includes the following fields (note that some fields include embedded JSON data, these are all noted below).
 
 Note that the heavy JSON columns (`input` and `scan_events`) are excluded by default as they dominate file size and memory usage—pass `exclude_columns=[]` to include all columns, or an explicit list to exclude exactly those columns (the default exclusions are available as the `HEAVY_COLUMNS` constant, e.g. `exclude_columns=[*HEAVY_COLUMNS, "metadata"]`).
 

--- a/docs/_results-data-frame.md
+++ b/docs/_results-data-frame.md
@@ -27,7 +27,9 @@ Note that by default the results data frame will include an individual row for e
 
 #### Available Fields
 
-The data frame includes the following fields (note that some fields included embedded JSON data, these are all noted below):
+The data frame includes the following fields (note that some fields included embedded JSON data, these are all noted below).
+
+Note that the heavy JSON columns (`input` and `scan_events`) are excluded by default as they dominate file size and memory usage—pass `exclude_columns=[]` to include all columns, or an explicit list to exclude exactly those columns.
 
 | Field | Type | Description |
 |-------------------|-------------------|----------------------------------|
@@ -65,7 +67,7 @@ The data frame includes the following fields (note that some fields included emb
 | `scanner_params` | dict<br/><small>JSON</small> | Params used to create scanner. |
 | `input_type` | transcript \| message \| messages \| event \| events | Input type received by scanner. |
 | `input_ids` | list\[str\]<br/><small>JSON</small> | Unique ids of scanner input. |
-| `input` | ScannerInput<br/><small>JSON</small> | Scanner input value. |
+| `input` | ScannerInput<br/><small>JSON</small> | Scanner input value (excluded by default). |
 | `uuid` | str | Globally unique id for scan result. |
 | `label` | str | Label for the origin of the result (optional). |
 | `value` | JsonValue<br/><small>JSON</small> | Value returned by scanner. |
@@ -82,7 +84,7 @@ The data frame includes the following fields (note that some fields included emb
 | `scan_error` | str | Error which occurred during scan. |
 | `scan_error_traceback` | str | Traceback for error (if any) |
 | `scan_error_type` | str | Error type (either "refusal" for refusals or null for other errors). |
-| `scan_events` | list\[Event\]<br/><small>JSON</small> | Scan events (e.g. model event, log event, etc.) |
+| `scan_events` | list\[Event\]<br/><small>JSON</small> | Scan events (e.g. model event, log event, etc.) (excluded by default) |
 | `scan_total_tokens` | number | Total tokens used by scan (only included when `rows = "transcripts"`). |
 | `scan_model_usage` | dict \[str, ModelUsage\]<br/><small>JSON</small> | Token usage by model for scan (only included when `rows = "transcripts"`). |
 

--- a/docs/reference/results.qmd
+++ b/docs/reference/results.qmd
@@ -15,6 +15,7 @@ reference: inspect_scout
 ### scan_results_arrow
 ### ScanResultsArrow
 ### scan_results_batches
+### HEAVY_COLUMNS
 
 ## Validation
 

--- a/src/inspect_scout/__init__.py
+++ b/src/inspect_scout/__init__.py
@@ -18,6 +18,7 @@ from ._observe import ObserveEmit, ObserveProvider, observe, observe_update
 from ._project import ProjectConfig
 from ._query.condition import Condition
 from ._recorder.recorder import (
+    HEAVY_COLUMNS,
     ScanResultsArrow,
     ScanResultsDF,
     Status,
@@ -134,6 +135,7 @@ __all__ = [
     "scan_results_arrow",
     "ScanResultsArrow",
     "scan_results_batches",
+    "HEAVY_COLUMNS",
     "Summary",
     # transcript
     "transcripts_db",

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -414,7 +414,7 @@ class FileRecorder(ScanRecorder):
                 self,
                 scanner: str,
                 streaming_batch_size: int = 1024,
-                exclude_columns: list[str] | None = None,
+                exclude_columns: Sequence[str] | None = None,
             ) -> pa.RecordBatchReader:
                 # iter_batches() streams lazily for both local files and
                 # PyArrow cloud filesystems (which do ranged reads on demand),
@@ -553,12 +553,12 @@ class FileRecorder(ScanRecorder):
         scan_location: str,
         *,
         scanner: str | None = None,
-        exclude_columns: list[str] | None = None,
+        exclude_columns: Sequence[str] | None = None,
     ) -> ScanResultsDF:
         scan_dir = UPath(scan_location)
         status = await FileRecorder.status(scan_location)
 
-        exclude_columns = resolve_exclude_columns(exclude_columns)
+        resolved_exclude = resolve_exclude_columns(exclude_columns)
 
         # Determine available scanner names
         if scanner is not None:
@@ -574,7 +574,7 @@ class FileRecorder(ScanRecorder):
         scanners = LazyScannerMapping(
             scanner_names=scanner_names,
             loader=lambda name: _load_scanner_df(
-                scan_dir, name, exclude_columns=exclude_columns
+                scan_dir, name, exclude_columns=resolved_exclude
             ),
         )
 
@@ -594,7 +594,7 @@ class FileRecorder(ScanRecorder):
         scanner: str,
         *,
         batch_size: int = 1024,
-        exclude_columns: list[str] | None = None,
+        exclude_columns: Sequence[str] | None = None,
     ) -> ScanResultsBatches:
         parquet = _open_scanner_parquet(UPath(scan_location), scanner)
 

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -44,6 +44,7 @@ from .._scanspec import ScanSpec, ScanTranscripts
 from .._transcript.types import TranscriptInfo
 from .._util.duckdb import create_parquet_view, restrict_external_access
 from .recorder import (
+    HEAVY_COLUMNS,
     ScanRecorder,
     ScanResultsArrow,
     ScanResultsBatches,
@@ -420,7 +421,9 @@ class FileRecorder(ScanRecorder):
                 # keeping memory bounded by streaming_batch_size.
                 parquet = _open_scanner_parquet(scan_path, scanner)
 
-                exclude = set(exclude_columns) if exclude_columns else set()
+                exclude = set(
+                    HEAVY_COLUMNS if exclude_columns is None else exclude_columns
+                )
                 columns = [c for c in parquet.schema.names if c not in exclude]
 
                 fields_by_name = {f.name: f for f in parquet.schema_arrow}
@@ -557,6 +560,10 @@ class FileRecorder(ScanRecorder):
         scan_dir = UPath(scan_location)
         status = await FileRecorder.status(scan_location)
 
+        # None means "exclude the heavy columns" (pass [] to include all)
+        if exclude_columns is None:
+            exclude_columns = HEAVY_COLUMNS
+
         # Determine available scanner names
         if scanner is not None:
             scanner_names = [scanner]
@@ -595,7 +602,7 @@ class FileRecorder(ScanRecorder):
     ) -> ScanResultsBatches:
         parquet = _open_scanner_parquet(UPath(scan_location), scanner)
 
-        exclude = set(exclude_columns) if exclude_columns else set()
+        exclude = set(HEAVY_COLUMNS if exclude_columns is None else exclude_columns)
         columns = [c for c in parquet.schema.names if c not in exclude]
 
         # The single-DataFrame path makes its value-cast decisions over the

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -44,13 +44,13 @@ from .._scanspec import ScanSpec, ScanTranscripts
 from .._transcript.types import TranscriptInfo
 from .._util.duckdb import create_parquet_view, restrict_external_access
 from .recorder import (
-    HEAVY_COLUMNS,
     ScanRecorder,
     ScanResultsArrow,
     ScanResultsBatches,
     ScanResultsDB,
     ScanResultsDF,
     Status,
+    resolve_exclude_columns,
 )
 
 SCAN_JSON = "_scan.json"
@@ -421,9 +421,7 @@ class FileRecorder(ScanRecorder):
                 # keeping memory bounded by streaming_batch_size.
                 parquet = _open_scanner_parquet(scan_path, scanner)
 
-                exclude = set(
-                    HEAVY_COLUMNS if exclude_columns is None else exclude_columns
-                )
+                exclude = set(resolve_exclude_columns(exclude_columns))
                 columns = [c for c in parquet.schema.names if c not in exclude]
 
                 fields_by_name = {f.name: f for f in parquet.schema_arrow}
@@ -560,9 +558,7 @@ class FileRecorder(ScanRecorder):
         scan_dir = UPath(scan_location)
         status = await FileRecorder.status(scan_location)
 
-        # None means "exclude the heavy columns" (pass [] to include all)
-        if exclude_columns is None:
-            exclude_columns = list(HEAVY_COLUMNS)
+        exclude_columns = resolve_exclude_columns(exclude_columns)
 
         # Determine available scanner names
         if scanner is not None:
@@ -602,7 +598,7 @@ class FileRecorder(ScanRecorder):
     ) -> ScanResultsBatches:
         parquet = _open_scanner_parquet(UPath(scan_location), scanner)
 
-        exclude = set(HEAVY_COLUMNS if exclude_columns is None else exclude_columns)
+        exclude = set(resolve_exclude_columns(exclude_columns))
         columns = [c for c in parquet.schema.names if c not in exclude]
 
         # The single-DataFrame path makes its value-cast decisions over the

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -562,7 +562,7 @@ class FileRecorder(ScanRecorder):
 
         # None means "exclude the heavy columns" (pass [] to include all)
         if exclude_columns is None:
-            exclude_columns = HEAVY_COLUMNS
+            exclude_columns = list(HEAVY_COLUMNS)
 
         # Determine available scanner names
         if scanner is not None:
@@ -1303,15 +1303,16 @@ def _load_scanner_df(
     scan_dir: UPath,
     scanner_name: str,
     *,
-    exclude_columns: list[str] | None = None,
+    exclude_columns: list[str],
 ) -> pd.DataFrame:
     """Load a scanner's DataFrame from a parquet file.
 
     Args:
         scan_dir: Directory containing the scan parquet files.
         scanner_name: Name of the scanner (without .parquet extension).
-        exclude_columns: List of column names to exclude when reading.
-            Non-existent columns are silently ignored.
+        exclude_columns: Column names to exclude when reading (callers resolve
+            any default before calling; `[]` excludes nothing). Non-existent
+            columns are silently ignored.
 
     Returns:
         DataFrame with the scanner results, value column cast appropriately.

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -28,14 +28,14 @@ needs them. Pass `exclude_columns=[]` to include all columns.
 """
 
 
-def resolve_exclude_columns(exclude_columns: list[str] | None) -> list[str]:
+def resolve_exclude_columns(exclude_columns: Sequence[str] | None) -> list[str]:
     """Resolve an `exclude_columns` argument to the columns to exclude.
 
     `None` (the default everywhere) means "exclude the heavy columns"
-    (`HEAVY_COLUMNS`); an explicit list (including `[]`) excludes exactly
+    (`HEAVY_COLUMNS`); an explicit sequence (including `[]`) excludes exactly
     those columns.
     """
-    return list(HEAVY_COLUMNS) if exclude_columns is None else exclude_columns
+    return list(HEAVY_COLUMNS if exclude_columns is None else exclude_columns)
 
 
 @dataclass
@@ -82,7 +82,7 @@ class ScanResultsArrow(Status):
         self,
         scanner: str,
         streaming_batch_size: int = 1024,
-        exclude_columns: list[str] | None = None,
+        exclude_columns: Sequence[str] | None = None,
     ) -> pa.RecordBatchReader:
         """Acquire a reader for the specified scanner.
 
@@ -91,7 +91,7 @@ class ScanResultsArrow(Status):
         `exclude_columns=None` (the default) excludes the heavy columns
         (`input`, `input_data`, and `scan_events`, available as
         `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        sequence to exclude exactly those columns.
         """
         ...
 
@@ -321,14 +321,14 @@ class ScanRecorder(abc.ABC):
         scan_location: str,
         *,
         scanner: str | None = None,
-        exclude_columns: list[str] | None = None,
+        exclude_columns: Sequence[str] | None = None,
     ) -> ScanResultsDF:
         """Read scan results as pandas DataFrames.
 
         `exclude_columns=None` (the default) excludes the heavy columns
         (`input`, `input_data`, and `scan_events`, available as
         `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        sequence to exclude exactly those columns.
         """
         ...
 
@@ -339,7 +339,7 @@ class ScanRecorder(abc.ABC):
         scanner: str,
         *,
         batch_size: int = 1024,
-        exclude_columns: list[str] | None = None,
+        exclude_columns: Sequence[str] | None = None,
     ) -> ScanResultsBatches:
         """Stream a scanner's results as raw DataFrame batches.
 
@@ -352,7 +352,7 @@ class ScanRecorder(abc.ABC):
         `exclude_columns=None` (the default) excludes the heavy columns
         (`input`, `input_data`, and `scan_events`, available as
         `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        sequence to exclude exactly those columns.
 
         Note that batches are read with synchronous I/O (unlike the other
         recorder methods, which are async).

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -28,6 +28,16 @@ needs them. Pass `exclude_columns=[]` to include all columns.
 """
 
 
+def resolve_exclude_columns(exclude_columns: list[str] | None) -> list[str]:
+    """Resolve an `exclude_columns` argument to the columns to exclude.
+
+    `None` (the default everywhere) means "exclude the heavy columns"
+    (`HEAVY_COLUMNS`); an explicit list (including `[]`) excludes exactly
+    those columns.
+    """
+    return list(HEAVY_COLUMNS) if exclude_columns is None else exclude_columns
+
+
 @dataclass
 class Status:
     """Status of scan job."""
@@ -79,8 +89,9 @@ class ScanResultsArrow(Status):
         The return reader is a context manager that should be acquired before reading.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
-        columns, or an explicit list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`, available as
+        `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
         """
         ...
 
@@ -315,8 +326,9 @@ class ScanRecorder(abc.ABC):
         """Read scan results as pandas DataFrames.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
-        columns, or an explicit list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`, available as
+        `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
         """
         ...
 
@@ -338,8 +350,9 @@ class ScanRecorder(abc.ABC):
         transformations depend on are provided alongside the iterator.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
-        columns, or an explicit list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`, available as
+        `HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
 
         Note that batches are read with synchronous I/O (unlike the other
         recorder methods, which are async).

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -18,6 +18,15 @@ from .._transcript.types import TranscriptInfo
 from .._util.duckdb import generated_identifier
 from .summary import Summary
 
+HEAVY_COLUMNS: list[str] = ["input", "input_data", "scan_events"]
+"""Large JSON columns excluded by default when reading scan results.
+
+These columns (full serialized scanner input, deduplicated message/call
+pools, and scanner execution events) dominate parquet file size and memory
+usage, and the common case (analysis over values/scores/metadata) never
+needs them. Pass `exclude_columns=[]` to include all columns.
+"""
+
 
 @dataclass
 class Status:
@@ -68,6 +77,10 @@ class ScanResultsArrow(Status):
         """Acquire a reader for the specified scanner.
 
         The return reader is a context manager that should be acquired before reading.
+
+        `exclude_columns=None` (the default) excludes the heavy columns
+        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
         """
         ...
 
@@ -298,7 +311,14 @@ class ScanRecorder(abc.ABC):
         *,
         scanner: str | None = None,
         exclude_columns: list[str] | None = None,
-    ) -> ScanResultsDF: ...
+    ) -> ScanResultsDF:
+        """Read scan results as pandas DataFrames.
+
+        `exclude_columns=None` (the default) excludes the heavy columns
+        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
+        """
+        ...
 
     @staticmethod
     @abc.abstractmethod
@@ -316,6 +336,10 @@ class ScanRecorder(abc.ABC):
         batches of `batch_size` rows, with memory bounded by `batch_size`
         rather than the size of the results. File-scoped facts that per-batch
         transformations depend on are provided alongside the iterator.
+
+        `exclude_columns=None` (the default) excludes the heavy columns
+        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
+        list to exclude exactly those columns.
 
         Note that batches are read with synchronous I/O (unlike the other
         recorder methods, which are async).

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -18,7 +18,7 @@ from .._transcript.types import TranscriptInfo
 from .._util.duckdb import generated_identifier
 from .summary import Summary
 
-HEAVY_COLUMNS: list[str] = ["input", "input_data", "scan_events"]
+HEAVY_COLUMNS: tuple[str, ...] = ("input", "input_data", "scan_events")
 """Large JSON columns excluded by default when reading scan results.
 
 These columns (full serialized scanner input, deduplicated message/call
@@ -79,8 +79,8 @@ class ScanResultsArrow(Status):
         The return reader is a context manager that should be acquired before reading.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
+        columns, or an explicit list to exclude exactly those columns.
         """
         ...
 
@@ -315,8 +315,8 @@ class ScanRecorder(abc.ABC):
         """Read scan results as pandas DataFrames.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
+        columns, or an explicit list to exclude exactly those columns.
         """
         ...
 
@@ -338,8 +338,8 @@ class ScanRecorder(abc.ABC):
         transformations depend on are provided alongside the iterator.
 
         `exclude_columns=None` (the default) excludes the heavy columns
-        (`HEAVY_COLUMNS`); pass `[]` to include all columns, or an explicit
-        list to exclude exactly those columns.
+        (`input`, `input_data`, and `scan_events`); pass `[]` to include all
+        columns, or an explicit list to exclude exactly those columns.
 
         Note that batches are read with synchronous I/O (unlike the other
         recorder methods, which are async).

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -89,7 +89,11 @@ def scan_results_df(
             for each transcript (in which case multiple results will be packed
             into the `value` field as a JSON list of `Result`).
         exclude_columns: List of column names to exclude when reading parquet files.
-            Useful for reducing memory usage by skipping large unused columns.
+            Defaults to `None`, which excludes the heavy columns (`input`,
+            `input_data`, and `scan_events`) that dominate file size and memory
+            usage. Pass `[]` to include all columns, or an explicit list to
+            exclude exactly those columns. Use `scan_results_arrow()` field
+            accessors for per-row access to heavy columns.
 
     Returns:
          ScanResults: Results as pandas data frames.
@@ -118,7 +122,11 @@ async def scan_results_df_async(
             for each transcript (in which case multiple results will be packed
             into the `value` field as a JSON list of `Result`).
         exclude_columns: List of column names to exclude when reading parquet files.
-            Useful for reducing memory usage by skipping large unused columns.
+            Defaults to `None`, which excludes the heavy columns (`input`,
+            `input_data`, and `scan_events`) that dominate file size and memory
+            usage. Pass `[]` to include all columns, or an explicit list to
+            exclude exactly those columns. Use `scan_results_arrow()` field
+            accessors for per-row access to heavy columns.
 
     Returns:
          ScanResults: Results as Pandas data frames.
@@ -178,7 +186,11 @@ def scan_results_batches(
         batch_size: Maximum number of parquet rows read per batch (note that
             resultset expansion can yield more than `batch_size` rows per batch).
         exclude_columns: List of column names to exclude when reading parquet files.
-            Useful for reducing memory usage by skipping large unused columns.
+            Defaults to `None`, which excludes the heavy columns (`input`,
+            `input_data`, and `scan_events`) that dominate file size and memory
+            usage. Pass `[]` to include all columns, or an explicit list to
+            exclude exactly those columns. Use `scan_results_arrow()` field
+            accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result
             (potentially multiple per transcript); Specify "transcript" to yield a row
             for each transcript (in which case multiple results will be packed
@@ -223,7 +235,11 @@ async def scan_results_batches_async(
         batch_size: Maximum number of parquet rows read per batch (note that
             resultset expansion can yield more than `batch_size` rows per batch).
         exclude_columns: List of column names to exclude when reading parquet files.
-            Useful for reducing memory usage by skipping large unused columns.
+            Defaults to `None`, which excludes the heavy columns (`input`,
+            `input_data`, and `scan_events`) that dominate file size and memory
+            usage. Pass `[]` to include all columns, or an explicit list to
+            exclude exactly those columns. Use `scan_results_arrow()` field
+            accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result
             (potentially multiple per transcript); Specify "transcript" to yield a row
             for each transcript (in which case multiple results will be packed

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import Any, Literal
 
 import pandas as pd
@@ -77,7 +77,7 @@ def scan_results_df(
     *,
     scanner: str | None = None,
     rows: Literal["results", "transcripts"] = "results",
-    exclude_columns: list[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
 ) -> ScanResultsDF:
     """Scan results as Pandas data frames.
 
@@ -88,11 +88,11 @@ def scan_results_df(
             (potentially multiple per transcript); Specify "transcript" to yield a row
             for each transcript (in which case multiple results will be packed
             into the `value` field as a JSON list of `Result`).
-        exclude_columns: List of column names to exclude when reading parquet files.
+        exclude_columns: Column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
             `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
             that dominate file size and memory usage. Pass `[]` to include
-            all columns, or an explicit list to exclude exactly those
+            all columns, or an explicit sequence to exclude exactly those
             columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
 
@@ -111,7 +111,7 @@ async def scan_results_df_async(
     *,
     scanner: str | None = None,
     rows: Literal["results", "transcripts"] = "results",
-    exclude_columns: list[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
 ) -> ScanResultsDF:
     """Scan results as Pandas data frames.
 
@@ -122,11 +122,11 @@ async def scan_results_df_async(
             (potentially multiple per transcript); Specify "transcript" to yield a row
             for each transcript (in which case multiple results will be packed
             into the `value` field as a JSON list of `Result`).
-        exclude_columns: List of column names to exclude when reading parquet files.
+        exclude_columns: Column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
             `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
             that dominate file size and memory usage. Pass `[]` to include
-            all columns, or an explicit list to exclude exactly those
+            all columns, or an explicit sequence to exclude exactly those
             columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
 
@@ -164,7 +164,7 @@ def scan_results_batches(
     scanner: str,
     *,
     batch_size: int = 1024,
-    exclude_columns: list[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
     rows: Literal["results", "transcripts"] = "results",
 ) -> Iterator[pd.DataFrame]:
     """Stream a scanner's results as pandas DataFrame batches.
@@ -187,11 +187,11 @@ def scan_results_batches(
         scanner: Scanner name.
         batch_size: Maximum number of parquet rows read per batch (note that
             resultset expansion can yield more than `batch_size` rows per batch).
-        exclude_columns: List of column names to exclude when reading parquet files.
+        exclude_columns: Column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
             `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
             that dominate file size and memory usage. Pass `[]` to include
-            all columns, or an explicit list to exclude exactly those
+            all columns, or an explicit sequence to exclude exactly those
             columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result
@@ -223,7 +223,7 @@ async def scan_results_batches_async(
     scanner: str,
     *,
     batch_size: int = 1024,
-    exclude_columns: list[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
     rows: Literal["results", "transcripts"] = "results",
 ) -> AsyncIterator[pd.DataFrame]:
     """Stream a scanner's results as pandas DataFrame batches.
@@ -237,11 +237,11 @@ async def scan_results_batches_async(
         scanner: Scanner name.
         batch_size: Maximum number of parquet rows read per batch (note that
             resultset expansion can yield more than `batch_size` rows per batch).
-        exclude_columns: List of column names to exclude when reading parquet files.
+        exclude_columns: Column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
             `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
             that dominate file size and memory usage. Pass `[]` to include
-            all columns, or an explicit list to exclude exactly those
+            all columns, or an explicit sequence to exclude exactly those
             columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result

--- a/src/inspect_scout/_scanresults.py
+++ b/src/inspect_scout/_scanresults.py
@@ -90,9 +90,10 @@ def scan_results_df(
             into the `value` field as a JSON list of `Result`).
         exclude_columns: List of column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
-            `input_data`, and `scan_events`) that dominate file size and memory
-            usage. Pass `[]` to include all columns, or an explicit list to
-            exclude exactly those columns. Use `scan_results_arrow()` field
+            `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
+            that dominate file size and memory usage. Pass `[]` to include
+            all columns, or an explicit list to exclude exactly those
+            columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
 
     Returns:
@@ -123,9 +124,10 @@ async def scan_results_df_async(
             into the `value` field as a JSON list of `Result`).
         exclude_columns: List of column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
-            `input_data`, and `scan_events`) that dominate file size and memory
-            usage. Pass `[]` to include all columns, or an explicit list to
-            exclude exactly those columns. Use `scan_results_arrow()` field
+            `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
+            that dominate file size and memory usage. Pass `[]` to include
+            all columns, or an explicit list to exclude exactly those
+            columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
 
     Returns:
@@ -187,9 +189,10 @@ def scan_results_batches(
             resultset expansion can yield more than `batch_size` rows per batch).
         exclude_columns: List of column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
-            `input_data`, and `scan_events`) that dominate file size and memory
-            usage. Pass `[]` to include all columns, or an explicit list to
-            exclude exactly those columns. Use `scan_results_arrow()` field
+            `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
+            that dominate file size and memory usage. Pass `[]` to include
+            all columns, or an explicit list to exclude exactly those
+            columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result
             (potentially multiple per transcript); Specify "transcript" to yield a row
@@ -236,9 +239,10 @@ async def scan_results_batches_async(
             resultset expansion can yield more than `batch_size` rows per batch).
         exclude_columns: List of column names to exclude when reading parquet files.
             Defaults to `None`, which excludes the heavy columns (`input`,
-            `input_data`, and `scan_events`) that dominate file size and memory
-            usage. Pass `[]` to include all columns, or an explicit list to
-            exclude exactly those columns. Use `scan_results_arrow()` field
+            `input_data`, and `scan_events`, available as `HEAVY_COLUMNS`)
+            that dominate file size and memory usage. Pass `[]` to include
+            all columns, or an explicit list to exclude exactly those
+            columns. Use `scan_results_arrow()` field
             accessors for per-row access to heavy columns.
         rows: Row granularity. Specify "results" to yield a row for each scanner result
             (potentially multiple per transcript); Specify "transcript" to yield a row

--- a/tests/recorder/test_load_scanner_df.py
+++ b/tests/recorder/test_load_scanner_df.py
@@ -13,8 +13,8 @@ from pathlib import Path
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
+from inspect_scout import HEAVY_COLUMNS
 from inspect_scout._recorder.file import _load_scanner_df, _parquet_source
-from inspect_scout._recorder.recorder import HEAVY_COLUMNS
 from inspect_scout._scanresults import scan_results_df
 from upath import UPath
 

--- a/tests/recorder/test_load_scanner_df.py
+++ b/tests/recorder/test_load_scanner_df.py
@@ -37,7 +37,7 @@ def memory_scan_dir() -> Iterator[UPath]:
 def test_exclude_columns_matches_full_read(scanner_name: str) -> None:
     """Excluding columns drops them and leaves all other data unchanged."""
     scan_dir = UPath(SCAN_DIR.as_posix())
-    full = _load_scanner_df(scan_dir, scanner_name)
+    full = _load_scanner_df(scan_dir, scanner_name, exclude_columns=[])
     excluded = _load_scanner_df(scan_dir, scanner_name, exclude_columns=EXCLUDED)
 
     assert len(full) > 0
@@ -47,13 +47,13 @@ def test_exclude_columns_matches_full_read(scanner_name: str) -> None:
 
 @pytest.mark.parametrize(
     "exclude_columns",
-    [None, [], ["not_a_column"]],
-    ids=["none", "empty", "nonexistent"],
+    [[], ["not_a_column"]],
+    ids=["empty", "nonexistent"],
 )
-def test_exclude_columns_noop_variants(exclude_columns: list[str] | None) -> None:
-    """None, empty, and non-existent exclusions all yield the full read."""
+def test_exclude_columns_noop_variants(exclude_columns: list[str]) -> None:
+    """Empty and non-existent exclusions both yield the full read."""
     scan_dir = UPath(SCAN_DIR.as_posix())
-    full = _load_scanner_df(scan_dir, "word_counter")
+    full = _load_scanner_df(scan_dir, "word_counter", exclude_columns=[])
     df = _load_scanner_df(scan_dir, "word_counter", exclude_columns=exclude_columns)
     pd.testing.assert_frame_equal(df, full)
 

--- a/tests/recorder/test_load_scanner_df.py
+++ b/tests/recorder/test_load_scanner_df.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pyarrow.parquet as pq
 import pytest
 from inspect_scout._recorder.file import _load_scanner_df, _parquet_source
+from inspect_scout._recorder.recorder import HEAVY_COLUMNS
 from inspect_scout._scanresults import scan_results_df
 from upath import UPath
 
@@ -78,13 +79,30 @@ def test_value_cast_skipped_when_value_type_excluded() -> None:
 def test_scan_results_df_exclude_columns(scanner_name: str) -> None:
     """exclude_columns via the public scan_results_df API matches a full read."""
     location = SCAN_DIR.as_posix()
-    full = scan_results_df(location, scanner=scanner_name).scanners[scanner_name]
+    full = scan_results_df(location, scanner=scanner_name, exclude_columns=[]).scanners[
+        scanner_name
+    ]
     results = scan_results_df(location, scanner=scanner_name, exclude_columns=EXCLUDED)
     df = results.scanners[scanner_name]
 
     assert len(full) > 0
     assert list(df.columns) == [c for c in full.columns if c not in EXCLUDED]
     pd.testing.assert_frame_equal(df, full[df.columns])
+
+
+@pytest.mark.parametrize("scanner_name", SCANNERS)
+def test_scan_results_df_default_excludes_heavy_columns(scanner_name: str) -> None:
+    """Default (None) excludes heavy columns; [] includes everything."""
+    location = SCAN_DIR.as_posix()
+    full = scan_results_df(location, scanner=scanner_name, exclude_columns=[]).scanners[
+        scanner_name
+    ]
+    default = scan_results_df(location, scanner=scanner_name).scanners[scanner_name]
+
+    assert len(default) > 0
+    # input_data is dropped from the full read too (by event expansion)
+    assert list(default.columns) == [c for c in full.columns if c not in HEAVY_COLUMNS]
+    pd.testing.assert_frame_equal(default, full[default.columns])
 
 
 def test_load_scanner_df_from_fsspec_only_protocol(memory_scan_dir: UPath) -> None:

--- a/tests/test_event_expansion.py
+++ b/tests/test_event_expansion.py
@@ -67,7 +67,9 @@ def test_events_expanded_in_results_df() -> None:
             max_processes=1,
         )
 
-        results = scan_results_df(status.location, scanner="events_scanner")
+        results = scan_results_df(
+            status.location, scanner="events_scanner", exclude_columns=[]
+        )
         df = results.scanners["events_scanner"]
 
         assert "input_data" not in df.columns
@@ -77,6 +79,26 @@ def test_events_expanded_in_results_df() -> None:
         events = json.loads(input_json)
         assert isinstance(events, list)
         assert not _has_unresolved_refs(events)
+
+
+def test_heavy_columns_excluded_by_default() -> None:
+    """Default read excludes input, input_data, and scan_events."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[events_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+            max_processes=1,
+        )
+
+        results = scan_results_df(status.location, scanner="events_scanner")
+        df = results.scanners["events_scanner"]
+
+        assert "input" not in df.columns
+        assert "input_data" not in df.columns
+        assert "scan_events" not in df.columns
+        assert "value" in df.columns
 
 
 def test_results_input_columns_are_compact_json() -> None:
@@ -133,7 +155,9 @@ def test_transcript_input_expanded_in_results_df() -> None:
             max_processes=1,
         )
 
-        results = scan_results_df(status.location, scanner="transcript_scanner")
+        results = scan_results_df(
+            status.location, scanner="transcript_scanner", exclude_columns=[]
+        )
         df = results.scanners["transcript_scanner"]
 
         assert "input_data" not in df.columns
@@ -155,7 +179,9 @@ def test_messages_only_scanner_no_errors() -> None:
             max_processes=1,
         )
 
-        results = scan_results_df(status.location, scanner="messages_scanner")
+        results = scan_results_df(
+            status.location, scanner="messages_scanner", exclude_columns=[]
+        )
         df = results.scanners["messages_scanner"]
 
         # input_data column should be dropped regardless
@@ -175,7 +201,10 @@ def test_transcript_mode_also_expands() -> None:
         )
 
         results = scan_results_df(
-            status.location, scanner="events_scanner", rows="transcripts"
+            status.location,
+            scanner="events_scanner",
+            rows="transcripts",
+            exclude_columns=[],
         )
         df = results.scanners["events_scanner"]
 

--- a/tests/test_scan_results_batches.py
+++ b/tests/test_scan_results_batches.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 import pytest
 from fsspec.implementations.local import LocalFileSystem  # type: ignore[import-untyped]
 from inspect_scout import (
+    HEAVY_COLUMNS,
     Result,
     Scanner,
     scan,
@@ -20,7 +21,6 @@ from inspect_scout import (
     scan_results_df,
     scanner,
 )
-from inspect_scout._recorder.recorder import HEAVY_COLUMNS
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
 from inspect_scout.aio import scan_results_batches_async

--- a/tests/test_scan_results_batches.py
+++ b/tests/test_scan_results_batches.py
@@ -20,6 +20,7 @@ from inspect_scout import (
     scan_results_df,
     scanner,
 )
+from inspect_scout._recorder.recorder import HEAVY_COLUMNS
 from inspect_scout._transcript.factory import transcripts_from
 from inspect_scout._transcript.types import Transcript
 from inspect_scout.aio import scan_results_batches_async
@@ -267,6 +268,32 @@ def test_exclude_columns(scan_location: str) -> None:
     for batch in batches:
         assert "scan_events" not in batch.columns
         assert "eval_metadata" not in batch.columns
+
+
+def test_default_excludes_heavy_columns(scan_location: str) -> None:
+    """Default (None) excludes heavy columns; [] includes everything."""
+    default_batches = assert_batches_match_df(scan_location, "bool_scanner")
+    for batch in default_batches:
+        assert not set(HEAVY_COLUMNS) & set(batch.columns)
+
+    full_batches = assert_batches_match_df(
+        scan_location, "bool_scanner", exclude_columns=[]
+    )
+    full = pd.concat(full_batches, ignore_index=True)
+    # input_data is dropped by event expansion after the full read
+    assert "input" in full.columns
+    assert "scan_events" in full.columns
+
+
+def test_reader_default_excludes_heavy_columns() -> None:
+    """Arrow reader default (None) excludes heavy columns; [] includes them."""
+    results = scan_results_arrow(FIXTURE_SCAN.as_posix())
+
+    default_schema = results.reader("word_counter").schema
+    assert not set(HEAVY_COLUMNS) & set(default_schema.names)
+
+    full_schema = results.reader("word_counter", exclude_columns=[]).schema
+    assert set(default_schema.names) == set(full_schema.names) - set(HEAVY_COLUMNS)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #502

Change the default for exclude_columns (None) to exclude the heavy JSON
columns (input, input_data, scan_events) in scan_results_df(),
scan_results_batches(), ScanRecorder.results_df()/results_batches(), and
ScanResultsArrow.reader(). Pass exclude_columns=[] to include all columns;
an explicit list excludes exactly those columns. The heavy set is defined
once as HEAVY_COLUMNS in _recorder/recorder.py.

The scan_df HTTP endpoint already defaults exclude_column=[], which under
the new semantics still means "exclude nothing", so API behavior is
unchanged.

BREAKING CHANGE: callers that rely on input, input_data, or scan_events
being present in default dataframe/reader output must pass
exclude_columns=[] (or use ScanResultsArrow.get_fields() for per-row
access).

Closes #502

Co-authored-by: Eric Patey <769548+epatey@users.noreply.github.com>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>