### PR TITLE
feat: validation predicates can return per-case float scores

### DIFF
--- a/docs/_results-data-frame.md
+++ b/docs/_results-data-frame.md
@@ -79,7 +79,8 @@ Note that the heavy JSON columns (`input` and `scan_events`) are excluded by def
 | `event_references` | list\[Reference\]<br/><small>JSON</small> | Events referenced by scanner. |
 | `validation_target` | JsonValue<br/><small>JSON</small> | Target value from validation set. |
 | `validation_predicate` | str | Predicate used for comparison (e.g. "eq", "gt", etc.). |
-| `validation_result` | JsonValue<br/><small>JSON</small> | Result returned from comparing `validation_target` to `value` using `validation_predicate`. |
+| `validation_result` | JsonValue<br/><small>JSON</small> | Result returned from comparing `validation_target` to `value` using `validation_predicate` (null when the predicate returned a score). |
+| `validation_score` | number | Score returned by a score-returning predicate (null for pass/fail predicates). |
 | `validation_split` | str | Validation split the case was drawn from (if any). |
 | `scan_error` | str | Error which occurred during scan. |
 | `scan_error_traceback` | str | Traceback for error (if any) |

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -401,12 +401,16 @@ def scanner_table(
         ) from e
 
     # Correct schema to handle type inconsistencies across files:
-    # 1. Promote null-type columns to string (unknown type)
-    # 2. Force 'value' and 'transcript_score' columns to string since they can have
+    # 1. Pin 'validation_score' to float64 (it is all-null, and therefore
+    #    null-typed, in fragments validated with pass/fail predicates)
+    # 2. Promote null-type columns to string (unknown type)
+    # 3. Force 'value' and 'transcript_score' columns to string since they can have
     #    mixed types across different result reports / transcripts
-    corrected_fields = []
+    corrected_fields: list[pa.Field[Any]] = []
     for field in schema:
-        if pa.types.is_null(field.type):
+        if field.name == "validation_score":
+            corrected_fields.append(pa.field(field.name, pa.float64(), nullable=True))
+        elif pa.types.is_null(field.type):
             # Promote null type to string
             corrected_fields.append(pa.field(field.name, pa.string(), nullable=True))
         elif field.name in {"value", "transcript_score"}:

--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -993,6 +993,7 @@ def _create_expanded_view_sql(
     validation_fields = {
         "validation_target",
         "validation_result",
+        "validation_score",
         "validation_predicate",
         "validation_split",
     }

--- a/src/inspect_scout/_recorder/summary.py
+++ b/src/inspect_scout/_recorder/summary.py
@@ -113,6 +113,12 @@ class Summary(BaseModel):
                     )
                 else:
                     agg_results += 1
+            # Record an entry for every validated result so completeness
+            # checks over `entries` see all matched cases. Score-returning
+            # predicates yield entries with valid=None and a score; they carry
+            # no pass/fail outcome and are excluded from the confusion-matrix
+            # metrics (their per-case scores also live in the
+            # `validation_score` results column).
             if result.validation is not None:
                 # Normalize input_ids: single string if length 1, else list
                 entry_id: str | list[str] = (
@@ -129,6 +135,7 @@ class Summary(BaseModel):
                         id=entry_id,
                         target=result.validation.target,
                         valid=result.validation.valid,
+                        score=result.validation.score,
                     )
                 )
             agg_errors += 1 if result.error is not None else 0

--- a/src/inspect_scout/_recorder/validation.py
+++ b/src/inspect_scout/_recorder/validation.py
@@ -3,13 +3,27 @@
 from typing import Any
 
 from pydantic import BaseModel, Field, JsonValue, computed_field, model_validator
+from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Self
 
 from inspect_scout._validation.validate import is_positive_value
 
 
 class ValidationEntry(BaseModel):
-    """A single validation result with its target."""
+    """A single validation result with its target.
+
+    Entries mirror the `ResultValidation` shape: pass/fail predicates set
+    `valid`; score-returning predicates set `score` and leave `valid` as None.
+    Scored entries are recorded so that every validated case appears in
+    `entries` (e.g. for coverage/completeness checks), but they are excluded
+    from the pass/fail confusion-matrix metrics.
+
+    The score-bearing shape is kept out of the generated OpenAPI schema
+    (`SkipJsonSchema`): the view consumes only entry counts and aggregate
+    metrics, and exposing the new fields would force the coordinated ts-mono
+    types regeneration. Remove the `SkipJsonSchema` wrappers when the UI
+    grows a use for per-entry scores.
+    """
 
     id: str | list[str]
     """ID(s) from the validation case (e.g., transcript_id)."""
@@ -17,8 +31,11 @@ class ValidationEntry(BaseModel):
     target: JsonValue
     """Expected target value."""
 
-    valid: bool | dict[str, bool]
-    """Whether validation passed."""
+    valid: bool | dict[str, bool] | SkipJsonSchema[None]
+    """Whether validation passed (None when the predicate returned a score)."""
+
+    score: SkipJsonSchema[float | None] = Field(default=None)
+    """Score returned by a score-returning predicate (None for pass/fail predicates)."""
 
     @model_validator(mode="before")
     @classmethod
@@ -141,14 +158,16 @@ def compute_validation_metrics(
 
     Returns (total_metrics, per_key_metrics) tuple.
     per_key_metrics is None for bool-based entries, dict for dict-based entries.
-    Returns None if no entries have non-None targets.
+    Returns None if no entries have both a non-None target and a pass/fail
+    outcome (scored entries have `valid=None` and carry no pass/fail signal,
+    so they are excluded from the confusion matrix).
 
     Note: If entries contain a mix of bool and dict `valid` values, only dict
     entries are processed (bool entries are silently skipped). This handles
     edge cases in incremental data collection but should be rare in practice.
     """
-    # Filter to entries with non-None targets
-    with_targets = [e for e in entries if e.target is not None]
+    # Filter to pass/fail entries with non-None targets
+    with_targets = [e for e in entries if e.target is not None and e.valid is not None]
     if not with_targets:
         return None
 

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -1274,6 +1274,8 @@ async def _validate_scan(
                     labels=v_case.labels,
                     predicate_override=v_case.predicate,
                 )
+                # label validation always produces one bool per label
+                assert isinstance(valid, dict)
                 return ResultValidation(
                     target=cast(JsonValue, v_case.labels),
                     valid=valid,
@@ -1288,11 +1290,21 @@ async def _validate_scan(
                     target=v_case.target,
                     predicate_override=v_case.predicate,
                 )
-                return ResultValidation(
-                    target=v_case.target,
-                    valid=valid,
-                    predicate=predicate_str,
-                    split=v_case.split,
-                )
+                # a float (non-bool) outcome is a score rather than pass/fail
+                if isinstance(valid, (bool, dict)):
+                    return ResultValidation(
+                        target=v_case.target,
+                        valid=valid,
+                        predicate=predicate_str,
+                        split=v_case.split,
+                    )
+                else:
+                    return ResultValidation(
+                        target=v_case.target,
+                        valid=None,
+                        score=valid,
+                        predicate=predicate_str,
+                        split=v_case.split,
+                    )
     else:
         return None

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -106,7 +106,10 @@ class Error(BaseModel):
 
 class ResultValidation(BaseModel):
     target: JsonValue
-    valid: bool | dict[str, bool]
+    valid: bool | dict[str, bool] | None = Field(default=None)
+    """Pass/fail validation result (None when the predicate returned a score)."""
+    score: float | None = Field(default=None)
+    """Score returned by a score-returning predicate (None for pass/fail predicates)."""
     predicate: str | None = Field(default=None)
     """The predicate used for validation (e.g., 'eq', 'gte', 'contains')."""
     split: str | None = Field(default=None)
@@ -206,7 +209,12 @@ class ResultReport(BaseModel):
         # report validation
         if self.validation is not None:
             columns["validation_target"] = to_json_str_compact(self.validation.target)
-            columns["validation_result"] = to_json_str_compact(self.validation.valid)
+            columns["validation_result"] = (
+                to_json_str_compact(self.validation.valid)
+                if self.validation.valid is not None
+                else None
+            )
+            columns["validation_score"] = self.validation.score
             columns["validation_predicate"] = self.validation.predicate
             columns["validation_split"] = self.validation.split
             if isinstance(self.validation.valid, dict):
@@ -216,6 +224,7 @@ class ResultReport(BaseModel):
         else:
             columns["validation_target"] = None
             columns["validation_result"] = None
+            columns["validation_score"] = None
             columns["validation_predicate"] = None
             columns["validation_split"] = None
 

--- a/src/inspect_scout/_validation/predicates.py
+++ b/src/inspect_scout/_validation/predicates.py
@@ -7,9 +7,15 @@ from inspect_scout._scanner.result import Result
 
 # Predicate function signatures
 PredicateFn: TypeAlias = Callable[
-    [Result, JsonValue], Awaitable[bool | dict[str, bool]]
+    [Result, JsonValue], Awaitable[bool | float | dict[str, bool]]
 ]
-"""Function that implements a validation predicate."""
+"""Function that implements a validation predicate.
+
+For single-value targets a predicate may return either a `bool` (pass/fail,
+recorded as `validation_result`) or a `float` score (e.g. an error magnitude
+or graded agreement, recorded as `validation_score`). For dict targets a
+predicate must return a `dict[str, bool]`.
+"""
 
 # String name of a built-in validation predicate
 PredicateType: TypeAlias = Literal[

--- a/src/inspect_scout/_validation/validate.py
+++ b/src/inspect_scout/_validation/validate.py
@@ -1,3 +1,5 @@
+import math
+
 from pydantic import JsonValue
 
 from inspect_scout._scanner.result import Result
@@ -12,7 +14,7 @@ async def validate(
     target: JsonValue | None = None,
     labels: dict[str, bool] | None = None,
     predicate_override: ValidationPredicate | None = None,
-) -> bool | dict[str, bool]:
+) -> bool | float | dict[str, bool]:
     """Validate a result against a target or labels using the validation set's predicate.
 
     Args:
@@ -23,7 +25,8 @@ async def validate(
         predicate_override: Optional predicate to override the validation set's predicate
 
     Returns:
-        bool if target is a single value
+        bool if target is a single value and the predicate returned pass/fail
+        float if target is a single value and the predicate returned a score
         dict[str, bool] if target is a dict OR labels is provided (one bool per key/label)
 
     Raises:
@@ -53,14 +56,23 @@ async def _validate_single(
     result: Result,
     target: list[JsonValue] | str | bool | int | float | None,
     predicate: ValidationPredicate | None,
-) -> bool:
+) -> bool | float:
     predicate_fn = resolve_predicate(predicate)
     valid = await predicate_fn(result, target)
-    if not isinstance(valid, bool):
-        raise RuntimeError(
-            f"Validation function must return bool for target of type '{type(target)}' (returned '{type(valid)}')"
-        )
-    return valid
+    if isinstance(valid, bool):
+        return valid
+    if isinstance(valid, (int, float)):
+        score = float(valid)
+        # reject NaN eagerly -- once recorded it is indistinguishable from
+        # NULL in the validation_score column
+        if math.isnan(score):
+            raise RuntimeError(
+                f"Validation function returned NaN for target of type '{type(target)}'"
+            )
+        return score
+    raise RuntimeError(
+        f"Validation function must return bool or float for target of type '{type(target)}' (returned '{type(valid)}')"
+    )
 
 
 async def _validate_dict(

--- a/tests/recorder/test_summary.py
+++ b/tests/recorder/test_summary.py
@@ -8,7 +8,12 @@ from inspect_scout._recorder.validation import (
     ValidationResults,
     compute_validation_metrics,
 )
-from inspect_scout._scanner.result import Result, ResultReport, as_resultset
+from inspect_scout._scanner.result import (
+    Result,
+    ResultReport,
+    ResultValidation,
+    as_resultset,
+)
 from inspect_scout._transcript.types import Transcript
 from inspect_scout._validation.validate import is_positive_value
 
@@ -247,6 +252,27 @@ class TestComputeValidationMetrics:
         assert per_key["b"].tp == 0
         assert per_key["b"].fn == 0
 
+    def test_scored_entries_excluded(self) -> None:
+        """Scored entries (valid=None) are excluded even when they have targets."""
+        validations = [
+            ValidationEntry(id="t1", target=5, valid=None, score=2.0),
+            ValidationEntry(id="t2", target=True, valid=True),  # TP
+        ]
+        result = compute_validation_metrics(validations)
+        assert result is not None
+        metrics, per_key = result
+        assert per_key is None
+        assert metrics.total == 1
+        assert metrics.tp == 1
+
+    def test_all_scored_entries_yield_no_metrics(self) -> None:
+        """All-scored entries carry no pass/fail signal, so metrics are None."""
+        validations = [
+            ValidationEntry(id="t1", target=5, valid=None, score=2.0),
+            ValidationEntry(id="t2", target=7, valid=None, score=0.5),
+        ]
+        assert compute_validation_metrics(validations) is None
+
     def test_mixed_with_legacy(self) -> None:
         """Mixed entries with some legacy (target=None) are handled correctly."""
         validations = [
@@ -311,6 +337,52 @@ class TestSummaryResultsetCounting:
         summary._report(None, "scanner", [r3], None)  # type: ignore[arg-type]
         assert summary.scanners["scanner"].results == 4
         assert summary.scanners["scanner"].scans == 3
+
+
+class TestSummaryScoredValidation:
+    """Tests that scored validations are recorded but excluded from metrics."""
+
+    def _make_report(self, validation: ResultValidation) -> ResultReport:
+        """Helper: create a ResultReport with the given validation."""
+        return ResultReport(
+            input_type="transcript",
+            input_ids=["t1"],
+            input=Transcript(transcript_id="t1"),
+            result=Result(value=1),
+            validation=validation,
+            error=None,
+            events=[],
+            model_usage={},
+        )
+
+    def test_scored_validation_recorded_but_excluded_from_metrics(self) -> None:
+        summary = Summary(scanners=["scanner"])
+        scored = self._make_report(ResultValidation(target=5, score=2.0))
+        passed = self._make_report(ResultValidation(target=True, valid=True))
+        summary._report(None, "scanner", [scored, passed], None)  # type: ignore[arg-type]
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        # Both validated results are recorded as entries
+        assert len(validation.entries) == 2
+        assert validation.entries[0].valid is None
+        assert validation.entries[0].score == 2.0
+        assert validation.entries[1].valid is True
+        assert validation.entries[1].score is None
+        # Metrics count only the pass/fail entry
+        assert validation.metrics is not None
+        assert validation.metrics.total == 1
+        assert validation.metrics.tp == 1
+
+    def test_only_scored_validations_yield_entries_without_metrics(self) -> None:
+        summary = Summary(scanners=["scanner"])
+        scored = self._make_report(ResultValidation(target=5, score=2.0))
+        summary._report(None, "scanner", [scored], None)  # type: ignore[arg-type]
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 1
+        assert validation.entries[0].valid is None
+        assert validation.entries[0].score == 2.0
+        assert validation.metrics is None
 
 
 class TestValidationResults:

--- a/tests/test_validation_e2e.py
+++ b/tests/test_validation_e2e.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Sequence
 
+import pandas as pd
 import pytest
 from inspect_ai.event import Event
 from inspect_ai.model import ChatMessage
@@ -503,6 +504,132 @@ async def test_validation_with_custom_predicate_e2e() -> None:
         assert all(isinstance(v, bool) for v in deserialized_results), (
             "All validation results should be boolean"
         )
+
+
+@pytest.mark.asyncio
+async def test_validation_score_predicate_e2e() -> None:
+    """Test validation with a score-returning predicate (recorded in validation_score)."""
+    # Get test transcript IDs
+    transcript_ids = await get_n_transcript_ids(3)
+
+    # Define score predicate function (absolute error rather than pass/fail)
+    async def absolute_error(result: Result, target: Any) -> float:
+        assert isinstance(result.value, (int, float))
+        assert isinstance(target, (int, float))
+        return abs(result.value - target)
+
+    # Create validation set with score predicate
+    targets = [50, 50, 50]
+    validation = ValidationSet(
+        cases=[
+            ValidationCase(id=tid, target=target)
+            for tid, target in zip(transcript_ids, targets, strict=True)
+        ],
+        predicate=absolute_error,
+    )
+
+    # Run scan with validation
+    with tempfile.TemporaryDirectory() as tmpdir:
+        scan_result = scan(
+            scanners=[int_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            validation=validation,
+            scans=tmpdir,
+            limit=3,  # Only scan 3 transcripts for efficiency
+        )
+
+        # Get results
+        results = scan_results_df(scan_result.location, scanner="int_scanner")
+        df = results.scanners["int_scanner"]
+
+        # Verify validation columns exist
+        assert "validation_target" in df.columns
+        assert "validation_score" in df.columns
+        assert "validation_result" in df.columns
+
+        # Scored rows have a float score and no pass/fail result
+        df_validated = df[df["validation_target"].notna()]
+        assert len(df_validated) == 3
+        assert all(df_validated["validation_score"].notna())
+        assert all(df_validated["validation_result"].isna())
+
+        # Score equals the absolute error between scanner value and target
+        for _, row in df_validated.iterrows():
+            expected_score = abs(float(row["value"]) - 50.0)
+            assert row["validation_score"] == expected_score
+
+        # Scored validations are recorded as entries (with the score and no
+        # pass/fail outcome) so all matched cases are visible in the summary,
+        # but they are excluded from the pass/fail confusion-matrix metrics
+        summary = scan_result.summary.scanners["int_scanner"]
+        assert summary.validation is not None
+        assert len(summary.validation.entries) == 3
+        assert all(e.valid is None for e in summary.validation.entries)
+        assert all(e.score is not None for e in summary.validation.entries)
+        assert summary.validation.metrics is None
+
+
+@pytest.mark.asyncio
+async def test_validation_mixed_score_and_bool_e2e() -> None:
+    """Test a validation set mixing score cases with per-case bool predicates."""
+    # Get test transcript IDs
+    transcript_ids = await get_n_transcript_ids(3)
+
+    # Global score predicate; one case overrides with a pass/fail predicate
+    async def absolute_error(result: Result, target: Any) -> float:
+        assert isinstance(result.value, (int, float))
+        assert isinstance(target, (int, float))
+        return abs(result.value - target)
+
+    # First case uses a bool predicate override ("gte" against 0 always passes
+    # for int_scanner values); the remaining cases use the score predicate
+    bool_case_id = transcript_ids[0]
+    validation = ValidationSet(
+        cases=[
+            ValidationCase(id=bool_case_id, target=0, predicate="gte"),
+            ValidationCase(id=transcript_ids[1], target=50),
+            ValidationCase(id=transcript_ids[2], target=50),
+        ],
+        predicate=absolute_error,
+    )
+
+    # Run scan with validation
+    with tempfile.TemporaryDirectory() as tmpdir:
+        scan_result = scan(
+            scanners=[int_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            validation=validation,
+            scans=tmpdir,
+            limit=3,  # Only scan 3 transcripts for efficiency
+        )
+
+        # Get results
+        results = scan_results_df(scan_result.location, scanner="int_scanner")
+        df = results.scanners["int_scanner"]
+
+        df_validated = df[df["validation_target"].notna()]
+        assert len(df_validated) == 3
+
+        for _, row in df_validated.iterrows():
+            if row["transcript_id"] == bool_case_id:
+                # Bool-validated row: pass/fail recorded, no score
+                assert json.loads(row["validation_result"]) is True
+                assert pd.isna(row["validation_score"])
+            else:
+                # Scored row: score recorded, no pass/fail result
+                assert pd.isna(row["validation_result"])
+                assert row["validation_score"] == abs(float(row["value"]) - 50.0)
+
+        # All validated cases are recorded as entries, but only the
+        # bool-validated case contributes to summary metrics
+        summary = scan_result.summary.scanners["int_scanner"]
+        assert summary.validation is not None
+        assert len(summary.validation.entries) == 3
+        scored_entries = [e for e in summary.validation.entries if e.valid is None]
+        assert len(scored_entries) == 2
+        assert all(e.score is not None for e in scored_entries)
+        assert summary.validation.metrics is not None
+        assert summary.validation.metrics.total == 1
 
 
 @pytest.mark.asyncio

--- a/tests/validation/test_predicates.py
+++ b/tests/validation/test_predicates.py
@@ -197,6 +197,75 @@ async def test_custom_callable_predicate() -> None:
     assert await validate(validation, Result(value=123), "456") is False
 
 
+# Test score-returning predicates
+
+
+@pytest.mark.asyncio
+async def test_score_predicate_returns_float() -> None:
+    """Test that a predicate may return a float score for single-value targets."""
+
+    async def absolute_error(result: Result, target: JsonValue) -> float:
+        assert isinstance(result.value, (int, float))
+        assert isinstance(target, (int, float))
+        return abs(result.value - target)
+
+    validation = ValidationSet(cases=[], predicate=absolute_error)
+    score = await validate(validation, Result(value=7), 5)
+    assert score == 2.0
+    assert isinstance(score, float)
+    assert not isinstance(score, bool)
+
+
+@pytest.mark.asyncio
+async def test_score_predicate_int_coerced_to_float() -> None:
+    """Test that an int score is coerced to float."""
+
+    async def int_score(result: Result, target: JsonValue) -> float:
+        return 3
+
+    validation = ValidationSet(cases=[], predicate=int_score)
+    score = await validate(validation, Result(value=1), 1)
+    assert score == 3.0
+    assert isinstance(score, float)
+    assert not isinstance(score, bool)
+
+
+@pytest.mark.asyncio
+async def test_score_predicate_bool_still_returned_as_bool() -> None:
+    """Test that a bool return is passed through as bool, not coerced to float."""
+
+    async def bool_predicate(result: Result, target: JsonValue) -> bool:
+        return result.value == target
+
+    validation = ValidationSet(cases=[], predicate=bool_predicate)
+    valid = await validate(validation, Result(value=5), 5)
+    assert valid is True
+
+
+@pytest.mark.asyncio
+async def test_score_predicate_nan_raises() -> None:
+    """Test that a NaN score is rejected (indistinguishable from NULL once recorded)."""
+
+    async def nan_score(result: Result, target: JsonValue) -> float:
+        return float("nan")
+
+    validation = ValidationSet(cases=[], predicate=nan_score)
+    with pytest.raises(RuntimeError, match="returned NaN"):
+        await validate(validation, Result(value=5), 5)
+
+
+@pytest.mark.asyncio
+async def test_predicate_invalid_return_type_raises() -> None:
+    """Test that non-bool/non-numeric predicate returns raise RuntimeError."""
+
+    async def bad_predicate(result: Result, target: JsonValue) -> bool:
+        return "high"  # type: ignore[return-value]
+
+    validation = ValidationSet(cases=[], predicate=bad_predicate)
+    with pytest.raises(RuntimeError, match="must return bool or float"):
+        await validate(validation, Result(value=5), 5)
+
+
 # Test dict target validation (string predicates applied to each key)
 
 


### PR DESCRIPTION
## What

Allows a validation predicate to return a `float` score (in addition to the existing `bool` / `dict[str, bool]`), and records it per-case in a new `validation_score` results column alongside `validation_target` / `validation_result`.

```python
async def absolute_error(result: Result, target: JsonValue) -> float:
    return abs(result.value - target)

scan(
    scanners=[judge_scanner()],
    transcripts=transcripts,
    validation=ValidationSet(cases=cases, predicate=absolute_error),
)
```

For scored cases, `validation_result` is NULL and `validation_score` holds the float; for pass/fail cases the columns are exactly as before (with `validation_score` NULL).

## Why

Graders that score ordinal or continuous values (e.g. a 1-10 LLM judge compared to a human label) currently can only record pass/fail per case — `_validate_single` raises `RuntimeError` on any non-bool predicate return. That throws away magnitude: users who want MSE/MAE/correlation against ground truth end up hand-rolling it downstream off the results dataframe, re-deriving per-case errors that the predicate already computed at scan time. Recording the predicate's score per-case makes the results dataframe the single source for both pass/fail and graded validation.

## Design notes

This is a design-forward draft — we'd like maintainer input on the semantics before polishing. The chosen design (deliberately the least-invasive option):

- **`PredicateFn` return type** widens to `bool | float | dict[str, bool]`. `_validate_single` passes bools through unchanged, coerces numeric returns to `float`, and still raises `RuntimeError` for anything else (message now says "bool or float"). The bool check runs first, so `True`/`False` are never treated as scores. `NaN` is rejected eagerly (once recorded it is indistinguishable from NULL); `±inf` is accepted — unlike NaN it stays distinguishable from NULL, and it survives the whole recording path (parquet `float64`, and the view streams result rows as Arrow IPC rather than JSON).
- **`ResultValidation`** gains `score: float | None`, and `valid` becomes `bool | dict[str, bool] | None` (None exactly when the predicate returned a score). Old serialized data always carries `valid`, so deserialization is unaffected.
- **Results columns**: `validation_score` is emitted beside `validation_result` (NULL for pass/fail cases; conversely `validation_result` is NULL for scored cases rather than a derived bool — there is no canonical threshold to derive one from). In the compaction schema, `validation_score` is pinned to `float64` because fragments whose cases were all pass/fail have the column all-null (null-typed), which would otherwise be promoted to string and stringify scores from other fragments.
- **Summary entries and metrics**: every validated case is recorded as a `ValidationEntry` in the scan summary — scored cases with `valid: None` plus a new `score` field — so completeness/coverage checks over the summary's entries see scored cases; the confusion-matrix metrics skip `valid: None` entries (a score has no tp/fp meaning), leaving metric values unchanged. The new entry fields are excluded from the openapi schema via `SkipJsonSchema` (the view reads only entry counts and aggregate metrics today), so `openapi.json` and the frontend's `generated.ts` still need no regeneration (verified: regenerating produces only docstring-text drift, which CI tolerates by design); exposing per-entry scores to the UI would ride along with open question 1's coordinated regeneration.
- **SQL resultset expansion** NULLs `validation_score` in expanded rows, same as the other validation fields.

Alternatives considered and rejected for this draft:

- Deriving `validation_result` from the score via a threshold — no canonical threshold; magnitude and pass/fail are different questions.
- A separate score-predicate type (or explicit opt-in flag) instead of overloading the return type — heavier API surface for the same information.

### Open questions

1. **Summary aggregation**: should `ValidationResults` grow score aggregates (mean score, MSE, MAE) so scored validation shows up in the summary/UI? That touches the openapi schema and frontend types, so it's deferred here — happy to add it in this PR or a follow-up if you'd like it.
2. **Dict scores**: should dict-target predicates be allowed to return `dict[str, float]` (per-key scores, `validation_score_{key}` columns)? Currently dict predicates must still return `dict[str, bool]`.
3. **Naming/semantics of `validation_result` for scored cases**: NULL (chosen) vs. some sentinel vs. derived bool.
4. **Int returns**: a predicate returning an `int` is coerced to a float score (natural for e.g. `abs(judge - label)` on int values), which means a predicate accidentally returning `0`/`1` intending pass/fail is now silently scored instead of raising as before. Requiring a strict `float` would keep that case loud at the cost of `float()` boilerplate — preference?
5. **Interrupted-scan upgrade edge**: buffer compaction discovers the parquet schema from the first fragment, so a scan started on an older version and resumed after upgrading could compact fragments whose unified schema lacks `validation_score`, dropping scores from newer fragments. This is a pre-existing property of schema discovery (dynamic `validation_result_{label}` columns have the same exposure) so it's left as-is here; unifying schemas across fragments would fix it generally if you want that.
6. **Docs**: `docs/validation.qmd` doesn't currently document custom callable predicates, so fully documenting score predicates would mean introducing callables there first; this PR only adds the `validation_score` row to the results dataframe column table. Happy to write the fuller docs section once the semantics settle.
7. **Interaction with #589 (strict coverage)**: reconciled in this PR. #589's strict-coverage check counts coverage from the summary's validation entries, so this PR now records a `ValidationEntry` for every validated case — scored cases with `valid: None` plus a `score` field, skipped by the confusion-matrix computation — making the two PRs order-independent. Verified empirically on a local merge of both branches: a strict validation set whose cases were all matched by a score-returning predicate falsely raised `ValidationCoverageError` before this reconciliation and completes cleanly with it (while a genuinely unmatched case still raises).

## Compatibility

Every existing bool / dict-of-bool path is byte-identical:

- Bool and dict predicates produce the same `validation_result` serialization, the same `validation_result_{key}` columns, and the same summary metrics as before; `validation_score` is a new always-NULL column for them.
- Built-in string predicates (`eq`, `gte`, `contains`, …) are unchanged.
- Label-based (resultset) validation is unchanged.
- `ResultValidation` deserialization of previously recorded data is unchanged (`valid` was always present).
- `openapi.json` is unchanged (regeneration verified: only docstring-text drift, which the schema-drift CI check tolerates by design), so no frontend type regeneration is needed.

## Testing

- New unit tests (`tests/validation/test_predicates.py`): float score returned through `validate()`, int coerced to float, bool passthrough untouched, NaN rejected, non-numeric return still raises `RuntimeError`.
- New e2e tests (`tests/test_validation_e2e.py`): score predicate recorded in `validation_score` with `validation_result` NULL (round-tripped through the parquet recorder); mixed validation set (per-case `gte` override + global score predicate) records each case in the right column and only pass/fail cases enter summary metrics.
- New summary unit tests (`tests/recorder/test_summary.py`): scored validations recorded as entries (`valid=None`, `score` set) and excluded from the confusion-matrix metrics (all-scored → no metrics; mixed → metrics count only pass/fail entries).
- `ruff check` / `ruff format --check`: clean. `mypy src examples tests`: clean (460 files).
- Full local pytest suite: 3238 passed, 107 skipped, 0 failed (default suite, no API keys).

### Agent review

- Reviewer: Claude (Fable 5) via a fresh-context general-purpose review agent (same model as author), 1 pass over the full diff plus a repo-wide sweep of every consumer of `validation_result` / `ResultValidation.valid` (including recorder compaction, resultset expansion, summary aggregation, CLI display, and `_view` server code); it also empirically verified the pyarrow schema-unification behavior the buffer fix relies on.
- Findings: 5 — 2 fixed, 3 dismissed/deferred:
  - Fixed: `float("nan")` scores were accepted but indistinguishable from NULL once recorded — now rejected with `RuntimeError` at validation time (test added).
  - Fixed: results dataframe docs didn't mention `validation_score` — column table updated.
  - Deferred: first-fragment schema discovery in buffer compaction could drop `validation_score` when resuming a pre-upgrade scan (open question 5 above; pre-existing pattern).
  - Dismissed: int `0`/`1` returns are now scored instead of raising (intended coercion, surfaced as open question 4 above).
  - Dismissed: `ResultValidation` doesn't enforce exactly-one-of `valid`/`score` — it is only constructed by `_validate_scan`, which maintains the invariant; happy to add a model validator if you'd prefer.
- Independent adversarial pass: Claude (Fable 5), fresh context, after the draft opened. Re-verified rather than trusted the claims above: local `ruff`/`mypy`/full pytest at branch HEAD (3236 passed), openapi regeneration (no diff), the first-fragment schema-discovery behavior in `scanner_table` (confirmed pre-existing, not worsened by the `float64` pin), the dict-target-plus-float-predicate path (defined: raises `RuntimeError`, unchanged), and `±inf` handling end-to-end (accepted, non-breaking; noted in design notes above). One new finding: the semantic interaction with #589, added as open question 7; no code changes were needed on this branch.
- Amendment (reconciliation with #589, same author agent): scored cases are now recorded as summary validation entries (`valid: None` + `score`, schema-invisible via `SkipJsonSchema`) and excluded from the confusion-matrix metrics; re-verified at the amended HEAD (ruff/mypy/full pytest, openapi regeneration structurally clean) and cross-verified on a local merge of both branches (the false `ValidationCoverageError` before, no raise after, genuinely unmatched cases still raise).

---

This PR was prepared by an AI coding agent (Claude Code) at the direction of a human contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


