### PR TITLE
docs: codify panel-ownership rule for async query lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,9 @@ pnpm install
 - Strict mode enabled; no `any`, no type assertions
 - ESLint + Prettier
 
+### Architecture
+- Panels that initiate an async query own its `AsyncData` lifecycle and render loading/error states at that boundary; components rendered only after data is ready take required data props rather than reading query/loading state themselves
+
 ### Common Pitfalls
 - Use pnpm, not npm—this project uses pnpm exclusively
 - Hook tests don't need JSX—use `.test.ts` not `.test.tsx`; see `useMapAsyncData.test.ts`


### PR DESCRIPTION
## Summary

Adds a short `### Architecture` subsection to AGENTS.md's TypeScript section stating the panel-ownership rule that is already enforced in review and implemented in the codebase: a panel that initiates an async query owns its `AsyncData` lifecycle (loading/error rendering); components that only render once data is ready take required data props instead of reading query/loading state themselves.

## Why

The rule is already the enforced convention, but it is not written anywhere an agent or new contributor would find it:

- #178 fixed a bug caused by loading state not being threaded down to a leaf component (`inputLoading` missing on `ResultBody`, producing a false "No input available" state).
- #180 (merged) is the direct follow-through, and its own description states the rule this PR documents: "Lift loading state handling up to top level panel components as much as possible... Pass `inputData` as prop to `ResultPanel` instead of fetching internally."
- #194 review applied the same boundary discipline to grid-API access.

AGENTS.md was recently expanded with async guardrails and PR conventions (#585), but those cover the Python side; the frontend design docs (`react-query.md`, `front-end-testing.md`) don't state this rule either. This just writes down what contributors are already held to, in the file agents read.

### Agent review
- Reviewer: Claude (this PR was drafted and reviewed by Claude sessions acting for Sami; same-model, not fresh-context)
- Passes: 3 — an initial line-by-line duplication check of the new text against AGENTS.md, CONTRIBUTING.md, and design/*.md at drafting time; a second pass six days later re-verifying against current main after #585's AGENTS.md expansion (no overlap: #585's async guardrails are Python-side) and re-checking `react-query.md`/`front-end-testing.md` in the ts-mono submodule; and a thermonuclear-deep-review pass that re-verified the rule against current code (`ScannerResultPanel.tsx:180-181,195-200,383-384,449-452`; `ResultBody.tsx:24-26`'s required `inputData: ScannerInput` prop) and found the rule text itself sound, but flagged the `(see #178, #180)` parenthetical on the AGENTS.md line as doubly wrong: #178 is closed-unmerged, and even citing it alongside #180 invites a reader to treat both as equally authoritative evidence.
- Findings: the third pass's finding is fixed in this PR — the `(see #178, #180)` parenthetical was removed from the AGENTS.md line (that provenance belongs in this PR body, which already correctly identifies #180 as the merged follow-through, not in the evergreen rule text). No other change; the rule text and placement were otherwise sound. Placement was adjusted once before this (originally drafted for CONTRIBUTING.md, moved to AGENTS.md since that is the file agents read — the same reasoning as #585).
