### PR TITLE
feat: optionally fail a scan when validation cases match no scanned input

### DIFF
--- a/docs/reference/results.qmd
+++ b/docs/reference/results.qmd
@@ -22,6 +22,7 @@ reference: inspect_scout
 ### validation_set
 ### ValidationSet
 ### ValidationCase
+### ValidationCoverageError
 ### PredicateType
 ### PredicateFn
 ### ValidationPredicate

--- a/docs/validation.qmd
+++ b/docs/validation.qmd
@@ -103,6 +103,50 @@ For YAML/JSON files, use a labels key instead of target:
 
 ---->
 
+## Strict Coverage {#strict-coverage}
+
+Validation cases are matched to scanner inputs by id, and by default a case whose id matches nothing that was scanned is ignored. This keeps partial validation sets convenient (see [Validation Splits](#validation-splits)), but it also means a scan can report validation metrics for a fraction of your cases without saying so — for example when transcript ids have changed, when the scan reads a different transcripts database, or when a transcript filter excludes labelled transcripts.
+
+Set `strict` on the validation set to require that every case matches something that was scanned:
+
+``` python
+from inspect_scout import scan, transcripts_from, validation_set
+
+scan(
+    scanners=[ctf_environment()],
+    transcripts=transcripts_from("./logs"),
+    validation=validation_set("ctf-environment.csv", strict=True)
+)
+```
+
+If any case matched no scanned input, the scan writes its results as usual and then raises `ValidationCoverageError`, listing the unmatched case ids per scanner:
+
+``` default
+Strict validation: 2 validation case(s) matched no scanned input.
+  ctf_environment (2): Fg3KBpgFr6RSsEWmHBUqeo, VFkCH7gXWpJYUYonvfHxrG
+Scan results were written to scans/2025-11-14T09-33-12+00-00_ctf-environment_bMLcBnvVzX.
+Check that these case ids match the ids of the inputs that were scanned, or set 'strict' to False on the validation set to ignore unmatched cases.
+```
+
+The error carries the completed scan's `status`, so results are still available programmatically:
+
+``` python
+from inspect_scout import ValidationCoverageError, scan
+
+try:
+    status = scan(...)
+except ValidationCoverageError as ex:
+    status = ex.status  # results were written; coverage was incomplete
+```
+
+`scout scan` prints the message and exits non-zero.
+
+Coverage is checked when the scan completes rather than before it starts, since case ids can also address messages or events, which aren't known until the transcripts are read. Scans that are interrupted or that end with errors are reported as usual and aren't checked for coverage.
+
+Because coverage is measured against what was actually scanned, anything that narrows the scan can leave cases unmatched: a transcript filter, `limit`, or a `worklist`. Narrowing the scan *to* the validation set with `transcripts.for_validation()` doesn't guarantee coverage either — case ids that aren't in the transcripts simply match nothing — so `strict` is useful there too.
+
+`strict` is a property of the validation set rather than of a single scan, so it applies per scanner (each scanner in a scan can have its own setting) and is recorded in the scan spec — a scan resumed with `scan_resume()` checks coverage on the same terms as the original scan, counting the cases that were validated before the interruption.
+
 ## Predicates
 
 By default, validation compares scanner results to targets using equality (`eq`). You can specify different comparison predicates either per-case or as a default for all cases.

--- a/src/inspect_scout/__init__.py
+++ b/src/inspect_scout/__init__.py
@@ -25,6 +25,7 @@ from ._recorder.recorder import (
 )
 from ._recorder.summary import Summary
 from ._scan import (
+    ValidationCoverageError,
     scan,
     scan_complete,
     scan_resume,
@@ -203,6 +204,7 @@ __all__ = [
     "PredicateType",
     "PredicateFn",
     "validation_set",
+    "ValidationCoverageError",
     # version
     "__version__",
 ]

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -37,6 +37,7 @@ from inspect_ai.util import span
 from inspect_ai.util._anyio import inner_exception
 from pydantic import JsonValue, TypeAdapter
 from rich import box
+from rich.markup import escape
 from rich.table import Column, Table
 from typing_extensions import Unpack
 
@@ -135,7 +136,9 @@ def scan(
         worklist: Transcripts too process for each scanner (defaults to processing all transcripts). Either a list of `ScannerWork` or a YAML or JSON file with same.
         validation: Validation cases to evaluate for scanners. Can be a file path
             (CSV, JSON, JSONL, YAML), a ValidationSet, or a dict mapping scanner
-            names to file paths or ValidationSets.
+            names to file paths or ValidationSets. A validation set with `strict`
+            enabled raises `ValidationCoverageError` if any of its cases matched
+            no scanned input.
         model: Model to use for scanning by default (individual scanners can always
             call `get_model()` to us arbitrary models). If not specified use the model specified in the scout project config (if any).
         model_config: `GenerationConfig` for calls to the model.
@@ -226,7 +229,9 @@ async def scan_async(
         worklist: Transcript ids to process for each scanner (defaults to processing all transcripts). Either a list of `ScannerWork` or a YAML or JSON file contianing the same.
         validation: Validation cases to apply for scanners. Can be a file path
             (CSV, JSON, JSONL, YAML), a ValidationSet, or a dict mapping scanner
-            names to file paths or ValidationSets.
+            names to file paths or ValidationSets. A validation set with `strict`
+            enabled raises `ValidationCoverageError` if any of its cases matched
+            no scanned input.
         model: Model to use for scanning by default (individual scanners can always
             call `get_model()` to us arbitrary models). If not specified use the model specified in the scout project config (if any).
         model_config: `GenerationConfig` for calls to the model.
@@ -509,6 +514,16 @@ async def _scan_async(
         _scan_async_running = False
 
     assert result is not None, "scan async did not return a result."
+
+    # a scan that didn't run to completion hasn't had the chance to match all of
+    # its validation cases, so coverage is only checked for a complete scan (an
+    # interrupted or errored scan is already reported as such in the status)
+    if result.complete:
+        unmatched = _unmatched_validation_cases(scan.validation, result.summary)
+        if unmatched:
+            raise ValidationCoverageError(
+                _unmatched_validation_message(unmatched, result.location), result
+            )
 
     return result
 
@@ -1240,6 +1255,96 @@ def _resolve_validation(
             k: v if isinstance(v, ValidationSet) else vs_from_file(v)
             for k, v in validation.items()
         }
+
+
+class ValidationCoverageError(PrerequisiteError):
+    """Raised when a strict validation set has cases that matched no scanned input.
+
+    The scan itself ran to completion and its results were written, so the
+    status of the completed scan is carried on the error.
+
+    Attributes:
+        message: Description of the unmatched cases.
+        status: Status of the completed scan (spec, summary, location, errors).
+    """
+
+    def __init__(self, message: str, status: Status) -> None:
+        super().__init__(message)
+        self.status = status
+
+    def __str__(self) -> str:
+        # BaseException captures every constructor argument in `args`, so
+        # without this the default __str__ renders the (message, status) tuple
+        return str(self.message)
+
+
+MAX_REPORTED_UNMATCHED_CASES = 25
+"""Maximum number of unmatched case ids reported per scanner."""
+
+
+def _unmatched_validation_cases(
+    validation: dict[str, ValidationSet] | None, summary: recorder_summary.Summary
+) -> dict[str, list[str | list[str]]]:
+    """Ids of strict validation cases that matched no scanned input, by scanner.
+
+    Coverage is determined from the validation entries recorded for the scan
+    (rather than from the transcripts in the scan) because case ids can address
+    messages, events, or groups thereof, none of which are known before the
+    scanners run.
+    """
+    unmatched: dict[str, list[str | list[str]]] = {}
+    for scanner, validation_set in (validation or {}).items():
+        if not validation_set.strict:
+            continue
+
+        validated: set[str | tuple[str, ...]] = set()
+        scanner_summary = summary.scanners.get(scanner)
+        if scanner_summary is not None and scanner_summary.validation is not None:
+            validated = {
+                _case_id_key(entry.id) for entry in scanner_summary.validation.entries
+            }
+
+        missing = [
+            case.id
+            for case in validation_set.cases
+            if _case_id_key(case.id) not in validated
+        ]
+        if missing:
+            unmatched[scanner] = missing
+
+    return unmatched
+
+
+def _case_id_key(case_id: str | list[str]) -> str | tuple[str, ...]:
+    """Hashable form of a case id or of a recorded validation entry id."""
+    return tuple(case_id) if isinstance(case_id, list) else case_id
+
+
+def _unmatched_validation_message(
+    unmatched: dict[str, list[str | list[str]]], location: str
+) -> str:
+    total = sum(len(ids) for ids in unmatched.values())
+    lines = [f"Strict validation: {total} validation case(s) matched no scanned input."]
+    for scanner, ids in unmatched.items():
+        reported = ", ".join(
+            _case_id_str(case_id) for case_id in ids[:MAX_REPORTED_UNMATCHED_CASES]
+        )
+        if len(ids) > MAX_REPORTED_UNMATCHED_CASES:
+            reported += f", ... ({len(ids) - MAX_REPORTED_UNMATCHED_CASES} more)"
+        lines.append(f"  {scanner} ({len(ids)}): {reported}")
+    lines.append(f"Scan results were written to {pretty_path(location)}.")
+    lines.append(
+        "Check that these case ids match the ids of the inputs that were scanned, "
+        "or set 'strict' to False on the validation set to ignore unmatched cases."
+    )
+    # case ids are user data, and unescaped '[' would be eaten as markup by the
+    # rich console that prints this message
+    return escape("\n".join(lines))
+
+
+def _case_id_str(case_id: str | list[str]) -> str:
+    """Composite ids are rendered like the quoted, comma-separated CSV form."""
+    return f'"{",".join(case_id)}"' if isinstance(case_id, list) else case_id
 
 
 async def _validate_scan(

--- a/src/inspect_scout/_validation/types.py
+++ b/src/inspect_scout/_validation/types.py
@@ -86,6 +86,17 @@ class ValidationSet(BaseModel):
     split: str | list[str] | None = Field(default=None)
     """Active split filter applied to this validation set (informational)."""
 
+    strict: bool = Field(default=False)
+    """Require every case in the set to match a scanned input.
+
+    Cases are matched to scanner inputs by id, and by default a case whose id
+    matches nothing that was scanned is ignored -- so a scan can score against
+    a fraction of the set (e.g. after transcript ids drift, or when a
+    transcripts filter excludes labelled transcripts) without saying so. When
+    `strict` is enabled the scan fails at completion, reporting the ids of the
+    cases that matched no scanned input.
+    """
+
     @field_serializer("predicate")
     def serialize_predicate(
         self, predicate: ValidationPredicate | None, _info: Any

--- a/src/inspect_scout/_validation/validation.py
+++ b/src/inspect_scout/_validation/validation.py
@@ -16,6 +16,7 @@ def validation_set(
     cases: str | Path | pd.DataFrame,
     predicate: ValidationPredicate | None = "eq",
     split: str | list[str] | None = None,
+    strict: bool = False,
 ) -> ValidationSet:
     """Create a validation set by reading cases from a file or data frame.
 
@@ -28,6 +29,8 @@ def validation_set(
         split: Optional split name(s) to filter cases by. Only cases with matching
             split values will be included. Can be a single split name or a list of
             split names. Cases without a split field are excluded when filtering.
+        strict: Fail the scan at completion if any case in the set matched no
+            scanned input (defaults to False, which ignores unmatched cases).
     """
     # Load data into DataFrame if not already one
     if isinstance(cases, pd.DataFrame):
@@ -95,7 +98,9 @@ def validation_set(
 
         validate_cases = filtered_cases
 
-    return ValidationSet(cases=validate_cases, predicate=predicate, split=split)
+    return ValidationSet(
+        cases=validate_cases, predicate=predicate, split=split, strict=strict
+    )
 
 
 def _load_file(file: str | Path) -> pd.DataFrame:

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -12127,10 +12127,16 @@
               }
             ],
             "title": "Split"
+          },
+          "strict": {
+            "default": false,
+            "title": "Strict",
+            "type": "boolean"
           }
         },
         "required": [
-          "cases"
+          "cases",
+          "strict"
         ],
         "title": "ValidationSet",
         "type": "object"
@@ -12172,10 +12178,16 @@
               }
             ],
             "title": "Split"
+          },
+          "strict": {
+            "default": false,
+            "title": "Strict",
+            "type": "boolean"
           }
         },
         "required": [
-          "cases"
+          "cases",
+          "strict"
         ],
         "title": "ValidationSet",
         "type": "object"

--- a/tests/scan/test_strict_validation_resume.py
+++ b/tests/scan/test_strict_validation_resume.py
@@ -1,0 +1,88 @@
+"""Strict validation coverage across a resumed scan.
+
+A resumed scan skips work recorded by the earlier attempt, so the cases those
+transcripts matched are only visible in the accumulated scan summary. Strict
+coverage has to count them, otherwise resuming a scan would report cases as
+unmatched purely because they were validated before the interruption.
+"""
+
+from pathlib import Path
+
+import pytest
+from inspect_scout import Result, Scanner, ValidationCase, ValidationSet, scanner
+from inspect_scout._scan import top_level_sync_init
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+from inspect_scout.aio import scan_async, scan_resume_async
+
+from tests.helpers import temp_active_scans_store
+
+LOGS_DIR = Path(__file__).parent.parent / "recorder" / "logs"
+
+# transcripts the scanner should fail on, set by the test to make the first
+# attempt end with errors (and so leave work for the resumed attempt)
+_failing_transcript_ids: set[str] = set()
+
+
+@scanner(name="failing_once_scanner", messages="all")
+def failing_once_scanner() -> Scanner[Transcript]:
+    async def scan_transcript(transcript: Transcript) -> Result:
+        if transcript.transcript_id in _failing_transcript_ids:
+            raise RuntimeError("scanner failed for this transcript")
+        return Result(value=True)
+
+    return scan_transcript
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_counts_cases_validated_before_resume(
+    tmp_path: Path,
+) -> None:
+    top_level_sync_init("none")
+
+    transcripts = transcripts_from(LOGS_DIR)
+    async with transcripts.reader() as tr:
+        transcript_ids = [info.transcript_id async for info in tr.index()][:2]
+
+    validation = ValidationSet(
+        cases=[
+            ValidationCase(id=transcript_id, target=True)
+            for transcript_id in transcript_ids
+        ],
+        strict=True,
+    )
+
+    _failing_transcript_ids.clear()
+    _failing_transcript_ids.add(transcript_ids[1])
+    with temp_active_scans_store():
+        try:
+            status = await scan_async(
+                scanners=[failing_once_scanner()],
+                transcripts=transcripts,
+                validation=validation,
+                scans=str(tmp_path),
+                limit=2,
+                max_processes=1,
+            )
+            assert not status.complete, (
+                "scan with a failing scanner should not complete"
+            )
+            # only the transcript that succeeded was validated
+            first_validation = status.summary["failing_once_scanner"].validation
+            assert first_validation is not None
+            assert [str(entry.id) for entry in first_validation.entries] == [
+                transcript_ids[0]
+            ]
+        finally:
+            _failing_transcript_ids.clear()
+
+        # the resumed attempt only re-scans the transcript that failed, so the
+        # case validated by the first attempt must come from the scan summary
+        status = await scan_resume_async(status.location)
+
+    assert status.complete
+    scanner_validation = status.summary["failing_once_scanner"].validation
+    assert scanner_validation is not None
+    assert sorted(str(entry.id) for entry in scanner_validation.entries) == sorted(
+        transcript_ids
+    )

--- a/tests/test_validation_e2e.py
+++ b/tests/test_validation_e2e.py
@@ -13,11 +13,14 @@ from inspect_scout import (
     Result,
     Scanner,
     ValidationCase,
+    ValidationCoverageError,
     ValidationSet,
     loader,
     scan,
     scanner,
 )
+from inspect_scout._recorder.recorder import Status
+from inspect_scout._scan import MAX_REPORTED_UNMATCHED_CASES
 from inspect_scout._scanner.loader import Loader
 from inspect_scout._scanresults import scan_results_db, scan_results_df
 from inspect_scout._transcript.factory import transcripts_from
@@ -445,6 +448,177 @@ async def test_validation_partial_coverage_e2e() -> None:
         assert all(df_without_validation["validation_result"].isna()), (
             "Non-validated transcripts should have null validation_result"
         )
+
+
+# ============================================================================
+# Strict Coverage Tests
+# ============================================================================
+
+UNSCANNED_ID = "not-a-transcript-id"
+
+
+def scan_with_case_ids(scans_dir: str, case_ids: list[str], *, strict: bool) -> Status:
+    """Scan 2 transcripts with a validation case (target True) for each id."""
+    return scan(
+        scanners=[validation_scanner_a_factory()],
+        transcripts=transcripts_from(LOGS_DIR),
+        validation=ValidationSet(
+            cases=[ValidationCase(id=case_id, target=True) for case_id in case_ids],
+            predicate="eq",
+            strict=strict,
+        ),
+        scans=scans_dir,
+        limit=2,
+    )
+
+
+def validated_ids(status: Status) -> list[str | list[str]]:
+    """Ids of the cases that were validated during the scan."""
+    validation = status.summary["validation_scanner_a"].validation
+    assert validation is not None, "scan recorded no validation results"
+    return [entry.id for entry in validation.entries]
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_all_cases_matched_e2e() -> None:
+    """A strict validation set whose cases all match completes normally."""
+    transcript_ids = await get_n_transcript_ids(2)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan_with_case_ids(tmpdir, transcript_ids, strict=True)
+
+        assert status.complete
+        assert sorted(validated_ids(status)) == sorted(transcript_ids)
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_unmatched_case_fails_e2e() -> None:
+    """A strict validation set fails the scan and names the unmatched cases."""
+    transcript_ids = await get_n_transcript_ids(2)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValidationCoverageError) as ex_info:
+            scan_with_case_ids(tmpdir, transcript_ids + [UNSCANNED_ID], strict=True)
+
+        message = str(ex_info.value)
+        # the console (which prints `message`) and str() report the same thing
+        assert message == str(ex_info.value.message)
+        assert UNSCANNED_ID in message
+        assert "validation_scanner_a" in message
+        # cases that did match are not reported as unmatched
+        assert not any(tid in message for tid in transcript_ids)
+
+        # the scan's own results are complete and readable
+        status = ex_info.value.status
+        assert status.complete
+        df = scan_results_df(status.location, scanner="validation_scanner_a").scanners[
+            "validation_scanner_a"
+        ]
+        assert len(df) == 2
+
+
+@pytest.mark.asyncio
+async def test_unmatched_case_ignored_by_default_e2e() -> None:
+    """Without strict, an unmatched case is ignored (the pre-existing behavior)."""
+    transcript_ids = await get_n_transcript_ids(2)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan_with_case_ids(
+            tmpdir, transcript_ids + [UNSCANNED_ID], strict=False
+        )
+
+        assert status.complete
+        assert sorted(validated_ids(status)) == sorted(transcript_ids)
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_applies_per_scanner_e2e() -> None:
+    """Only the scanners whose validation set is strict are held to coverage."""
+    transcript_ids = await get_n_transcript_ids(2)
+
+    def cases(case_ids: list[str], target: bool) -> list[ValidationCase]:
+        return [ValidationCase(id=case_id, target=target) for case_id in case_ids]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValidationCoverageError) as ex_info:
+            scan(
+                scanners=[
+                    validation_scanner_a_factory(),
+                    validation_scanner_b_factory(),
+                ],
+                transcripts=transcripts_from(LOGS_DIR),
+                validation={
+                    "validation_scanner_a": ValidationSet(
+                        cases=cases(transcript_ids + [UNSCANNED_ID], target=True),
+                        strict=True,
+                    ),
+                    # scanner b returns False, so its cases target False
+                    "validation_scanner_b": ValidationSet(
+                        cases=cases(transcript_ids + [UNSCANNED_ID], target=False),
+                    ),
+                },
+                scans=tmpdir,
+                limit=2,
+            )
+
+    message = str(ex_info.value)
+    assert "validation_scanner_a" in message
+    assert "validation_scanner_b" not in message
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_composite_case_ids_e2e() -> None:
+    """Cases with multiple ids are matched (and reported) as a whole."""
+    # first pass: discover the message pair ids the loader yields
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[pair_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+        )
+        df = scan_results_df(status.location, scanner="pair_scanner").scanners[
+            "pair_scanner"
+        ]
+        scanned_pair: list[str] = json.loads(df["input_ids"].iloc[0])
+
+    unscanned_pair = ["unscanned-id-1", "unscanned-id-2"]
+    validation = ValidationSet(
+        cases=[
+            ValidationCase(id=scanned_pair, target=True),
+            ValidationCase(id=unscanned_pair, target=True),
+        ],
+        strict=True,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValidationCoverageError) as ex_info:
+            scan(
+                scanners=[pair_scanner_factory()],
+                transcripts=transcripts_from(LOGS_DIR),
+                validation=validation,
+                scans=tmpdir,
+                limit=1,
+            )
+
+    message = str(ex_info.value)
+    assert ",".join(unscanned_pair) in message
+    assert not any(message_id in message for message_id in scanned_pair)
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_truncates_long_id_list_e2e() -> None:
+    """Only the first MAX_REPORTED_UNMATCHED_CASES ids are listed."""
+    unscanned_ids = [f"unscanned-{index:02}" for index in range(26)]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValidationCoverageError) as ex_info:
+            scan_with_case_ids(tmpdir, unscanned_ids, strict=True)
+
+    message = str(ex_info.value)
+    assert unscanned_ids[MAX_REPORTED_UNMATCHED_CASES - 1] in message
+    assert unscanned_ids[MAX_REPORTED_UNMATCHED_CASES] not in message
+    assert "(1 more)" in message
 
 
 # ============================================================================


### PR DESCRIPTION
## What

Adds an opt-in `strict` flag to `ValidationSet` (and to the `validation_set()` factory). When it is set, a scan that runs to completion without every case in the set having matched a scanned input raises `ValidationCoverageError`, listing the unmatched case ids per scanner:

```
Strict validation: 2 validation case(s) matched no scanned input.
  ctf_environment (2): Fg3KBpgFr6RSsEWmHBUqeo, VFkCH7gXWpJYUYonvfHxrG
Scan results were written to scans/2025-11-14T09-33-12+00-00_ctf-environment_bMLcBnvVzX.
Check that these case ids match the ids of the inputs that were scanned, or set 'strict' to False on the validation set to ignore unmatched cases.
```

The results are written first and the completed scan's `Status` is carried on the error (`ex.status`), so nothing is lost — the scan itself succeeded, the label coverage didn't. `scout scan` prints the message and exits non-zero. The default is `False`, so behavior is unchanged unless you opt in.

## Why

`_validate_scan()` matches cases to scanner inputs by id, and a case that matches nothing is dropped without a trace: no result row, no error, no warning. The accuracy/precision/recall reported in the scan summary and in Scout View can therefore be computed from a fraction of the labels while looking entirely healthy. Ways to end up there without noticing:

- transcript ids drift (re-imported or re-run logs), so a validation file written last week matches half of this week's scan
- the scan reads a different or stale transcripts database than the one the cases were created against
- a `.where()` filter, `limit`, or a `worklist` excludes labelled transcripts
- `transcripts.for_validation()` doesn't protect against this either — it filters `sample_id IN (...)`, so ids that aren't present just yield fewer transcripts

This is exactly the failure you want to be loud in CI, where a validation set is the regression gate for scanner prompt changes.

## API choice

Two candidate surfaces: a field on the validation set, or a `scan()`-level flag next to `fail_on_error`. I went with the field on `ValidationSet` because:

- **It's a property of the label set, not of a run.** "This file is the complete ground truth for this scanner" is a statement about the labels. It also gives per-scanner granularity for free — one scanner in a scan can be strict while another is spot-checked with a partial set.
- **It rides along the paths that already carry validation sets.** `scan()`, `scan_async()`, `ScanJob(validation=...)`, and a `@scanjob` that builds its sets with `validation_set(..., strict=True)` all work with no new plumbing.
- **It is recorded in `ScanSpec`, so `scan_resume()` re-checks on the same terms.** A runtime-only `scan()` argument would silently lose strictness on resume, or would need a new `ScanOptions` field — which touches `openapi.json` anyway, so the schema cost isn't avoided by the alternative design.

Placement of the check: coverage is evaluated when the scan completes, not up front, because case ids can address messages, events, or groups of them (custom loaders), none of which are known before transcripts are read. It reads the validation entries recorded in the scan summary, which means cases validated by an earlier attempt of a resumed scan still count. Only a scan that reached `complete` is checked — an interrupted or errored scan already reports itself as such, and its cases genuinely haven't all had their chance yet.

`ValidationCoverageError` subclasses `PrerequisiteError` (inspect_ai's user-facing "fix your configuration" error, which prints without a traceback and exits non-zero) and adds `.status`.

## Testing

New tests in `tests/test_validation_e2e.py` (Strict Coverage section):

| Case | Expectation |
|---|---|
| strict, all cases match | scan completes, both cases validated |
| strict, one unmatched case | `ValidationCoverageError` naming the id and scanner but not the matched ids; `ex.status.complete` and results readable at `ex.status.location` |
| default (lenient), one unmatched case | scan completes, unmatched case ignored (pre-existing behavior) |
| two scanners, only one strict | only the strict scanner is reported |
| composite (multi-id) cases | matched pair passes, unmatched pair reported as `"id1,id2"` |
| 26 unmatched cases | list truncated at 25 with `(1 more)` |

`tests/scan/test_strict_validation_resume.py` covers the resume path: a case validated before an interruption counts toward coverage on `scan_resume()`.

Checks: `ruff check`, `ruff format`, and `mypy src examples tests` clean; full `pytest` suite 3234 passed / 107 skipped.

## Generated types

`openapi.json` is regenerated (adds `strict` to `ValidationSet`). `apps/scout/src/types/generated.ts` in the ts-mono submodule is **not** — that needs the coordinated submodule flow, which is why this is a draft (the `check-schema-and-types` failure is exactly this: the only drift is the two `strict: boolean` additions to the generated `ValidationSet` types). Note that the schema generator marks non-nullable fields required by design ("required is determined by nullability, not defaults" in `CustomJsonSchemaGenerator`), so the TS type gains a required `strict: boolean` and any `ValidationSet` object literal in `apps/scout` will need it. This matches the existing convention rather than creating a new case: `openapi.json` already has 16 required boolean-with-default fields (e.g. `Summary.complete`, `MessageFormatOptions.exclude_system`), so keeping `strict` non-nullable and following the coordinated regeneration flow seems right; happy to hand that off.

## Interaction with #588 (score predicates)

Reconciled — the fix is included in #588: it now records a `ValidationEntry` for every validated case (scored cases get `valid: None` plus a `score` field, and the confusion-matrix metrics skip them), so this PR's coverage check sees scored cases as covered and the two PRs are order-independent. Verified empirically on a local merge of both branches: a strict validation set whose cases were all matched by a score-returning predicate falsely raised `ValidationCoverageError` before the reconciliation and completes cleanly with it, while a genuinely unmatched case still raises.

## Things I deliberately left alone

Found while working on this; per AGENTS.md I'm flagging rather than fixing. Happy to fix any of them here or in follow-ups:

1. **A single-element list id can never match.** `_validate_scan()` normalizes the scanned ids (`["abc"]` → `"abc"`) but not `case.id`, and `_parse_id()` produces `["abc"]` from a validation file cell containing `["abc"]`. Such a case is silently skipped today; with `strict` it now fails the scan (correctly reporting that it wasn't validated, though the real fix belongs in the matcher).
2. **Duplicate case ids.** `_validate_scan()` uses `next(...)`, so only the first case with a given id is evaluated; the coverage check compares against the set of validated ids, so duplicates count as matched. A duplicated row in a CSV still loses a label silently. A pre-flight duplicate-id check (independent of `strict`) would catch it.
3. **`scan_complete()` bypasses the check** — force-completing an errored scan marks it complete without verifying coverage.
4. **`_scan_one()` can reuse a stale `validation_result`.** It is initialized outside the loader loop, so an iteration that raises before validation attaches the previous iteration's `ResultValidation` to the new report; that records a validation entry for an input that was never validated. One-line fix (reset inside the loop).
5. **No CLI or config way to enable `strict`** — `-V scanner:file.csv:predicate` has no slot for it, and the scan job / project config forms take a file path rather than a `ValidationSet`. It can be set from a `@scanjob` in Python today; a CLI or config form could follow.

### Agent review

- Reviewer: Claude Opus 5 via a general review agent (fresh context, different model from the author, which was Claude Fable 5), 1 pass; second pass by Claude Sonnet 4.6 (fresh context) on the revised diff.
- Pass 1 findings: 13 — 5 fixed (list-valued ids were being swallowed as rich markup in the message; the error now carries the scan status instead of discarding it; misleading "confirm the ids correspond to transcripts" wording; test isolation via `temp_active_scans_store()`; a resume-test assertion that depended on summary double-counting), 4 addressed by new tests (composite ids, per-scanner strictness, truncation, results readable after the failure), 4 disclosed above as flagged-not-fixed. One design objection dismissed with disagreement: the reviewer wanted the scan marked incomplete on disk; the scan's work *is* complete, and marking it otherwise would misreport the run and invite a pointless resume, so the coverage failure is surfaced as an exception carrying the status instead.
- Pass 2 findings: 3 — 2 fixed (`BaseException` captured `(message, status)` in `args`, so `str(ex)` dumped the entire `Status`; the `status` attribute docstring moved into an `Attributes:` section), 1 dismissed (display ambiguity when a case id itself contains a comma — the CSV format can't express that either).
- Independent adversarial pass: Claude (Fable 5), fresh context, after the draft opened. Re-verified rather than trusted the claims above: local `ruff`/`mypy`/full pytest at branch HEAD (3234 passed); no race between the coverage check and result recording (the summary is updated synchronously under a lock in `RecorderBuffer.record`, and `recorder.sync` runs after the strategy completes); the `str(ex)` fix (`BaseException.__new__` does capture both constructor args, and `args=(message, status)` also keeps the exception picklable); the CI failure hides nothing beyond the expected `generated.ts` drift (regenerating `openapi.json` locally is a no-op); and the `scan_complete()` bypass flag is accurate (`scan_complete_async` calls `recorder.sync(complete=True)` directly — it is an explicit "complete despite errors" override, so the bypass is arguably coherent, but worth a maintainer decision). New findings: the semantic interaction with #588 (section above), and a note that `repr(ex)` still embeds the full `Status` via `args` (no default display path uses `repr`, so left as-is). No code changes were needed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


