### PR TITLE
docs: require a linked issue or crisp minimal repro on bug-fix PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Development setup (editable install, inspect_ai tracked from `main`, frontend/Gi
 - Body lines starting with `<type>:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
 - Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
 - After opening a PR, watch its checks until they complete (`gh pr checks <number> --watch`); investigate and fix any failures
+- A bug-fix PR needs a linked issue or a crisp minimal repro that *demonstrates* the bug—a real affected input or reproducible steps, not just an asserted root cause. A regression test that encodes an unproven premise doesn't count. Without one, review is deferred until you add it
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines
 
 ### Agent review disclosure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,7 @@ stays out of the headline sections.
 ## Reporting issues
 
 Found a bug or have a feature request? Please open an issue on the [GitHub issue tracker](https://github.com/meridianlabs-ai/inspect_scout/issues).
+
+## Bug-fix pull requests
+
+A bug-fix PR should either link the issue it resolves or include a crisp minimal repro that **demonstrates** the bug: a real affected input, or steps that reproduce it, alongside the root cause. Show the repro rather than asserting the cause. That lets a reviewer confirm the diagnosis instead of reverse-engineering it, and keeps the PR from stalling. Without an issue or a demonstrated repro, review is deferred until you add one.


### PR DESCRIPTION
Documents, contributor-side, the rule we apply at intake: a bug-fix PR should link an issue or include a crisp minimal repro that *demonstrates* the bug (a real affected input or reproducible steps), not just assert a root cause. A regression test encoding an unproven premise doesn't clear it.

Added to both AGENTS.md (agent-opened PRs) and CONTRIBUTING.md (human contributors). Prompted by a PR whose stated root cause contradicted the loader's own documented ordering invariant, which a demonstrated repro would have surfaced up front.

Docs only.