### PR TITLE
refactor: collect concurrent scan reads with tg_collect

### DIFF
--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -1,4 +1,3 @@
-import asyncio
 import functools
 import io
 import json
@@ -18,6 +17,7 @@ import pyarrow.compute as pc
 import pyarrow.dataset as ds
 import pyarrow.fs as pafs
 import pyarrow.parquet as pq
+from inspect_ai._util._async import tg_collect
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import file, filesystem
 from inspect_ai._util.json import to_json_str_safe
@@ -729,10 +729,9 @@ class FileRecorder(ScanRecorder):
                 scan_dirs.append(entry.as_posix())
 
         # Fetch in parallel; skip scans that no longer exist and propagate
-        # any other error. return_exceptions=True keeps one failure from
-        # cancelling its siblings.
-        results = await asyncio.gather(
-            *(FileRecorder.status(d) for d in scan_dirs), return_exceptions=True
+        # any other error.
+        results = await tg_collect(
+            [functools.partial(_status_or_error, d) for d in scan_dirs]
         )
         scans: list[Status] = []
         for r in results:
@@ -757,6 +756,20 @@ class FileRecorder(ScanRecorder):
 # cleared when a run starts (`init`/`resume`/`attach`) and when a sync
 # completes the scan.
 _prior_parquet_cache: dict[str, dict[str, str | None]] = {}
+
+
+async def _status_or_error(scan_dir: str) -> Status | BaseException:
+    """Read one scan's status, returning any failure as a value.
+
+    Concurrent reads run in a task group, which cancels the remaining reads as
+    soon as one raises. Cancellation is captured too — the caller re-raises it,
+    and anyio re-delivers a genuine cancellation on scope exit — but
+    KeyboardInterrupt and SystemExit are left to unwind as they always did.
+    """
+    try:
+        return await FileRecorder.status(scan_dir)
+    except (Exception, anyio.get_cancelled_exc_class()) as ex:
+        return ex
 
 
 def _clear_prior_parquet_cache(scan_location: str) -> None:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -42,6 +42,7 @@ from .._recorder.buffer import (
 from .._scanner.result import Error, ResultReport
 from .._scanspec import ScanSpec, ScanTranscripts
 from .._transcript.types import TranscriptInfo
+from .._util._async import as_value
 from .._util.duckdb import create_parquet_view, restrict_external_access
 from .recorder import (
     ScanRecorder,
@@ -731,7 +732,10 @@ class FileRecorder(ScanRecorder):
         # Fetch in parallel; skip scans that no longer exist and propagate
         # any other error.
         results = await tg_collect(
-            [functools.partial(_status_or_error, d) for d in scan_dirs]
+            [
+                functools.partial(as_value, functools.partial(FileRecorder.status, d))
+                for d in scan_dirs
+            ]
         )
         scans: list[Status] = []
         for r in results:
@@ -756,20 +760,6 @@ class FileRecorder(ScanRecorder):
 # cleared when a run starts (`init`/`resume`/`attach`) and when a sync
 # completes the scan.
 _prior_parquet_cache: dict[str, dict[str, str | None]] = {}
-
-
-async def _status_or_error(scan_dir: str) -> Status | BaseException:
-    """Read one scan's status, returning any failure as a value.
-
-    Concurrent reads run in a task group, which cancels the remaining reads as
-    soon as one raises. Cancellation is captured too — the caller re-raises it,
-    and anyio re-delivers a genuine cancellation on scope exit — but
-    KeyboardInterrupt and SystemExit are left to unwind as they always did.
-    """
-    try:
-        return await FileRecorder.status(scan_dir)
-    except (Exception, anyio.get_cancelled_exc_class()) as ex:
-        return ex
 
 
 def _clear_prior_parquet_cache(scan_location: str) -> None:

--- a/src/inspect_scout/_scanjobs/refresh.py
+++ b/src/inspect_scout/_scanjobs/refresh.py
@@ -13,7 +13,6 @@ from functools import partial
 from logging import getLogger
 from typing import Protocol
 
-import anyio
 from inspect_ai._util._async import tg_collect
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import FileInfo
@@ -21,7 +20,8 @@ from inspect_ai.util._anyio import inner_exception
 from upath import UPath
 
 from .._recorder.active_scans_store import active_scans_store
-from .._recorder.file import _is_not_found, _status_or_error
+from .._recorder.file import FileRecorder, _is_not_found
+from .._util._async import as_value
 from .convert import scan_row_from_status
 from .store import ScanIndexStore
 
@@ -137,22 +137,6 @@ async def _listing_from_scan_dir(
     return ScanListing(scan_id, normalized_scan_dir, token)
 
 
-async def _listing_or_error(
-    fs: ScanListingFilesystem,
-    scan_dir: str,
-    semaphore: asyncio.Semaphore,
-) -> ScanListing | None | BaseException:
-    """Read one scan's listing, returning any failure as a value.
-
-    A task group drops a child CancelledError without reporting it, which would
-    silently shorten the listing rather than fail it.
-    """
-    try:
-        return await _listing_from_scan_dir(fs, scan_dir, semaphore)
-    except (Exception, anyio.get_cancelled_exc_class()) as ex:
-        return ex
-
-
 async def async_listing_to_scans(
     fs: ScanListingFilesystem, location: str
 ) -> dict[str, ScanListing]:
@@ -168,7 +152,10 @@ async def async_listing_to_scans(
 
     semaphore = asyncio.Semaphore(_METADATA_CONCURRENCY)
     listings = await tg_collect(
-        [partial(_listing_or_error, fs, scan_dir, semaphore) for scan_dir in scan_dirs]
+        [
+            partial(as_value, partial(_listing_from_scan_dir, fs, scan_dir, semaphore))
+            for scan_dir in scan_dirs
+        ]
     )
 
     result: dict[str, ScanListing] = {}
@@ -237,7 +224,10 @@ async def refresh_index(store: ScanIndexStore, location: str) -> None:
 
         # Read Status for the delta in parallel; missing scans are skipped.
         statuses = await tg_collect(
-            [partial(_status_or_error, listing.dir_path) for listing in delta.to_read]
+            [
+                partial(as_value, partial(FileRecorder.status, listing.dir_path))
+                for listing in delta.to_read
+            ]
         )
 
     rows = []

--- a/src/inspect_scout/_scanjobs/refresh.py
+++ b/src/inspect_scout/_scanjobs/refresh.py
@@ -9,16 +9,19 @@ import asyncio
 import sys
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from functools import partial
 from logging import getLogger
 from typing import Protocol
 
+import anyio
+from inspect_ai._util._async import tg_collect
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.file import FileInfo
 from inspect_ai.util._anyio import inner_exception
 from upath import UPath
 
 from .._recorder.active_scans_store import active_scans_store
-from .._recorder.file import FileRecorder, _is_not_found
+from .._recorder.file import _is_not_found, _status_or_error
 from .convert import scan_row_from_status
 from .store import ScanIndexStore
 
@@ -134,6 +137,22 @@ async def _listing_from_scan_dir(
     return ScanListing(scan_id, normalized_scan_dir, token)
 
 
+async def _listing_or_error(
+    fs: ScanListingFilesystem,
+    scan_dir: str,
+    semaphore: asyncio.Semaphore,
+) -> ScanListing | None | BaseException:
+    """Read one scan's listing, returning any failure as a value.
+
+    A task group drops a child CancelledError without reporting it, which would
+    silently shorten the listing rather than fail it.
+    """
+    try:
+        return await _listing_from_scan_dir(fs, scan_dir, semaphore)
+    except (Exception, anyio.get_cancelled_exc_class()) as ex:
+        return ex
+
+
 async def async_listing_to_scans(
     fs: ScanListingFilesystem, location: str
 ) -> dict[str, ScanListing]:
@@ -148,12 +167,14 @@ async def async_listing_to_scans(
         raise
 
     semaphore = asyncio.Semaphore(_METADATA_CONCURRENCY)
-    listings = await asyncio.gather(
-        *(_listing_from_scan_dir(fs, scan_dir, semaphore) for scan_dir in scan_dirs)
+    listings = await tg_collect(
+        [partial(_listing_or_error, fs, scan_dir, semaphore) for scan_dir in scan_dirs]
     )
 
     result: dict[str, ScanListing] = {}
     for listing in listings:
+        if isinstance(listing, BaseException):
+            raise listing
         if listing is not None:
             result[listing.scan_id] = listing
     return result
@@ -215,9 +236,8 @@ async def refresh_index(store: ScanIndexStore, location: str) -> None:
         delta = compute_delta(listed, store.stored_tokens(), active_ids)
 
         # Read Status for the delta in parallel; missing scans are skipped.
-        statuses = await asyncio.gather(
-            *(FileRecorder.status(listing.dir_path) for listing in delta.to_read),
-            return_exceptions=True,
+        statuses = await tg_collect(
+            [partial(_status_or_error, listing.dir_path) for listing in delta.to_read]
         )
 
     rows = []

--- a/src/inspect_scout/_util/_async.py
+++ b/src/inspect_scout/_util/_async.py
@@ -1,0 +1,26 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import anyio
+
+T = TypeVar("T")
+
+
+async def as_value(fn: Callable[[], Awaitable[T]]) -> T | BaseException:
+    """Run an async function, returning its failure as a value instead of raising.
+
+    Concurrent helpers such as `tg_collect` run their tasks in a task group,
+    which cancels the remaining tasks as soon as one raises — and drops a child
+    cancellation without reporting it at all, so the collected results come back
+    short with no error. Capturing each failure keeps every task accounted for
+    and lets the caller decide which ones to skip and which to re-raise.
+
+    Cancellation is captured too. A genuine cancellation still propagates: the
+    caller re-raises the captured value, and anyio re-delivers the cancellation
+    on scope exit either way. KeyboardInterrupt and SystemExit are left alone so
+    they unwind immediately, as they would without this wrapper.
+    """
+    try:
+        return await fn()
+    except (Exception, anyio.get_cancelled_exc_class()) as ex:
+        return ex

--- a/tests/recorder/test_list.py
+++ b/tests/recorder/test_list.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from inspect_scout._recorder.file import FileRecorder
+from inspect_scout._recorder.recorder import Status
 from inspect_scout._scanspec import ScannerSpec, ScanSpec
 
 
@@ -59,3 +60,70 @@ async def test_list_plain_path_locations_unchanged(
     assert [s.location for s in statuses] == [
         (scans_dir / f"scan_id={spec.scan_id}").as_posix()
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_skips_scan_that_vanished_after_listing(
+    tmp_path: Path, scout_buffer_dir: Path
+) -> None:
+    """A scan that disappears between listing and read is skipped, not fatal.
+
+    Listing and then reading each scan is inherently racy on a remote store,
+    so a scan can go away in between. That must cost one entry rather than the
+    whole listing.
+    """
+    scans_dir = tmp_path / "scans"
+    kept_spec = _make_spec(["s"])
+    await FileRecorder().init(kept_spec, scans_dir.as_posix())
+    vanished_spec = _make_spec(["s"])
+    await FileRecorder().init(vanished_spec, scans_dir.as_posix())
+    (scans_dir / f"scan_id={vanished_spec.scan_id}" / "_scan.json").unlink()
+
+    statuses = await FileRecorder.list(scans_dir.as_posix())
+
+    assert {s.spec.scan_id for s in statuses} == {kept_spec.scan_id}
+
+
+@pytest.mark.asyncio
+async def test_list_returns_every_readable_scan_when_one_is_missing(
+    tmp_path: Path, scout_buffer_dir: Path
+) -> None:
+    """One missing scan must not cancel the reads of its siblings.
+
+    Concurrent reads share a task group, so a failure that isn't contained
+    would cancel the scans queued alongside it. Three scans with the failure
+    in the middle also pins that results stay aligned with their scans.
+    """
+    scans_dir = tmp_path / "scans"
+    specs = [_make_spec(["s"]) for _ in range(3)]
+    for spec in specs:
+        await FileRecorder().init(spec, scans_dir.as_posix())
+    (scans_dir / f"scan_id={specs[1].scan_id}" / "_scan.json").unlink()
+
+    statuses = await FileRecorder.list(scans_dir.as_posix())
+
+    assert {s.spec.scan_id for s in statuses} == {specs[0].scan_id, specs[2].scan_id}
+
+
+@pytest.mark.asyncio
+async def test_list_propagates_error_other_than_missing_scan(
+    tmp_path: Path, scout_buffer_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A read error that isn't a missing scan surfaces, naming that scan."""
+    scans_dir = tmp_path / "scans"
+    kept_spec = _make_spec(["s"])
+    await FileRecorder().init(kept_spec, scans_dir.as_posix())
+    denied_spec = _make_spec(["s"])
+    await FileRecorder().init(denied_spec, scans_dir.as_posix())
+
+    real_status = FileRecorder.status
+
+    async def status(scan_location: str) -> Status:
+        if f"scan_id={denied_spec.scan_id}" in scan_location:
+            raise PermissionError(scan_location)
+        return await real_status(scan_location)
+
+    monkeypatch.setattr(FileRecorder, "status", staticmethod(status))
+
+    with pytest.raises(PermissionError, match=denied_spec.scan_id):
+        await FileRecorder.list(scans_dir.as_posix())

--- a/tests/scanjobs/test_refresh.py
+++ b/tests/scanjobs/test_refresh.py
@@ -249,3 +249,28 @@ async def test_refresh_index_propagates_cancelled_status_error(
             await refresh_module.refresh_index(store, "/s")
     finally:
         store.close()
+
+
+class _CancellingMetadataFilesystem(_FakeAsyncFilesystem):
+    """Raises CancelledError from metadata reads.
+
+    CancelledError is not an Exception, so it escapes the internal handler in
+    _listing_from_scan_dir and reaches the concurrent-collection call.
+    """
+
+    async def info(self, filename: str) -> FileInfo:
+        raise asyncio.CancelledError("stop listing")
+
+
+@pytest.mark.asyncio
+async def test_async_listing_to_scans_propagates_cancelled_metadata_error() -> None:
+    """A cancelled metadata read must surface, not silently drop the scan.
+
+    A dropped scan is not merely missing from the result: refresh_index feeds
+    the listing into compute_delta, which treats an absent scan_id as deleted
+    and removes its row from the index.
+    """
+    fs = _CancellingMetadataFilesystem(dirs=["/s/scan_id=a/"], infos={})
+
+    with pytest.raises(asyncio.CancelledError):
+        await async_listing_to_scans(fs, "/s")


### PR DESCRIPTION
Closes #584.

Converts the three remaining `asyncio.gather` call sites to `tg_collect`, per the async guardrails added in #585.

## The wrinkle

`tg_collect` has no `return_exceptions` equivalent — it always raises — and two of the three sites depend on per-scan failure isolation. A direct swap would change behaviour in ways CI would not catch:

- **`refresh_index`**: a scan directory with no `_scan.json` yet always raises `FileNotFoundError`, so a partially-created scan would abort the whole refresh instead of being skipped, and `store.upsert`/`store.delete` would never run.
- **`FileRecorder.list`**: a scan deleted between listing and read is routine on a remote store; `scout scan list` would raise instead of returning the other scans.
- **Worse, and not obvious**: an anyio task group drops a child `CancelledError` without recording it, then cancels its own scope — so `tg_collect` returns a **short list and raises nothing**. In `async_listing_to_scans` a short listing is not merely incomplete: `compute_delta` treats an absent `scan_id` as deleted, so `refresh_index` would delete indexed scans. Verified directly:

```
tg_collect([ok, raises_CancelledError, ok])  ->  returns ['ok', 'ok'], raises nothing
```

So each read captures its own failure and returns it as a value. Results stay aligned with the scans they came from, and the existing skip/propagate handling is untouched. The capture covers `Exception` and cancellation but deliberately not `KeyboardInterrupt`/`SystemExit`, which are left to unwind as before.

**If you would rather these sites were genuinely fail-fast**, that is a smaller diff than this one and I am happy to make it — the current behaviour is documented in comments at both sites, so I preserved it rather than assume.

## Behaviour differences I did not eliminate

Stating these rather than claiming "no change":

- `async_listing_to_scans` no longer short-circuits. It previously raised as soon as one listing failed, leaving siblings running detached; it now waits for all of them, so a failure surfaces after the remaining reads finish and the exception raised is the first in listing order rather than the first chronologically. Only `BaseException` can escape that path (`_listing_from_scan_dir` handles everything else internally), so this is rare — but it is a real difference, and it removes orphan tasks that previously outlived the `AsyncFilesystem` they were using.
- Structured concurrency costs more scheduling overhead than `gather` on the local-filesystem path, where `AsyncFilesystem.info` has no await point. I measured roughly 4x on a synthetic 2000-item fan-out with an empty body; real listings are dominated by I/O, so the practical effect is much smaller, but it is not zero and `async_listing_to_scans` runs on every `SqliteScanJobsView.connect()`.

I also left `asyncio.Semaphore` alone. Switching it to `anyio.Semaphore` would match `_transcript/messages.py`, but it is out of scope here, measurably slower on this path, and there is no trio backend in the repo for it to protect against.

## Tests

Three new tests, all **characterisation** tests — they pass before and after this change. Their value is that they fail against a direct swap, which I verified by making one:

| Test | Catches |
| --- | --- |
| `test_async_listing_to_scans_propagates_cancelled_metadata_error` | the silent-truncation path above |
| `test_list_skips_scan_that_vanished_after_listing` | a missing scan aborting the listing |
| `test_list_returns_every_readable_scan_when_one_is_missing` | one failure cancelling its siblings, and result/scan alignment |

`FileRecorder.list` previously had no error-path coverage at all. The first two of the three existing `refresh_index` tests already pinned the equivalent behaviour there and stay green.

## Verification

`ruff check`, `ruff format --check` and `mypy` clean on the changed files; `pytest tests/scanjobs tests/recorder` gives 100 passed. Three failures in that run (`test_duckdb_security` ×2, `test_list_preserves_file_uri_locations`) reproduce identically on a clean checkout of `main` — they are pre-existing and Windows-specific.

Full disclosure on the environment: `pip install -e ".[dev]"` fails on my machine because `litellm` needs a Rust toolchain, so I installed runtime dependencies plus pytest/ruff/mypy and the two stub packages rather than the complete dev extras. I ran the two affected test directories, not the entire suite.

### Agent review
- Reviewer: Claude Opus 5, two independent passes, each in a fresh context with no knowledge of the other — one on semantics preservation, one on repo conventions and test quality
- Findings: 12 — 8 fixed, 4 disclosed above rather than fixed
  - Fixed: hand-wrapped code that `ruff format` would rewrite (would have failed `py-ruff`); three `# noqa: B036` suppressing a rule ruff does not implement; `_status_or_error` duplicated verbatim in both modules, now defined once and imported; a call-site comment restating what the helper does; over-long docstrings that documented their callers; catching `BaseException` where it changed `KeyboardInterrupt` handling; an `asyncio.Semaphore` change that was out of scope and slower; a third test that passed under a direct swap and so pinned nothing, replaced with the sibling-isolation and alignment test above
  - Disclosed, not fixed: the loss of short-circuiting, the scheduling cost, exception-selection order at that site, and that an empty input now yields one extra checkpoint
