### PR TITLE
ci: gate config-level checker relaxations behind a reviewed ledger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,15 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv cache prune --ci
 
+  config-carveouts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # stdlib-only gate; the runner's default python3 (>= 3.11, has tomllib)
+      # is all it needs — no venv, no installs
+      - name: Check config carve-out ledger
+        run: python3 scripts/check_config_carveouts.py
+
   py-test:
     runs-on: ubuntu-latest
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@ Development setup (editable install, inspect_ai tracked from `main`, frontend/Gi
 - During development, run only implicated tests; run the full suite when the work is complete
 - Git LFS tracks `src/inspect_scout/_view/dist/**` (built frontend assets)—without `git lfs install`, a checkout leaves pointer stubs, not real files
 
+### Config carve-outs
+- A config-level relaxation that silences a checker (a mypy override, a ruff `ignore`, etc.) is a smell—name the root cause and check whether the repo already has an established practice for the problem before reaching for one
+- Escalate rather than work around: if a checker blocks you, flag it; don't relax the checker to get green
+- New carve-outs must be recorded in `config_carveouts.json` with a reason (`python3 scripts/check_config_carveouts.py --update`, then fill in the reason) and get maintainer sign-off on the ledger diff—CI fails on unrecorded carve-outs
+
 ## Pull Requests
 
 - Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ make check   # ruff check --fix, ruff format, and mypy
 make test    # pytest
 ```
 
+The `carveouts` step of `make check` needs a `python3` >= 3.11 (it uses `tomllib`); on an older interpreter it exits with a clear message rather than passing silently.
+
 **Frontend** (from `src/inspect_scout/_view/ts-mono`):
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@ ruff:
 mypy:
 	mypy src examples tests
 
+.PHONY: carveouts
+carveouts:
+	python3 scripts/check_config_carveouts.py
+
 .PHONY: check
-check: ruff mypy
+check: ruff mypy carveouts
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ mypy:
 	mypy src examples tests
 
 .PHONY: carveouts
+# needs a python3 >= 3.11 (tomllib); exits with a clear message otherwise
 carveouts:
 	python3 scripts/check_config_carveouts.py
 

--- a/config_carveouts.json
+++ b/config_carveouts.json
@@ -8,6 +8,13 @@
   },
   {
     "file": "pyproject.toml",
+    "location": "tool.ruff",
+    "setting": "extend-exclude",
+    "value": "docs",
+    "reason": "docs/ is Quarto site content with embedded code snippets, not package code; not lintable as-is. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
     "location": "tool.ruff.lint",
     "setting": "ignore",
     "value": "D10",

--- a/config_carveouts.json
+++ b/config_carveouts.json
@@ -1,0 +1,65 @@
+[
+  {
+    "file": "pyproject.toml",
+    "location": "tool.mypy.overrides[harbor.*]",
+    "setting": "ignore_missing_imports",
+    "value": "true",
+    "reason": "harbor requires Python >= 3.12 so it can be absent from the type-checking environment; see the comment in pyproject.toml"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "D10",
+    "reason": "missing-docstring checks off by choice; public-API docstrings are required by AGENTS.md and enforced in review. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "D212",
+    "reason": "docstring summary-position style choice. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "D415",
+    "reason": "docstring summary-punctuation style choice. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "E203",
+    "reason": "whitespace-before-punctuation conflicts with ruff format. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "E501",
+    "reason": "line length is handled by ruff format, not lint. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "PLW0127",
+    "reason": "self-assignment allowed by choice. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "PLW0603",
+    "reason": "global statement allowed by choice. Baselined (predates the ledger)"
+  },
+  {
+    "file": "pyproject.toml",
+    "location": "tool.ruff.lint",
+    "setting": "ignore",
+    "value": "PLW2901",
+    "reason": "loop-variable overwrite allowed by choice. Baselined (predates the ledger)"
+  }
+]

--- a/scripts/check_config_carveouts.py
+++ b/scripts/check_config_carveouts.py
@@ -107,7 +107,8 @@ def _scan_mypy(mypy: dict[str, Any], file: str) -> Iterator[Carveout]:
     for override in mypy.get("overrides", []):
         modules = override.get("module", [])
         modules = [modules] if isinstance(modules, str) else modules
-        location = f"tool.mypy.overrides[{','.join(modules)}]"
+        # sorted so reordering the module list doesn't churn the identity
+        location = f"tool.mypy.overrides[{','.join(sorted(modules))}]"
         yield from (
             Carveout(file, location, key, value)
             for key, value in _mypy_relaxations(override)
@@ -193,13 +194,31 @@ def scan_config(root: Path) -> list[Carveout]:
 
 
 def read_ledger(root: Path) -> dict[Carveout, str]:
+    # the ledger is hand-edited (reasons get filled in), so slips like invalid
+    # JSON, a missing/non-string field, or a duplicated entry need a legible
+    # error, not a traceback or a silent last-entry-wins collapse
     path = root / LEDGER_NAME
     if not path.exists():
         return {}
-    return {
-        Carveout(e["file"], e["location"], e["setting"], e["value"]): e["reason"]
-        for e in json.loads(path.read_text())
-    }
+    ledger: dict[Carveout, str] = {}
+    try:
+        for entry in json.loads(path.read_text()):
+            fields = [
+                entry[key] for key in ("file", "location", "setting", "value", "reason")
+            ]
+            if not all(isinstance(field, str) for field in fields):
+                raise TypeError(f"every field must be a string: {entry}")
+            carveout = Carveout(*fields[:4])
+            if carveout in ledger:
+                raise ValueError(f"duplicate entry for {carveout}")
+            ledger[carveout] = fields[4]
+    except (KeyError, TypeError, ValueError) as error:
+        sys.exit(
+            f"{LEDGER_NAME} is malformed — {type(error).__name__}: {error}."
+            f" Fix it by hand, or delete it and {UPDATE_HINT} to regenerate"
+            " (reasons will need re-entering)."
+        )
+    return ledger
 
 
 def write_ledger(root: Path, entries: dict[Carveout, str]) -> None:

--- a/scripts/check_config_carveouts.py
+++ b/scripts/check_config_carveouts.py
@@ -16,9 +16,9 @@ Scans (repo root only):
   ruff.toml / .ruff.toml
 
 Only settings that suppress or weaken diagnostics are flagged (e.g. mypy
-implicit_reexport = true, disable_error_code, disallow_* = false; ruff
-lint.ignore and per-file-ignores; pyright report* = false/"none").
-Formatting, path, and other benign config is not.
+implicit_reexport = true, disable_error_code, disallow_* = false, exclude;
+ruff lint.ignore, per-file-ignores, and exclude/extend-exclude; pyright
+report* = false/"none"). Formatting and other benign config is not.
 
 Checker config the gate cannot scan (mypy.ini, [mypy] sections in setup.cfg,
 pyrightconfig.json) fails the gate outright rather than being silently
@@ -85,6 +85,9 @@ def _mypy_relaxations(table: dict[str, Any]) -> Iterator[tuple[str, str]]:
         if key == "disable_error_code" and value:
             codes = value if isinstance(value, list) else [value]
             yield from (("disable_error_code", str(code)) for code in codes)
+        elif key == "exclude" and value:
+            patterns = value if isinstance(value, list) else [value]
+            yield from (("exclude", str(p)) for p in patterns)
         elif key == "follow_imports" and value in ("skip", "silent"):
             yield (key, str(value))
         elif key in _MYPY_RELAX_WHEN_TRUE and value is True:
@@ -117,6 +120,12 @@ def _scan_ruff_lint(
     for key in ("ignore", "extend-ignore"):
         yield from (
             Carveout(file, location, key, str(code)) for code in lint.get(key, [])
+        )
+    # excluding a path silences all lint for it — same relaxation channel as
+    # an ignore code, aimed at paths instead of rules
+    for key in ("exclude", "extend-exclude"):
+        yield from (
+            Carveout(file, location, key, str(path)) for path in lint.get(key, [])
         )
     for key in ("per-file-ignores", "extend-per-file-ignores"):
         for glob, codes in lint.get(key, {}).items():

--- a/scripts/check_config_carveouts.py
+++ b/scripts/check_config_carveouts.py
@@ -154,7 +154,10 @@ def _check_unscannable(root: Path) -> None:
     setup_cfg = root / "setup.cfg"
     if setup_cfg.exists():
         parser = configparser.ConfigParser()
-        parser.read(setup_cfg)
+        try:
+            parser.read(setup_cfg)
+        except configparser.Error as error:
+            sys.exit(f"setup.cfg is malformed — {type(error).__name__}: {error}")
         if any(s == "mypy" or s.startswith("mypy-") for s in parser.sections()):
             found.append("setup.cfg ([mypy] sections)")
     if found:
@@ -166,8 +169,11 @@ def _check_unscannable(root: Path) -> None:
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as f:
-        return tomllib.load(f)
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as error:
+        sys.exit(f"{path.name} is malformed — TOMLDecodeError: {error}")
 
 
 def scan_config(root: Path) -> list[Carveout]:

--- a/scripts/check_config_carveouts.py
+++ b/scripts/check_config_carveouts.py
@@ -66,6 +66,13 @@ def _render(value: object) -> str:
     return ("true" if value else "false") if isinstance(value, bool) else str(value)
 
 
+def _listify(value: Any) -> list[Any]:
+    # scalar-or-list settings: a bare string is one item, not its characters
+    if isinstance(value, list):
+        return value
+    return [value] if value else []
+
+
 # mypy knobs that relax checking when set to the given polarity. Everything
 # else in [tool.mypy] (paths, strictness enables, plugins) is benign.
 _MYPY_RELAX_WHEN_TRUE = {
@@ -82,12 +89,10 @@ _MYPY_RELAX_WHEN_FALSE = {"check_untyped_defs"}
 
 def _mypy_relaxations(table: dict[str, Any]) -> Iterator[tuple[str, str]]:
     for key, value in sorted(table.items()):
-        if key == "disable_error_code" and value:
-            codes = value if isinstance(value, list) else [value]
-            yield from (("disable_error_code", str(code)) for code in codes)
-        elif key == "exclude" and value:
-            patterns = value if isinstance(value, list) else [value]
-            yield from (("exclude", str(p)) for p in patterns)
+        if key == "disable_error_code":
+            yield from (("disable_error_code", str(code)) for code in _listify(value))
+        elif key == "exclude":
+            yield from (("exclude", str(p)) for p in _listify(value))
         elif key == "follow_imports" and value in ("skip", "silent"):
             yield (key, str(value))
         elif key in _MYPY_RELAX_WHEN_TRUE and value is True:
@@ -120,20 +125,19 @@ def _scan_ruff_lint(
 ) -> Iterator[Carveout]:
     for key in ("ignore", "extend-ignore"):
         yield from (
-            Carveout(file, location, key, str(code)) for code in lint.get(key, [])
+            Carveout(file, location, key, str(code)) for code in _listify(lint.get(key))
         )
     # excluding a path silences all lint for it — same relaxation channel as
     # an ignore code, aimed at paths instead of rules
     for key in ("exclude", "extend-exclude"):
         yield from (
-            Carveout(file, location, key, str(path)) for path in lint.get(key, [])
+            Carveout(file, location, key, str(path)) for path in _listify(lint.get(key))
         )
     for key in ("per-file-ignores", "extend-per-file-ignores"):
         for glob, codes in lint.get(key, {}).items():
-            codes = codes if isinstance(codes, list) else [codes]
             yield from (
                 Carveout(file, f"{location}.{key}", str(glob), str(code))
-                for code in codes
+                for code in _listify(codes)
             )
 
 

--- a/scripts/check_config_carveouts.py
+++ b/scripts/check_config_carveouts.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Gate for config-level checker relaxations ("carve-outs").
+
+config_carveouts.json (the ledger) must exactly match the checker-relaxing
+settings present in the repo's tool config — any add, remove, or change fails
+CI until the ledger is regenerated, so every carve-out shows up as a
+reviewable ledger diff in the PR. Every ledger entry must carry a reason.
+
+This is the config-level sibling of an inline-suppression gate: an agent (or
+human) who can't add `# type: ignore` unnoticed shouldn't be able to relax
+the checker in pyproject.toml unnoticed either.
+
+Scans (repo root only):
+  pyproject.toml  [tool.mypy], [[tool.mypy.overrides]],
+                  [tool.ruff] / [tool.ruff.lint], [tool.pyright]
+  ruff.toml / .ruff.toml
+
+Only settings that suppress or weaken diagnostics are flagged (e.g. mypy
+implicit_reexport = true, disable_error_code, disallow_* = false; ruff
+lint.ignore and per-file-ignores; pyright report* = false/"none").
+Formatting, path, and other benign config is not.
+
+Checker config the gate cannot scan (mypy.ini, [mypy] sections in setup.cfg,
+pyrightconfig.json) fails the gate outright rather than being silently
+ignored.
+
+Usage:
+  python3 scripts/check_config_carveouts.py            # check (CI)
+  python3 scripts/check_config_carveouts.py --update   # regenerate ledger,
+                                                       # preserving reasons
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    sys.exit("check_config_carveouts.py requires Python >= 3.11 (tomllib)")
+
+LEDGER_NAME = "config_carveouts.json"
+UPDATE_HINT = "run `python3 scripts/check_config_carveouts.py --update`"
+
+
+@dataclass(frozen=True, order=True)
+class Carveout:
+    """One checker-relaxing setting at one config location."""
+
+    file: str
+    location: str
+    setting: str
+    value: str
+
+    def __str__(self) -> str:
+        return f"{self.file}: [{self.location}] {self.setting} = {self.value}"
+
+
+def _render(value: object) -> str:
+    return ("true" if value else "false") if isinstance(value, bool) else str(value)
+
+
+# mypy knobs that relax checking when set to the given polarity. Everything
+# else in [tool.mypy] (paths, strictness enables, plugins) is benign.
+_MYPY_RELAX_WHEN_TRUE = {
+    "ignore_errors",
+    "ignore_missing_imports",
+    "implicit_reexport",
+    "implicit_optional",
+    "allow_untyped_globals",
+    "allow_redefinition",
+}
+_MYPY_RELAX_WHEN_FALSE_PREFIXES = ("disallow_", "warn_", "strict", "no_implicit_")
+_MYPY_RELAX_WHEN_FALSE = {"check_untyped_defs"}
+
+
+def _mypy_relaxations(table: dict[str, Any]) -> Iterator[tuple[str, str]]:
+    for key, value in sorted(table.items()):
+        if key == "disable_error_code" and value:
+            codes = value if isinstance(value, list) else [value]
+            yield from (("disable_error_code", str(code)) for code in codes)
+        elif key == "follow_imports" and value in ("skip", "silent"):
+            yield (key, str(value))
+        elif key in _MYPY_RELAX_WHEN_TRUE and value is True:
+            yield (key, "true")
+        elif value is False and (
+            key.startswith(_MYPY_RELAX_WHEN_FALSE_PREFIXES)
+            or key in _MYPY_RELAX_WHEN_FALSE
+        ):
+            yield (key, "false")
+
+
+def _scan_mypy(mypy: dict[str, Any], file: str) -> Iterator[Carveout]:
+    yield from (
+        Carveout(file, "tool.mypy", key, value)
+        for key, value in _mypy_relaxations(mypy)
+    )
+    for override in mypy.get("overrides", []):
+        modules = override.get("module", [])
+        modules = [modules] if isinstance(modules, str) else modules
+        location = f"tool.mypy.overrides[{','.join(modules)}]"
+        yield from (
+            Carveout(file, location, key, value)
+            for key, value in _mypy_relaxations(override)
+        )
+
+
+def _scan_ruff_lint(
+    lint: dict[str, Any], location: str, file: str
+) -> Iterator[Carveout]:
+    for key in ("ignore", "extend-ignore"):
+        yield from (
+            Carveout(file, location, key, str(code)) for code in lint.get(key, [])
+        )
+    for key in ("per-file-ignores", "extend-per-file-ignores"):
+        for glob, codes in lint.get(key, {}).items():
+            codes = codes if isinstance(codes, list) else [codes]
+            yield from (
+                Carveout(file, f"{location}.{key}", str(glob), str(code))
+                for code in codes
+            )
+
+
+def _scan_pyright(table: dict[str, Any], file: str) -> Iterator[Carveout]:
+    for key, value in sorted(table.items()):
+        if key.startswith("report") and (value is False or value == "none"):
+            yield Carveout(file, "tool.pyright", key, _render(value))
+        elif key == "typeCheckingMode" and value in ("off", "basic"):
+            yield Carveout(file, "tool.pyright", key, str(value))
+
+
+def _check_unscannable(root: Path) -> None:
+    found = [
+        name
+        for name in ("mypy.ini", ".mypy.ini", "pyrightconfig.json")
+        if (root / name).exists()
+    ]
+    setup_cfg = root / "setup.cfg"
+    if setup_cfg.exists():
+        parser = configparser.ConfigParser()
+        parser.read(setup_cfg)
+        if any(s == "mypy" or s.startswith("mypy-") for s in parser.sections()):
+            found.append("setup.cfg ([mypy] sections)")
+    if found:
+        sys.exit(
+            "check_config_carveouts.py only scans pyproject.toml and ruff.toml; "
+            f"found checker config it cannot scan: {', '.join(found)}. "
+            "Move that config into pyproject.toml or extend the gate."
+        )
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def scan_config(root: Path) -> list[Carveout]:
+    _check_unscannable(root)
+    found: list[Carveout] = []
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        tool = _load_toml(pyproject).get("tool", {})
+        found += _scan_mypy(tool.get("mypy", {}), "pyproject.toml")
+        ruff = tool.get("ruff", {})
+        # legacy pre-0.2 layout put lint settings directly under [tool.ruff]
+        found += _scan_ruff_lint(ruff, "tool.ruff", "pyproject.toml")
+        found += _scan_ruff_lint(
+            ruff.get("lint", {}), "tool.ruff.lint", "pyproject.toml"
+        )
+        found += _scan_pyright(tool.get("pyright", {}), "pyproject.toml")
+    for name in ("ruff.toml", ".ruff.toml"):
+        path = root / name
+        if path.exists():
+            data = _load_toml(path)
+            found += _scan_ruff_lint(data, "ruff", name)
+            found += _scan_ruff_lint(data.get("lint", {}), "lint", name)
+    return sorted(set(found))
+
+
+def read_ledger(root: Path) -> dict[Carveout, str]:
+    path = root / LEDGER_NAME
+    if not path.exists():
+        return {}
+    return {
+        Carveout(e["file"], e["location"], e["setting"], e["value"]): e["reason"]
+        for e in json.loads(path.read_text())
+    }
+
+
+def write_ledger(root: Path, entries: dict[Carveout, str]) -> None:
+    payload = [
+        {
+            "file": c.file,
+            "location": c.location,
+            "setting": c.setting,
+            "value": c.value,
+            "reason": reason,
+        }
+        for c, reason in sorted(entries.items())
+    ]
+    (root / LEDGER_NAME).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check config-level checker relaxations against the ledger."
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="regenerate the ledger from current config, preserving reasons",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repo root to scan (default: this script's repo)",
+    )
+    args = parser.parse_args()
+    root: Path = args.root
+
+    actual = scan_config(root)
+    ledger = read_ledger(root)
+
+    if args.update:
+        merged = {c: ledger.get(c, "") for c in actual}
+        write_ledger(root, merged)
+        print(f"{LEDGER_NAME} updated: {len(merged)} carve-out(s).")
+        missing = [c for c, reason in merged.items() if not reason.strip()]
+        for c in missing:
+            print(f"NEEDS REASON: {c}", file=sys.stderr)
+        if missing:
+            print(
+                f'Fill in the empty "reason" fields in {LEDGER_NAME} before committing.',
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    recorded = set(ledger)
+    failures = [
+        f"NEW: {c} — not recorded in {LEDGER_NAME}. Fix the root cause instead if at"
+        f" all possible; a genuinely unavoidable carve-out needs a reason:"
+        f" {UPDATE_HINT}, fill in the reason, and get maintainer sign-off on the"
+        f" ledger diff."
+        if c not in recorded
+        else f"NO REASON: {c} — ledger entry has an empty reason. Add one in {LEDGER_NAME}."
+        for c in actual
+        if c not in recorded or not ledger[c].strip()
+    ] + [
+        f"REMOVED: {c} — in {LEDGER_NAME} but no longer in config."
+        f" {UPDATE_HINT} to record the shrink."
+        for c in sorted(recorded - set(actual))
+    ]
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print(
+        f"config carve-out ledger matches: {len(actual)} carve-out(s)"
+        f" recorded in {LEDGER_NAME}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -70,6 +70,21 @@ def run_gate(root: Path, *args: str) -> "subprocess.CompletedProcess[str]":
             "[tool.pyright] reportMissingImports = false",
             id="pyright-report-off",
         ),
+        pytest.param(
+            '[tool.mypy]\nexclude = ["src/legacy/"]\n',
+            "[tool.mypy] exclude = src/legacy/",
+            id="mypy-exclude",
+        ),
+        pytest.param(
+            '[tool.ruff]\nextend-exclude = ["scripts"]\n',
+            "[tool.ruff] extend-exclude = scripts",
+            id="ruff-extend-exclude",
+        ),
+        pytest.param(
+            '[tool.ruff.lint]\nexclude = ["scripts/*.py"]\n',
+            "[tool.ruff.lint] exclude = scripts/*.py",
+            id="ruff-lint-exclude",
+        ),
     ],
 )
 def test_detects_relaxation(tmp_path: Path, config: str, expected: str) -> None:

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -1,0 +1,159 @@
+"""Tests for the config carve-out gate (scripts/check_config_carveouts.py)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "check_config_carveouts.py"
+)
+
+SCOUT_STYLE_OVERRIDE = """\
+[[tool.mypy.overrides]]
+module = ["inspect_ai._cli.util"]
+implicit_reexport = true
+"""
+
+
+def run_gate(root: Path, *args: str) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param(
+            SCOUT_STYLE_OVERRIDE,
+            "[tool.mypy.overrides[inspect_ai._cli.util]] implicit_reexport = true",
+            id="mypy-override-implicit-reexport",
+        ),
+        pytest.param(
+            "[tool.mypy]\ndisallow_untyped_defs = false\n",
+            "[tool.mypy] disallow_untyped_defs = false",
+            id="mypy-global-disallow-false",
+        ),
+        pytest.param(
+            '[tool.mypy]\ndisable_error_code = ["union-attr"]\n',
+            "[tool.mypy] disable_error_code = union-attr",
+            id="mypy-disable-error-code",
+        ),
+        pytest.param(
+            '[tool.mypy]\nfollow_imports = "skip"\n',
+            "[tool.mypy] follow_imports = skip",
+            id="mypy-follow-imports-skip",
+        ),
+        pytest.param(
+            '[tool.ruff.lint]\nignore = ["E501"]\n',
+            "[tool.ruff.lint] ignore = E501",
+            id="ruff-lint-ignore",
+        ),
+        pytest.param(
+            '[tool.ruff.lint.per-file-ignores]\n"tests/*" = ["D103"]\n',
+            "[tool.ruff.lint.per-file-ignores] tests/* = D103",
+            id="ruff-per-file-ignores",
+        ),
+        pytest.param(
+            "[tool.pyright]\nreportMissingImports = false\n",
+            "[tool.pyright] reportMissingImports = false",
+            id="pyright-report-off",
+        ),
+    ],
+)
+def test_detects_relaxation(tmp_path: Path, config: str, expected: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(config)
+    result = run_gate(tmp_path)
+    assert result.returncode == 1
+    assert "NEW:" in result.stderr
+    assert expected in result.stderr
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(
+            '[tool.mypy]\nstrict = true\nmypy_path = "src"\nfiles = ["src"]\n',
+            id="mypy-tightening-and-paths",
+        ),
+        pytest.param(
+            '[tool.ruff]\nsrc = ["."]\n[tool.ruff.lint]\nselect = ["E", "F"]\n',
+            id="ruff-select-and-paths",
+        ),
+    ],
+)
+def test_ignores_benign_config(tmp_path: Path, config: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(config)
+    result = run_gate(tmp_path)
+    assert result.returncode == 0
+
+
+def test_ruff_toml_scanned(tmp_path: Path) -> None:
+    (tmp_path / "ruff.toml").write_text('[lint]\nignore = ["E501"]\n')
+    result = run_gate(tmp_path)
+    assert result.returncode == 1
+    assert "ruff.toml: [lint] ignore = E501" in result.stderr
+
+
+def test_unscannable_checker_config_fails(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.mypy]\nstrict = true\n")
+    (tmp_path / "mypy.ini").write_text("[mypy]\n")
+    result = run_gate(tmp_path)
+    assert result.returncode != 0
+    assert "mypy.ini" in result.stderr
+
+
+def test_record_and_shrink_flow(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "config_carveouts.json"
+    (tmp_path / "pyproject.toml").write_text(SCOUT_STYLE_OVERRIDE)
+
+    # unrecorded carve-out fails the gate
+    assert run_gate(tmp_path).returncode == 1
+
+    # --update records it but demands a reason
+    update = run_gate(tmp_path, "--update")
+    assert update.returncode == 1
+    assert "NEEDS REASON" in update.stderr
+    entries = json.loads(ledger_path.read_text())
+    assert entries[0]["setting"] == "implicit_reexport"
+    assert entries[0]["reason"] == ""
+
+    # empty reason still fails the check
+    check = run_gate(tmp_path)
+    assert check.returncode == 1
+    assert "NO REASON" in check.stderr
+
+    # filled reason passes
+    entries[0]["reason"] = "upstream re-export quirk; tracked in #000"
+    ledger_path.write_text(json.dumps(entries))
+    assert run_gate(tmp_path).returncode == 0
+
+    # removing the carve-out leaves a stale ledger entry; --update records the shrink
+    (tmp_path / "pyproject.toml").write_text("[tool.mypy]\nstrict = true\n")
+    stale = run_gate(tmp_path)
+    assert stale.returncode == 1
+    assert "REMOVED:" in stale.stderr
+    assert run_gate(tmp_path, "--update").returncode == 0
+    assert run_gate(tmp_path).returncode == 0
+
+
+def test_update_preserves_existing_reasons(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "config_carveouts.json"
+    (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nignore = ["E501"]\n')
+    run_gate(tmp_path, "--update")
+    entries = json.loads(ledger_path.read_text())
+    entries[0]["reason"] = "kept reason"
+    ledger_path.write_text(json.dumps(entries))
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff.lint]\nignore = ["E501", "D10"]\n'
+    )
+    run_gate(tmp_path, "--update")
+    reasons = {e["value"]: e["reason"] for e in json.loads(ledger_path.read_text())}
+    assert reasons == {"E501": "kept reason", "D10": ""}

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -61,6 +61,16 @@ def run_gate(root: Path, *args: str) -> "subprocess.CompletedProcess[str]":
             id="ruff-lint-ignore",
         ),
         pytest.param(
+            '[tool.ruff.lint]\nignore = "E501"\n',
+            "[tool.ruff.lint] ignore = E501",
+            id="ruff-lint-ignore-string-scalar",
+        ),
+        pytest.param(
+            '[tool.mypy]\nexclude = "src/legacy/"\n',
+            "[tool.mypy] exclude = src/legacy/",
+            id="mypy-exclude-string-scalar",
+        ),
+        pytest.param(
             '[tool.ruff.lint.per-file-ignores]\n"tests/*" = ["D103"]\n',
             "[tool.ruff.lint.per-file-ignores] tests/* = D103",
             id="ruff-per-file-ignores",

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -163,6 +163,55 @@ def test_record_and_shrink_flow(tmp_path: Path) -> None:
     assert run_gate(tmp_path).returncode == 0
 
 
+@pytest.mark.parametrize(
+    "ledger_text",
+    [
+        pytest.param("{not json", id="invalid-json"),
+        pytest.param('[{"file": "pyproject.toml"}]', id="missing-fields"),
+        pytest.param(
+            '[{"file": "f", "location": "l", "setting": "s",'
+            ' "value": "v", "reason": null}]',
+            id="non-string-reason",
+        ),
+    ],
+)
+def test_malformed_ledger_fails_cleanly(tmp_path: Path, ledger_text: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(SCOUT_STYLE_OVERRIDE)
+    (tmp_path / "config_carveouts.json").write_text(ledger_text)
+    result = run_gate(tmp_path)
+    assert result.returncode == 1
+    assert "malformed" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_duplicate_ledger_entries_fail(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "config_carveouts.json"
+    (tmp_path / "pyproject.toml").write_text(SCOUT_STYLE_OVERRIDE)
+    run_gate(tmp_path, "--update")
+    entries = json.loads(ledger_path.read_text())
+    entries[0]["reason"] = "real reason"
+    ledger_path.write_text(json.dumps(entries + [dict(entries[0], reason="")]))
+    result = run_gate(tmp_path)
+    assert result.returncode == 1
+    assert "duplicate entry" in result.stderr
+
+
+def test_override_identity_ignores_module_order(tmp_path: Path) -> None:
+    def override(modules: str) -> str:
+        return f"[[tool.mypy.overrides]]\nmodule = [{modules}]\nignore_errors = true\n"
+
+    ledger_path = tmp_path / "config_carveouts.json"
+    (tmp_path / "pyproject.toml").write_text(override('"b_mod", "a_mod"'))
+    run_gate(tmp_path, "--update")
+    entries = json.loads(ledger_path.read_text())
+    entries[0]["reason"] = "shared reason"
+    ledger_path.write_text(json.dumps(entries))
+    assert run_gate(tmp_path).returncode == 0
+
+    (tmp_path / "pyproject.toml").write_text(override('"a_mod", "b_mod"'))
+    assert run_gate(tmp_path).returncode == 0
+
+
 def test_update_preserves_existing_reasons(tmp_path: Path) -> None:
     ledger_path = tmp_path / "config_carveouts.json"
     (tmp_path / "pyproject.toml").write_text('[tool.ruff.lint]\nignore = ["E501"]\n')

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="the gate script requires tomllib (Python >= 3.11)",
+)
+
 SCRIPT = (
     Path(__file__).resolve().parent.parent / "scripts" / "check_config_carveouts.py"
 )

--- a/tests/test_config_carveouts.py
+++ b/tests/test_config_carveouts.py
@@ -184,6 +184,23 @@ def test_malformed_ledger_fails_cleanly(tmp_path: Path, ledger_text: str) -> Non
     assert "Traceback" not in result.stderr
 
 
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        pytest.param("pyproject.toml", "[tool.mypy\nstrict = true\n", id="bad-toml"),
+        pytest.param("setup.cfg", "no section header\n", id="bad-setup-cfg"),
+    ],
+)
+def test_malformed_config_fails_cleanly(
+    tmp_path: Path, filename: str, content: str
+) -> None:
+    (tmp_path / filename).write_text(content)
+    result = run_gate(tmp_path)
+    assert result.returncode == 1
+    assert "malformed" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_duplicate_ledger_entries_fail(tmp_path: Path) -> None:
     ledger_path = tmp_path / "config_carveouts.json"
     (tmp_path / "pyproject.toml").write_text(SCOUT_STYLE_OVERRIDE)


### PR DESCRIPTION
## What

A worker recently "fixed" a broken import by relaxing mypy in pyproject.toml:

```toml
[[tool.mypy.overrides]]
module = ["inspect_ai._cli.util"]
implicit_reexport = true
```

A human caught it by hand. ts-mono's suppression gate turns every inline suppression into a reviewable ledger diff, but a config-level relaxation like this one leaves no trace anywhere a gate looks. This PR is a prototype of the config-level sibling of that gate.

- `scripts/check_config_carveouts.py` (stdlib only, needs Python >= 3.11 for tomllib): scans root-level config for checker-relaxing settings and compares them to `config_carveouts.json`. Any unrecorded addition, stale ledger entry, or empty reason fails. `--update` regenerates the ledger and preserves existing reasons.
- `config_carveouts.json`: scout's 10 current carve-outs (the harbor mypy override, 8 ruff ignore codes, and the ruff `extend-exclude = ["docs"]`), baselined as-is, each with a reason.
- CI job `config-carveouts` in build.yaml. Checkout plus the runner's python3, no installs, so it costs a few seconds.
- `make carveouts`, wired into `make check`.
- AGENTS.md section: a carve-out that silences a checker is a smell; name the root cause, check for an established in-repo practice, escalate rather than work around; new carve-outs need a reason and sign-off in the ledger.
- `tests/test_config_carveouts.py`: detection table plus the record/shrink flow, run as subprocesses against the script's CLI.

## What counts as a carve-out

Only settings that suppress or weaken diagnostics:

- mypy, in `[tool.mypy]` and `[[tool.mypy.overrides]]`: `ignore_errors`, `ignore_missing_imports`, `implicit_reexport`, `implicit_optional`, `allow_untyped_globals`, `allow_redefinition` set true; `disallow_*`, `warn_*`, `strict*`, `no_implicit_*`, `check_untyped_defs` set false; `disable_error_code` (one entry per code); `follow_imports = "skip" | "silent"`
- ruff: `lint.ignore` and `extend-ignore` (one entry per code), `per-file-ignores` (one entry per glob and code), in pyproject.toml (current and legacy pre-0.2 locations) and ruff.toml / .ruff.toml
- pyright, `[tool.pyright]`: `report* = false | "none"`, `typeCheckingMode = "off" | "basic"`. Scout doesn't use pyright today; the check is a few lines, so it's in.

Benign config (paths, `select`, formatting) is not flagged. Checker config the gate can't parse (mypy.ini, `[mypy]` sections in setup.cfg, pyrightconfig.json) fails the gate outright instead of being silently ignored.

## Proof it catches the original incident

```
$ python3 scripts/check_config_carveouts.py
config carve-out ledger matches: 9 carve-out(s) recorded in config_carveouts.json.

$ # add the exact override from the incident to pyproject.toml, then:
$ python3 scripts/check_config_carveouts.py
NEW: pyproject.toml: [tool.mypy.overrides[inspect_ai._cli.util]] implicit_reexport = true — not recorded in config_carveouts.json. Fix the root cause instead if at all possible; a genuinely unavoidable carve-out needs a reason: run `python3 scripts/check_config_carveouts.py --update`, fill in the reason, and get maintainer sign-off on the ledger diff.
(exit 1)

$ python3 scripts/check_config_carveouts.py --update
NEEDS REASON: pyproject.toml: [tool.mypy.overrides[inspect_ai._cli.util]] implicit_reexport = true
Fill in the empty "reason" fields in config_carveouts.json before committing.
(exit 1)

$ # fill in the reason, then:
$ python3 scripts/check_config_carveouts.py
config carve-out ledger matches: 10 carve-out(s) recorded in config_carveouts.json.

$ # revert the override; the stale ledger entry now fails until --update records the shrink
$ python3 scripts/check_config_carveouts.py
REMOVED: pyproject.toml: [tool.mypy.overrides[inspect_ai._cli.util]] implicit_reexport = true — in config_carveouts.json but no longer in config. run `python3 scripts/check_config_carveouts.py --update` to record the shrink.
(exit 1)
```

So the agent that wants to land a carve-out has exactly one path: record it in the ledger with a reason, which puts it in front of a reviewer as a ledger diff.

## Design decisions

1. Reasons live in the ledger JSON, not in TOML comments. tomllib drops comments, so a comment-based reason can't be checked. ts-mono keeps reasons in the code comments and its ledger only counts them; here the ledger is the only place a reason can exist. Consequence: `--update` writes new entries with an empty reason and exits nonzero until someone fills it in, so recording is a deliberate two-step.
2. No undescribed-count allowance like ts-mono's. Every entry needs a nonempty reason, including the baseline. The baseline was 9 entries, small enough to annotate directly.
3. An entry's identity includes its value, so changing a carve-out's value shows up as remove plus add and needs a fresh reason.
4. One ledger entry per ruff ignore code and per mypy knob, not per list. Adding a 9th ignore code is one NEW line naming that code.

## Open questions for review

1. The knob list is curated, not exhaustive. A relaxing mypy flag we didn't list slips through, though the prefix rules (`disallow_*`, `warn_*`, `strict*`, `no_implicit_*`) cover most of the space. Is curated acceptable, or should unknown keys in an override table be flagged by default?
2. Blind spot: the gate sees relaxations that are present, not tightenings that are deleted. Removing `strict = true` or dropping a code from ruff `select` doesn't trip it. Catching that means ledgering the full effective config, a much bigger tool. Left out on purpose; is that acceptable?
3. Root-level config files only. Nested ruff.toml in subdirectories isn't scanned. Fine for scout's layout; extending it means walking `git ls-files`.
4. Later unification with an inline suppression gate (scout doesn't have one yet): the two would share the ledger-diff pattern but probably not code (node vs python). Worth porting the ts-mono inline gate here as a follow-up?
5. Porting this gate to other repos: nothing in the script is scout-specific, it should drop into any pyproject-based Python repo. ts-mono would need an eslint/tsconfig equivalent instead.

Prototype for review. Not intended to merge without sign-off on the approach.

