### PR TITLE
fix: don't double-count validation entries when a resumed scan retries a transcript

### DIFF
--- a/src/inspect_scout/_recorder/summary.py
+++ b/src/inspect_scout/_recorder/summary.py
@@ -158,12 +158,25 @@ class Summary(BaseModel):
                 tot_results.model_usage[model], usage
             )
 
-        # Aggregate validation entries and rebuild ValidationResults with metrics
+        # Aggregate validation entries and rebuild ValidationResults with metrics.
+        # A resumed scan retries transcripts that errored, re-validating cases
+        # already recorded by the interrupted run, so this report's entries
+        # supersede prior entries with the same case ids rather than
+        # double-counting those cases in the metrics (mirroring the parquet
+        # layer, which rewrites a retried transcript's results file
+        # wholesale). Entries are keyed by case id alone (they carry no
+        # transcript identity; case ids are input ids, unique in practice).
+        # Legacy entries (id == "") have no identity and are never superseded.
         if new_entries:
             existing_entries = (
                 tot_results.validation.entries if tot_results.validation else []
             )
-            all_entries = existing_entries + new_entries
+            new_keys = {_entry_key(entry.id) for entry in new_entries if entry.id != ""}
+            all_entries = [
+                entry
+                for entry in existing_entries
+                if entry.id == "" or _entry_key(entry.id) not in new_keys
+            ] + new_entries
             tot_results.validation = ValidationResults.from_entries(all_entries)
 
     def _report_metrics(
@@ -177,6 +190,11 @@ class Summary(BaseModel):
 
     def __getitem__(self, scanner: str) -> ScannerSummary:
         return self.scanners[scanner]
+
+
+def _entry_key(entry_id: str | list[str]) -> str | tuple[str, ...]:
+    """Hashable case identity for a validation entry (list ids as tuples)."""
+    return tuple(entry_id) if isinstance(entry_id, list) else entry_id
 
 
 def add_model_usage(a: ModelUsage, b: ModelUsage) -> ModelUsage:

--- a/tests/recorder/test_summary.py
+++ b/tests/recorder/test_summary.py
@@ -8,7 +8,12 @@ from inspect_scout._recorder.validation import (
     ValidationResults,
     compute_validation_metrics,
 )
-from inspect_scout._scanner.result import Result, ResultReport, as_resultset
+from inspect_scout._scanner.result import (
+    Result,
+    ResultReport,
+    ResultValidation,
+    as_resultset,
+)
 from inspect_scout._transcript.types import Transcript
 from inspect_scout._validation.validate import is_positive_value
 
@@ -352,3 +357,153 @@ class TestValidationResults:
         assert len(results.entries) == 2
         assert results.metrics is None
         assert results.metrics_by_key is None
+
+
+class TestSummaryValidationDedup:
+    """_report replaces validation entries whose case id was already reported.
+
+    A resumed scan retries transcripts that errored, re-reporting results that
+    already validated before the interruption (the summary is seeded from the
+    scan dir on resume). Without replacement the duplicate entries double-count
+    those cases in the confusion-matrix metrics.
+    """
+
+    def _make_validated_report(self, input_ids: list[str], valid: bool) -> ResultReport:
+        """Helper: create a ResultReport validated against target=True."""
+        return ResultReport(
+            input_type="transcript",
+            input_ids=input_ids,
+            input=Transcript(transcript_id="t1"),
+            result=Result(value=valid),
+            validation=ResultValidation(target=True, valid=valid),
+            error=None,
+            events=[],
+            model_usage={},
+        )
+
+    def test_retry_replaces_entry_for_same_case(self) -> None:
+        summary = Summary(scanners=["scanner"])
+        summary._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [self._make_validated_report(["m1"], valid=True)],
+            None,
+        )
+        # retry of the same case with a different verdict
+        summary._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [self._make_validated_report(["m1"], valid=False)],
+            None,
+        )
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 1
+        assert validation.entries[0].valid is False  # last write wins
+        assert validation.metrics is not None
+        assert validation.metrics.total == 1
+        assert validation.metrics.tp == 0
+        assert validation.metrics.fn == 1
+
+    def test_distinct_cases_accumulate(self) -> None:
+        summary = Summary(scanners=["scanner"])
+        summary._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [self._make_validated_report(["m1"], valid=True)],
+            None,
+        )
+        summary._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [self._make_validated_report(["m2"], valid=True)],
+            None,
+        )
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 2
+        assert validation.metrics is not None
+        assert validation.metrics.total == 2
+
+    def test_list_ids_replace_by_tuple_identity(self) -> None:
+        summary = Summary(scanners=["scanner"])
+        for _ in range(2):
+            summary._report(
+                None,  # type: ignore[arg-type]
+                "scanner",
+                [self._make_validated_report(["m1", "m2"], valid=True)],
+                None,
+            )
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 1
+        assert validation.metrics is not None
+        assert validation.metrics.total == 1
+
+    def test_retry_supersedes_seeded_duplicates(self) -> None:
+        """A retry supersedes all prior entries for its case ids.
+
+        On resume the summary is seeded from persisted JSON, which may
+        already hold duplicates recorded before deduplication existed.
+        """
+        seeded = Summary.model_validate(
+            {
+                "complete": False,
+                "scanners": {
+                    "scanner": {
+                        "scans": 1,
+                        "validation": {
+                            "entries": [
+                                {"id": "m1", "target": True, "valid": True},
+                                {"id": "m1", "target": True, "valid": True},
+                            ]
+                        },
+                    }
+                },
+            }
+        )
+        seeded._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [self._make_validated_report(["m1"], valid=True)],
+            None,
+        )
+        validation = seeded.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 1
+        assert validation.metrics is not None
+        assert validation.metrics.total == 1
+
+    def test_same_case_within_one_report_is_kept(self) -> None:
+        """Same-id entries within a single report coexist.
+
+        Only prior reports are superseded, mirroring the parquet layer's
+        per-transcript file replacement.
+        """
+        summary = Summary(scanners=["scanner"])
+        summary._report(
+            None,  # type: ignore[arg-type]
+            "scanner",
+            [
+                self._make_validated_report(["m1"], valid=True),
+                self._make_validated_report(["m1"], valid=False),
+            ],
+            None,
+        )
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 2
+
+    def test_entries_without_identity_are_kept(self) -> None:
+        """Entries with no input ids (id == '') have no case identity."""
+        summary = Summary(scanners=["scanner"])
+        for _ in range(2):
+            summary._report(
+                None,  # type: ignore[arg-type]
+                "scanner",
+                [self._make_validated_report([], valid=True)],
+                None,
+            )
+        validation = summary.scanners["scanner"].validation
+        assert validation is not None
+        assert len(validation.entries) == 2


### PR DESCRIPTION
## What

Fixes a double-counting bug: when an interrupted scan is resumed, validation entries for cases that were already validated before the interruption are duplicated in the scan summary, inflating the confusion-matrix metrics (`total`, `tp`/`fp`/`tn`/`fn`, and everything derived from them).

## Why

The three pieces that combine into the bug:

1. `FileRecorder.resume()` seeds the buffer summary from the scan dir (`_seed_buffer_summary_from_scan_dir` in `_recorder/file.py`), so entries recorded before the interruption carry over.
2. `is_recorded()` (`_recorder/buffer.py`) returns `False` for any transcript whose parquet file has a non-null `scan_error` row, so an errored transcript is retried in full on resume.
3. `Summary._report()` (`_recorder/summary.py`) appended `ValidationEntry`s with no dedup.

So for a per-message scanner where message A validated and message B errored, resume retries the whole transcript, message A is re-validated, and its entry is appended a second time.

Reproduced end-to-end on main with a two-message transcript (scanner errors on one message on the first run, succeeds on resume; validation case on the other message):

```
=== after first (errored) run ===
complete=False errors=1
validation entries: 1  ->  id=JhLR... target=True valid=True
metrics: tp=1 total=1

=== after resume ===
complete=True
validation entries: 2  ->  id=JhLR... twice, identical
metrics: tp=2 total=2        # one labelled case counted twice
```

## Fix

`_report()` now supersedes previously reported entries whose case id appears in the current report (keyed by case id, `tuple(id)` for multi-id cases), then appends the report's entries and rebuilds `ValidationResults` as before. With the fix, the scenario above ends with 1 entry and `total=1`.

Placement rationale — dedup at `_report` (append) time rather than at metrics computation in `ValidationResults.from_entries`:

- `ValidationResults` stores `entries` and `metrics` side by side; dedup only inside metrics computation would leave the persisted `entries` list inconsistent with the metrics computed from it (and with what downstream consumers of `entries` see).
- The faithful record of scan output is the parquet results layer, and it already has supersede-on-retry semantics: one file per transcript, rewritten wholesale on retry. The summary now mirrors exactly that, instead of being the one layer that accumulates duplicates.
- `from_entries` has other callers (legacy-format migration in `ScannerSummary.migrate_validation`) where silently dropping entries would be surprising.

Scope of the dedup, chosen to supersede only what a retry re-reports:

- Only entries from *prior* reports are superseded; same-id entries within a single report call coexist (like rows within one parquet file).
- Legacy entries (`id == ""`, from pre-`ValidationEntry` summaries) have no case identity and are never superseded.
- Entries carry no transcript identity, so entries are keyed by case id alone. A case id that matched inputs in two different transcripts would collapse to its latest entry; case ids are input ids (transcript/message/event ids), which are unique in practice, and `_validate_scan` matches a case to an input by exact id equality, so distinct inputs produce distinct-id entries in every loader path.
- A summary that already contains duplicates recorded by pre-fix code is repaired for a case when that case's transcript is retried (all stale entries for the id are superseded).

Unrelated aggregate counters in the seeded summary (`scans`, `results`, `errors`, `tokens`) also re-accumulate on retry; that is pre-existing behavior and deliberately out of scope here — this PR only fixes the validation entries/metrics, where the double-count corrupts the labelled ground-truth comparison.

## Testing

- New unit tests in `tests/recorder/test_summary.py` (`TestSummaryValidationDedup`): retry replaces the entry and the metrics reflect the retried verdict (last-write-wins); distinct cases still accumulate; multi-id (`list[str]`) cases keyed as tuples; same-id entries within one report kept; entries without ids kept; seeded pre-fix duplicates repaired on retry (via `Summary.model_validate` round-trip, the same path `resume` uses). Three of these fail on main and pass with the fix.
- End-to-end reproduction (interrupt via scanner error, `scan_resume()`) verified manually before and after the fix (transcript above).
- `ruff check` / `ruff format --check` clean; `mypy` clean; `tests/recorder`, `tests/validation`, `tests/scan`, and the validation e2e suites pass (the only failures in a full local run are in `tests/sources/*`, `tests/observe/*`, and `tests/scan/test_results_buffer.py`, all of which fail identically on unmodified main in this environment).

## Other information

Interaction with open PRs #588 (score predicates) and #589 (strict validation coverage), both of which touch the same code:

- Merges cleanly with both (and with both together); no textual conflicts.
- #588's scored entries (`valid=None`, `score=float`) are treated like any other entry — supersession replaces whole entries keyed by id, so a scored retry supersedes a scored (or pass/fail) prior entry the same way. All of #588's summary tests pass on a local merge of the two branches.
- #589's coverage check builds a set of case-id keys from summary entries; dedup keeps at least (exactly) one entry per validated case id, so covered cases stay covered. #589's resume-coverage test (`tests/scan/test_strict_validation_resume.py`) passes on a local merge. (Incidentally #589 introduces `_case_id_key` in `_scan.py` with the same semantics as this PR's `_entry_key`; if both land, the helpers could be unified in a follow-up.)

### Agent review

- Reviewer: Claude (Fable 5) via a fresh-context general-purpose review agent (same model as author), 1 pass over the diff plus the surrounding recorder code (`summary.py`, `validation.py`, `buffer.py`, `file.py`), with empirical probes of the edge cases.
- Findings: 5 — 3 fixed, 1 addressed in the PR body, 1 dismissed:
  - Fixed: the initial index-based implementation replaced only the last occurrence when the seeded summary already contained pre-fix duplicates for a case; reworked to set-based supersession of all prior entries for the report's case ids.
  - Fixed: comment overclaimed "wholesale supersede" relative to that initial implementation; code now matches the comment.
  - Fixed: tests only exercised consecutive in-memory `_report` calls; added a `model_validate` round-trip test pinning the seeded resume path with pre-fix duplicates.
  - Addressed in body: sibling counters (`scans`/`results`/`errors`) also re-accumulate on retry — pre-existing, documented as out of scope above.
  - Dismissed (out of scope, pre-existing): in `_scan.py`, `validation_result` is initialized outside the scan loop and not reset when a scanner errors before validation runs, so an errored result can carry the previous iteration's validation payload; independent bug, not touched here.

---

This PR was prepared by an AI coding agent (Claude Code) at the direction of a human contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
