### PR TITLE
chore: track inspect_ai main and import parse_cli_args from its defining module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,3 +199,12 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = ["harbor.*"]
 ignore_missing_imports = true
+
+# We import parse_cli_args and friends from inspect_ai._cli.util, a private
+# module whose symbols move between inspect_ai versions (some are definitions,
+# some plain re-imports, depending on the version installed). Treat its plain
+# re-imports as exports so one import path type-checks across our whole
+# declared inspect-ai range.
+[[tool.mypy.overrides]]
+module = ["inspect_ai._cli.util"]
+implicit_reexport = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fastapi>=0.128.1",
     "ijson>=3.2.0",
     "importlib-metadata",
-    "inspect-ai>=0.3.252",
+    "inspect-ai @ git+https://github.com/UKGovernmentBEIS/inspect_ai@main",
     "inspect-swe>=0.2.56",
     "jinja2>=3.0.0",
     "jsonlines>=3.0.0",
@@ -199,12 +199,3 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = ["harbor.*"]
 ignore_missing_imports = true
-
-# We import parse_cli_args and friends from inspect_ai._cli.util, a private
-# module whose symbols move between inspect_ai versions (some are definitions,
-# some plain re-imports, depending on the version installed). Treat its plain
-# re-imports as exports so one import path type-checks across our whole
-# declared inspect-ai range.
-[[tool.mypy.overrides]]
-module = ["inspect_ai._cli.util"]
-implicit_reexport = true

--- a/src/inspect_scout/_cli/scan.py
+++ b/src/inspect_scout/_cli/scan.py
@@ -6,11 +6,10 @@ from click.core import ParameterSource
 from inspect_ai._cli.util import (
     int_bool_or_str_flag_callback,
     int_or_bool_flag_callback,
-    parse_cli_args,
     parse_cli_config,
     parse_model_role_cli_args,
 )
-from inspect_ai._util.config import resolve_args
+from inspect_ai._util.config import parse_cli_args, resolve_args
 from inspect_ai._util.constants import DEFAULT_CACHE_DAYS
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once


### PR DESCRIPTION
The nightly run https://github.com/meridianlabs-ai/inspect_scout/actions/runs/33372341850 failed py-mypy with:

```
src/inspect_scout/_cli/scan.py:6: error: Module "inspect_ai._cli.util" does not explicitly export attribute "parse_cli_args"  [attr-defined]
```

inspect_ai main (UKGovernmentBEIS/inspect_ai#5134, unreleased) moved the definition of `parse_cli_args` to `inspect_ai._util.config`; `inspect_ai._cli.util` now only re-imports it, which strict mypy (`no_implicit_reexport`) rejects as an import path.

No single import path works across both a released inspect_ai and git main: releases 0.3.252 through 0.3.261 define the symbol in `inspect_ai._cli.util` and do not have it in `inspect_ai._util.config`. So instead of straddling the two, this PR points the `inspect-ai` dependency at git main and imports from the module that defines the symbol there:

- `pyproject.toml`: `inspect-ai>=0.3.252` becomes `inspect-ai @ git+https://github.com/UKGovernmentBEIS/inspect_ai@main`, the same pattern as #508. Scout then tracks a single inspect_ai version and there is no skew between the nightly/PR lane and the release lane.
- `scan.py`: import `parse_cli_args` from `inspect_ai._util.config` (joining the existing `resolve_args` import there).

An earlier revision of this PR instead kept the old import and added a mypy `implicit_reexport` override for `inspect_ai._cli.util`; that override is dropped in favor of the dependency change.

**Release consequence, visible at merge**: with pyproject tracking inspect_ai main, `release-dep-guard.yml` blocks scout's next release until inspect_ai ships a release carrying the `parse_cli_args` move. That is the designed flow (the guard's "cut an inspect_ai release first" signal, per the pattern established in #508): `release-pin-deps.yml` runs on a 2-hour schedule and automatically re-pins the release PR to the newest PyPI version once inspect_ai publishes, and the release PR goes green from there without a human nudge.

`uv.lock` is deliberately untouched: the prior switch to git main (52f9ef7c) did not touch it either, and lockfile bumps land as separate commits (for example #553).

Verified on Python 3.10 against inspect_ai git main (0.3.262.dev3): `mypy src examples tests` finds 0 errors (460 files), ruff clean, `import inspect_scout._cli.scan` works, and `scout scan --help` runs.

Reaching into inspect_ai's private modules remains the underlying fragility (`scan.py` and `trace.py` both do it); a public inspect_ai path for these CLI helpers would remove it.