### PR TITLE
fix: reset validation result per scanned input so error reports don't carry a previous input's verdict

### DIFF
--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -1042,7 +1042,6 @@ async def _scan_one(
     init_transcript(inspect_transcript)
 
     results: list[ResultReport] = []
-    validation_result: ResultValidation | None = None
 
     scanner_config = config_for_scanner(job.scanner)
     loader = scanner_config.loader
@@ -1050,6 +1049,7 @@ async def _scan_one(
     async for loader_result in loader(job.union_transcript):
         result: Result | list[Result] | None = None
         final_result: Result | None = None
+        validation_result: ResultValidation | None = None
         error: Error | None = None
         try:
             type_and_ids = get_input_type_and_ids(loader_result)

--- a/tests/test_validation_e2e.py
+++ b/tests/test_validation_e2e.py
@@ -716,6 +716,93 @@ async def test_validation_message_based_scanner_e2e() -> None:
         )
 
 
+@scanner(name="failing_message_scanner", messages="all")
+def failing_message_scanner_factory(
+    fail_after_first: bool = False,
+) -> Scanner[ChatMessage]:
+    """Scanner that succeeds on its first call and (optionally) raises afterwards."""
+    calls = 0
+
+    async def scan_message(message: ChatMessage) -> Result:
+        nonlocal calls
+        calls += 1
+        if fail_after_first and calls > 1:
+            raise RuntimeError(f"failing scanner: {message.id}")
+        return Result(value=True, explanation="ok")
+
+    return scan_message
+
+
+@pytest.mark.asyncio
+async def test_validation_not_carried_onto_errored_inputs_e2e() -> None:
+    """Errored scanner inputs must not inherit a previous input's validation.
+
+    Regression test: `_scan_one` kept the previous iteration's validation
+    result across loader inputs, so when the scanner raised on a later input
+    of the same transcript, its error report (parquet row and summary entry)
+    carried the previous input's validation target/verdict.
+    """
+    # First pass: run without failures/validation to collect the message IDs
+    with tempfile.TemporaryDirectory() as tmpdir:
+        scan_result = scan(
+            scanners=[failing_message_scanner_factory()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,  # Only scan 1 transcript
+        )
+        results = scan_results_df(
+            scan_result.location, scanner="failing_message_scanner"
+        )
+        df_first = results.scanners["failing_message_scanner"]
+        message_ids = [json.loads(ids)[0] for ids in df_first["input_ids"]]
+
+    assert len(message_ids) >= 2, "Need at least 2 messages to cover a later failure"
+
+    # Second pass: validation cases for every message; the scanner succeeds
+    # (and validates) on the first message it sees and raises on all others
+    validation = ValidationSet(
+        cases=[ValidationCase(id=msg_id, target=True) for msg_id in message_ids],
+        predicate="eq",
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        scan_result = scan(
+            scanners=[failing_message_scanner_factory(fail_after_first=True)],
+            transcripts=transcripts_from(LOGS_DIR),
+            validation=validation,
+            scans=tmpdir,
+            limit=1,  # Scan same transcript
+        )
+        results = scan_results_df(
+            scan_result.location, scanner="failing_message_scanner"
+        )
+        df = results.scanners["failing_message_scanner"]
+        assert len(df) == len(message_ids)
+
+        # The first-scanned message succeeded and validated
+        df_valid = df[df["scan_error"].isna()]
+        assert len(df_valid) == 1
+        validated_id = json.loads(df_valid.iloc[0]["input_ids"])[0]
+        assert df_valid.iloc[0]["validation_result"] is not None
+
+        # Errored inputs never validated, so their rows must not carry the
+        # succeeded message's validation target/verdict
+        df_errored = df[df["scan_error"].notna()]
+        assert len(df_errored) == len(message_ids) - 1
+        assert df_errored["validation_result"].isna().all(), (
+            f"Errored inputs must not inherit a previous input's validation: "
+            f"{df_errored[['input_ids', 'validation_result']].to_dict('records')}"
+        )
+        assert df_errored["validation_target"].isna().all()
+
+        # The summary must contain exactly the one validation that ran
+        summary_validation = scan_result.summary.scanners[
+            "failing_message_scanner"
+        ].validation
+        assert summary_validation is not None
+        assert [entry.id for entry in summary_validation.entries] == [validated_id]
+
+
 @pytest.mark.asyncio
 async def test_validation_event_based_scanner_e2e() -> None:
     """Test validation with event-based scanner."""


### PR DESCRIPTION
## What

Fixes a stale-state bug in `_scan_one` (`src/inspect_scout/_scan.py`): `validation_result` was initialized once, outside the per-input loader loop, and only reassigned after a successful scanner call. Every other piece of per-iteration state (`result`, `final_result`, `error`) was already reset each iteration. The fix moves the `validation_result` initialization inside the loop.

- [x] Bug fix (non-breaking change which fixes an issue)

## Current behavior

When a scanner processes multiple inputs from the same transcript (per-message/per-event scanning or a custom loader) and a *later* input's scanner call raises, the error report recorded for that input silently reuses the *previous* input's `ResultValidation` — a wrong (input, verdict) pairing that is persisted into the parquet results and counted into summary validation metrics.

Minimal reproduction (per-message scanner over one transcript with 3 messages; a validation case for the first message; the scanner succeeds on message 1 and raises on messages 2 and 3):

```python
@scanner(name="probe_scanner", messages="all")
def probe_scanner_factory(ok_id: str | None = None) -> Scanner[ChatMessage]:
    async def scan_message(message: ChatMessage) -> Result:
        if ok_id is not None and message.id != ok_id:
            raise RuntimeError(f"boom on message {message.id}")
        return Result(value=True)
    return scan_message

status = scan(
    scanners=[probe_scanner_factory(ok_id=first_message_id)],
    transcripts=transcripts,
    validation=ValidationSet(cases=[ValidationCase(id=first_message_id, target=True)]),
    scans=tmpdir,
    limit=1,
)
```

Observed on `main` — the errored rows (which have no validation case of their own and never validated) carry message 1's verdict:

```
                    input_ids                              scan_error validation_target validation_result
0  ["U92RbrmE2sXRojd3xGBL4f"]                                    <NA>              true              true
1  ["JhLRWBHAc5WQvudvJ32edq"]  boom on message JhLRWBHAc5WQvudvJ32edq              true              true   <- stale
2  ["HuQjcGdNgJwYDu5uFJsf3k"]  boom on message HuQjcGdNgJwYDu5uFJsf3k              true              true   <- stale
```

The scan summary is corrupted the same way — the single real validation case is counted once per errored input, under the wrong ids, inflating the validation metrics:

```
entries: id=U92RbrmE2sXRojd3xGBL4f valid=True
         id=JhLRWBHAc5WQvudvJ32edq valid=True   <- stale
         id=HuQjcGdNgJwYDu5uFJsf3k valid=True   <- stale
metrics: tp=3 fp=0 tn=0 fn=0 total=3   (should be tp=1 total=1)
```

## New behavior

Each loader input starts with a clean `validation_result`, so an errored input records `validation_target`/`validation_result` as NULL (as first-input errors always did) and the summary contains exactly the validations that actually ran:

```
                    input_ids                              scan_error validation_target validation_result
0  ["U92RbrmE2sXRojd3xGBL4f"]                                    <NA>              true              true
1  ["JhLRWBHAc5WQvudvJ32edq"]  boom on message JhLRWBHAc5WQvudvJ32edq              <NA>              <NA>
2  ["HuQjcGdNgJwYDu5uFJsf3k"]  boom on message HuQjcGdNgJwYDu5uFJsf3k              <NA>              <NA>

entries: id=U92RbrmE2sXRojd3xGBL4f valid=True
metrics: tp=1 fp=0 tn=0 fn=0 total=1
```

## Testing

- New regression test `tests/test_validation_e2e.py::test_validation_not_carried_onto_errored_inputs_e2e`: per-message scanner that succeeds on the first message it sees and raises on all subsequent ones, with a validation case for every message id; asserts the errored rows carry no validation target/verdict and the summary contains exactly one entry. Fails on `main` (on exactly the stale-carry assertion), passes with the fix. The test is order-independent (it does not assume which message is scanned first).
- `ruff check` / `ruff format --check`: clean. `mypy src examples tests`: clean.
- Full local pytest suite: 3178 passed, 107 skipped, 50 failed — the failure set is byte-identical to unmodified `main` run in the same environment (all in third-party source integrations, openai stream-observe, and the results buffer; local dependency-version skew), so this change introduces no failures and adds exactly one passing test.

## Other information

While auditing `_scan_one` for other state initialized once but consumed in the per-iteration error path, two adjacent (pre-existing, unchanged here) issues turned up — flagging rather than fixing to keep this PR minimal; happy to file issues or follow-ups:

- `type_and_ids` is assigned as the first statement inside the `try` and consumed after the `except`. If `get_input_type_and_ids` itself raises (reachable when a custom loader yields a non-sequence, non-recognized value: `len(loader_result)` raises `TypeError`), the error report gets the previous input's `input_type`/`input_ids` (or an unbound-variable `NameError` on the first input). Unreachable with the built-in loaders.
- `model_usage()` and the inspect transcript events are initialized once per `_scan_one` but captured per report, so for multi-input scans row N's `scan_model_usage`/`scan_total_tokens`/events include inputs 1..N-1, and the summary sums per-report usage (over-counts for multi-input scanners).

Order-independence with the other open validation PRs was verified: this branch merges cleanly with both #588 and #589 (no textual conflicts), and the new regression test passes on a local throwaway merge with each.

---

This PR was prepared by an AI coding agent (Claude Code, model Claude Fable 5) at the direction of a human contributor.

### Agent review

- Reviewer: Claude (Fable 5) via a fresh-context general-purpose review agent (same model as author), 1 pass over the full commit plus `_scan_one`, `get_input_type_and_ids`, `_validate_scan`, the parquet column mapping (`result.py::to_df_columns`), and the summary aggregation (`_recorder/summary.py`). The reviewer independently re-verified that the regression test fails on pre-fix code and passes post-fix, and ran the validation e2e file under default xdist plus ruff/mypy.
- Findings: 5 — 1 fixed, 4 flagged/dismissed:
  - Fixed: the original regression test derived the validated message from dataframe row order (could pass vacuously if scan order ever diverged) — rewritten to be order-independent (scanner succeeds on first call; validation cases cover every message).
  - Flagged (pre-existing, out of scope): `type_and_ids` stale/unbound on `get_input_type_and_ids` failure — see Other information.
  - Flagged (pre-existing, out of scope): cumulative `model_usage`/events across loader inputs — see Other information.
  - Dismissed (pre-existing nit): when `_validate_scan` itself raises, the report carries both `result` and `error` and the parquet row shows no `scan_error` while the summary counts an error — unrelated to this change.
  - Dismissed: no downstream consumer relied on the buggy carry-over — the only consumers of `ResultReport.validation` are the summary aggregation and the parquet columns, and NULL validation columns on errored rows were already an existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
