### PR TITLE
ci: gate inline lint/type suppressions behind a reviewed ledger

### DIFF
--- a/.github/workflows/suppressions-comment.yml
+++ b/.github/workflows/suppressions-comment.yml
@@ -1,0 +1,85 @@
+# Posts the sticky suppression-ledger delta comment on PRs, fork PRs
+# included — see scripts/suppressions_pr_delta.py and the
+# "Suppression gate" section in AGENTS.md.
+#
+# SECURITY MODEL — read before editing.
+#
+# This workflow runs on pull_request_target, which executes in the BASE
+# repo's context with a WRITE token even for fork PRs. That is the only
+# reason it exists: the plain pull_request token on a fork PR is read-only
+# and cannot post the comment (enforcement lives in suppressions.yml,
+# where read-only is enough). A pull_request_target workflow that runs
+# PR-controlled code hands that write token to the PR author, so this job
+# keeps three invariants:
+#
+#   1. Only BASE code runs. The checkout below has no `ref`, so it checks
+#      out the base branch: the delta script and the base ledger are the
+#      base repo's own trusted copies. A PR's changes to the script take
+#      effect only after a maintainer merges them.
+#   2. PR content is data, never code. The PR's suppressions.json is read
+#      with `git show` on the fetched head ref — that reads a blob and
+#      executes nothing. The PR head is never checked out.
+#   3. No dependency installs. The delta script is stdlib-only by design;
+#      installing the project (pip/uv) would execute PR-controllable
+#      setup and dependency code.
+#
+# Do NOT "fix" this workflow by checking out the PR head, running any
+# script from it, or adding an install step — any of those breaks the
+# security model.
+name: Suppressions comment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - "release/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      # No `ref`: on pull_request_target this checks out the BASE branch
+      # (trusted script + base ledger). Never add ref: pull_request.head.
+      - uses: actions/checkout@v4
+
+      - name: Comment ledger delta on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # The PR's ledger is fetched and read as DATA: `git show` reads
+          # a blob and executes nothing. The PR head is never checked out.
+          git fetch --depth=1 origin "pull/$PR/head"
+          git show FETCH_HEAD:suppressions.json > /tmp/head-suppressions.json 2>/dev/null \
+            || echo '{}' > /tmp/head-suppressions.json
+          # The workspace is the base branch, so its ledger is the base side.
+          if [ -f suppressions.json ]; then
+            cp suppressions.json /tmp/base-suppressions.json
+          else
+            echo '{}' > /tmp/base-suppressions.json
+          fi
+          # Base script, system python, stdlib only — no installs (see the
+          # security model above).
+          body=$(python3 scripts/suppressions_pr_delta.py /tmp/base-suppressions.json /tmp/head-suppressions.json)
+          # Sticky comment: match on the marker, not --edit-last, so other
+          # bot comments on the PR are never clobbered.
+          cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            -q '.[] | select(.body | startswith("<!-- suppressions-delta -->")) | .id' | head -1)
+          if [ -n "$body" ] && [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" -f body="$body" > /dev/null
+          elif [ -n "$body" ]; then
+            gh pr comment "$PR" --body "$body"
+          elif [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" \
+              -f body="$(printf '<!-- suppressions-delta -->\nThis PR no longer changes the suppression ledger.')" > /dev/null
+          fi

--- a/.github/workflows/suppressions.yml
+++ b/.github/workflows/suppressions.yml
@@ -1,0 +1,47 @@
+# Suppression ledger gate — see scripts/check_suppressions.py and the
+# "Suppression gate" section in AGENTS.md. Enforcement only: it runs
+# fine with the read-only token fork PRs get. The PR delta comment is
+# posted by suppressions-comment.yml (pull_request_target), which needs a
+# write token — keep the two concerns in their separate workflows.
+name: Suppressions
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  suppressions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # setup-python rather than the runner's system python: Ubuntu 24.04
+      # marks system python externally-managed, so `pip install` there fails.
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      # The gate is stdlib-only by design: no dependency install needed.
+      - name: Check suppressions ledger
+        run: python3 scripts/check_suppressions.py
+
+      # --noconftest / addopts="": the gate test is self-contained; skip
+      # tests/conftest.py and the xdist addopts so a bare pytest install
+      # suffices.
+      - name: Test the gate script
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest --noconftest -o addopts="" -q tests/test_check_suppressions.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,15 @@ Development setup (editable install, inspect_ai tracked from `main`, frontend/Gi
 - Respect existing patterns
 - Before committing, run the appropriate checks for code you touched (lint, typecheck, test)
 
+### Suppression gate
+
+- Do NOT suppress lint or type errors (`# noqa`, `# type: ignore`, `# pyright: ignore`, or the file-wide `# ruff: noqa` / `# mypy: ignore-errors`). Fix the code. A deterministic gate enforces this (`make suppressions-check` against `suppressions.json`); maintainers reject suppressions that just make an error go away.
+- In the rare case a suppression is correct, it requires both: a reason in a trailing hash comment segment on the same line, the only style mypy accepts (e.g. `x = f()  # type: ignore[assignment]  # stub is wrong upstream`), and `make suppressions-update` to record it in `suppressions.json`. Always suppress the specific code (`# noqa: E501`, `# type: ignore[assignment]`), never the bare code-less form.
+- Every new suppression requires human maintainer approval; when it changes aggregate counts, that approval includes the `suppressions.json` diff. Expect the PR to be blocked until then, and say in the PR description why no fix is possible.
+- The ledger tracks aggregate counts by file and rule, not individual source locations. Moving or replacing the same rule within one file does not alter the ledger, so reviewers must still inspect suppression changes in the source diff.
+- If the `suppressions` CI check fails, never hand-edit the ledger to make it pass. Run `make suppressions-update` so the change shows in the ledger diff. `--update` refuses to grow any rule's repo-wide reason-less total (the ratchet): new suppressions must carry a reason, and the baselined reason-less ones burn down over time.
+- Merges from upstream are the one sanctioned ratchet exception: when a sync brings in new reason-less suppressions, do not edit the upstream-owned lines to add reasons (that creates permanent merge drift). Instead run `python3 scripts/check_suppressions.py --update --allow-growth` to record them; it prints each rule that grew, and the growth still shows in the ledger diff for maintainer review.
+
 ### Testing
 - Test observable behavior, not internal implementation details
 - Do not test things that are enforced by the type system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Development setup (editable install, inspect_ai tracked from `main`, frontend/Gi
 - Every new suppression requires human maintainer approval; when it changes aggregate counts, that approval includes the `suppressions.json` diff. Expect the PR to be blocked until then, and say in the PR description why no fix is possible.
 - The ledger tracks aggregate counts by file and rule, not individual source locations. Moving or replacing the same rule within one file does not alter the ledger, so reviewers must still inspect suppression changes in the source diff.
 - If the `suppressions` CI check fails, never hand-edit the ledger to make it pass. Run `make suppressions-update` so the change shows in the ledger diff. `--update` refuses to grow any rule's repo-wide reason-less total (the ratchet): new suppressions must carry a reason, and the baselined reason-less ones burn down over time.
-- Merges from upstream are the one sanctioned ratchet exception: when a sync brings in new reason-less suppressions, do not edit the upstream-owned lines to add reasons (that creates permanent merge drift). Instead run `python3 scripts/check_suppressions.py --update --allow-growth` to record them; it prints each rule that grew, and the growth still shows in the ledger diff for maintainer review.
+- Code imported wholesale from another repo is the one allowed ratchet exception: when a sync brings in new reason-less suppressions on lines we shouldn't rewrite (editing them creates permanent merge drift), run `python3 scripts/check_suppressions.py --update --allow-growth` to record them; it prints each rule that grew, and the growth still shows in the ledger diff for maintainer review.
 
 ### Testing
 - Test observable behavior, not internal implementation details

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,16 @@ ruff:
 mypy:
 	mypy src examples tests
 
+.PHONY: suppressions-check
+suppressions-check:
+	python3 scripts/check_suppressions.py
+
+.PHONY: suppressions-update
+suppressions-update:
+	python3 scripts/check_suppressions.py --update
+
 .PHONY: check
-check: ruff mypy
+check: ruff mypy suppressions-check
 
 .PHONY: test
 test:

--- a/scripts/check_suppressions.py
+++ b/scripts/check_suppressions.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Gate for lint/type-check suppression comments.
+
+suppressions.json (the ledger) must exactly match the per-file, per-rule
+suppression counts in the code. Count and reason-status changes fail CI until
+the ledger is regenerated, so they show up as a reviewable ledger diff in the
+PR. Moving or replacing an occurrence within the same file under the same rule
+does not change these aggregate counts and is reviewed in the source diff.
+
+The `undescribed` count (suppressions lacking a reason — a trailing hash
+comment segment on the same line, the only style mypy accepts after
+`type: ignore`) is a ratchet: --update refuses to increase any rule's
+repo-wide total, so new suppressions must carry a reason while the
+baselined reason-less ones burn down over time. The ratchet is per rule,
+not per file, so moving a file doesn't trip it. `--update --allow-growth`
+overrides the refusal for the one sanctioned case — a merge from upstream
+that brings in reason-less suppressions on lines this repo must not edit —
+and prints every rule that grew so the override is loud in the run log
+(the growth still shows in the ledger diff for review). See the
+"Suppression gate" section in AGENTS.md.
+
+Scanned directives (found via tokenize, so directive text inside string
+literals is never counted):
+  line-level: noqa / noqa: <codes> (ruff), type: ignore /
+    type: ignore[<codes>] (mypy), pyright: ignore / pyright: ignore[<rules>]
+  file-wide: ruff: noqa / flake8: noqa (optionally with codes),
+    mypy: ignore-errors, mypy: disable-error-code=<codes>
+
+Stdlib only by design — CI runs it with no dependency install.
+"""
+
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tokenize
+from pathlib import Path
+from typing import NamedTuple
+
+LEDGER_PATH = Path("suppressions.json")
+UPDATE_HINT = "run `make suppressions-update`"
+
+# File-wide directives suppress for the whole file. Key them distinguishably
+# so swapping a line-scoped directive for the file-wide form is a ledger
+# diff, not a count-neutral no-op.
+FILE_WIDE = " (file-wide)"
+
+_NOQA_CODES = r"[A-Z]+[0-9]+(?:[,\s]+[A-Z]+[0-9]+)*"
+_BRACKET = r"\[\s*(?P<{name}>[\w-]+(?:\s*,\s*[\w-]+)*)\s*\]"
+
+# A directive counts only when it opens a comment segment (anchored at `#`),
+# mirroring how ruff and mypy themselves locate directives, so prose like
+# "remove the type: ignore below" never matches.
+#
+# The file-level ruff/flake8 form is spelled loosely to match what ruff
+# honors (verified against the pinned ruff): the noqa token in any case and
+# whitespace tolerated around the colons ("ruff : NOQA" suppresses
+# file-wide). The ruff/flake8 prefix itself stays case-sensitive — ruff
+# ignores "RUFF: NOQA" (verified).
+DIRECTIVE_RE = re.compile(
+    r"""\#+\s*(?:
+        (?:ruff|flake8)\s*:\s*(?P<file_noqa>(?i:noqa))(?:\s*:\s*(?P<file_noqa_codes>{noqa_codes}))?
+      | (?P<noqa>(?i:noqa))(?![\w])(?:\s*:\s*(?P<noqa_codes>{noqa_codes}))?
+      | type:\s*(?P<type_ignore>ignore)(?![\w])(?:\s*{type_codes})?
+      | pyright:\s*(?P<pyright>ignore)(?![\w])(?:\s*{pyright_codes})?
+      | mypy:\s*(?:
+            (?P<mypy_ignore>ignore-errors)(?![\w-])
+          | disable-error-code\s*=\s*"?(?P<mypy_codes>[\w-]+(?:\s*,\s*[\w-]+)*)"?
+        )
+    )""".format(
+        noqa_codes=_NOQA_CODES,
+        type_codes=_BRACKET.format(name="type_codes"),
+        pyright_codes=_BRACKET.format(name="pyright_codes"),
+    ),
+    re.VERBOSE,
+)
+
+# Text that is only separators (hashes, dashes, whitespace) is not a reason.
+_SEPARATORS_RE = re.compile(r"[#\s—–-]+")
+
+# A legacy type comment (PEP 484 `x = f()  # type: List[int]`), which may
+# carry a trailing suppression: mypy honors the ignore in
+# `x = f()  # type: List[int]  # type: ignore` (verified) even though it
+# doesn't open the comment, but only when the ignore is the type comment's
+# first embedded segment — a prose segment in between defeats it (verified).
+# The lookahead keeps a leading `type: ignore` directive from qualifying as
+# a type comment, so its duplicate/reason segments stay inert.
+_LEGACY_TYPE_COMMENT_RE = re.compile(r"#\s*type:(?!\s*ignore\b)[^#]*")
+
+
+class Suppression(NamedTuple):
+    rule: str
+    described: bool
+
+
+def _split_codes(codes: str) -> list[str]:
+    return [c for c in re.split(r"[,\s]+", codes) if c]
+
+
+def _rules(m: re.Match[str]) -> list[str]:
+    """Ledger rule keys for one directive match (one per code)."""
+    if m.group("file_noqa"):
+        codes = m.group("file_noqa_codes")
+        prefixed = [f"noqa:{c}" for c in _split_codes(codes)] if codes else ["noqa"]
+        return [rule + FILE_WIDE for rule in prefixed]
+    if m.group("noqa"):
+        codes = m.group("noqa_codes")
+        return [f"noqa:{c}" for c in _split_codes(codes)] if codes else ["noqa"]
+    if m.group("type_ignore"):
+        codes = m.group("type_codes")
+        if codes:
+            return [f"type: ignore[{c}]" for c in _split_codes(codes)]
+        return ["type: ignore"]
+    if m.group("pyright"):
+        codes = m.group("pyright_codes")
+        if codes:
+            return [f"pyright: ignore[{c}]" for c in _split_codes(codes)]
+        return ["pyright: ignore"]
+    if m.group("mypy_ignore"):
+        return ["mypy: ignore-errors" + FILE_WIDE]
+    codes = m.group("mypy_codes")
+    assert codes is not None
+    return [f"mypy: disable-error-code[{c}]{FILE_WIDE}" for c in _split_codes(codes)]
+
+
+def _is_mypy(m: re.Match[str]) -> bool:
+    return any(m.group(g) for g in ("type_ignore", "mypy_ignore", "mypy_codes"))
+
+
+def _is_file_wide(m: re.Match[str]) -> bool:
+    return any(m.group(g) for g in ("file_noqa", "mypy_ignore", "mypy_codes"))
+
+
+def _active(m: re.Match[str], text: str, own_line: bool, col: int) -> bool:
+    # mypy honors `type: ignore` and `mypy:` config comments only when they
+    # open the comment (verified: `# prose  # type: ignore` and
+    # `## type: ignore` suppress nothing), except for a `type: ignore`
+    # trailing a legacy type comment (see _LEGACY_TYPE_COMMENT_RE). ruff's
+    # file-level directives (`ruff: noqa` / `flake8: noqa` opening a
+    # comment) must open the comment the same way, and are additionally
+    # honored only on a comment line of their own — trailing code, they
+    # draw a ruff warning and suppress nothing (all verified; the quoted
+    # spellings here avoid a literal hash before the directive because
+    # newer ruff warns on that even inside prose). mypy config comments
+    # must further start at column 0: an indented own-line
+    # `mypy: ignore-errors` comment suppresses nothing (verified), while
+    # ruff's file-level forms are honored even indented (verified).
+    # Line-level ruff/pyright directives count in any comment segment.
+    if m.group("type_ignore") and m.start() != 0:
+        return bool(_LEGACY_TYPE_COMMENT_RE.fullmatch(text, 0, m.start()))
+    if _is_mypy(m) or m.group("file_noqa"):
+        if m.start() != 0 or text.startswith("##"):
+            return False
+    if _is_file_wide(m):
+        return own_line if m.group("file_noqa") else own_line and col == 0
+    return True
+
+
+def _described(m: re.Match[str], rest: str) -> bool:
+    # For `type: ignore` a reason must be a new `#` segment: mypy rejects
+    # the whole directive when bare prose follows it (verified), so prose
+    # there is a broken comment, not a reason. After noqa codes ruff
+    # tolerates prose (and the repo already uses `— reason`), so any
+    # non-separator text counts.
+    if m.group("type_ignore") and not rest.lstrip().startswith("#"):
+        return False
+    return bool(_SEPARATORS_RE.sub("", rest))
+
+
+def scan_comment(text: str, own_line: bool = True, col: int = 0) -> list[Suppression]:
+    """Suppression records in one comment token's text.
+
+    `own_line` says whether the comment is a line of its own (nothing but
+    whitespace before it) and `col` where it starts — file-wide directives
+    are inert in a trailing comment, and mypy's config comments further
+    require column 0. A directive is "described" when reason text follows
+    it in the comment, stopping at the next directive — see _described for
+    the per-tool rules.
+    """
+    # Inert matches (see _active) produce no records but still bound the
+    # reason region: a duplicated `# type: ignore  # type: ignore` must not
+    # read its inert twin as a reason.
+    matches = list(DIRECTIVE_RE.finditer(text))
+    if not matches:
+        return []
+    ends = [n.start() for n in matches[1:]] + [len(text)]
+    return [
+        Suppression(rule, _described(m, text[m.end() : end]))
+        for m, end in zip(matches, ends, strict=True)
+        if _active(m, text, own_line, col)
+        for rule in _rules(m)
+    ]
+
+
+# Tokens that can precede a module's first docstring/code line.
+_PREAMBLE_TOKENS = (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING)
+
+
+def scan_source(source: str) -> list[Suppression]:
+    """Suppression records in Python source text (comments only)."""
+    records: list[Suppression] = []
+    preamble = True
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type not in _PREAMBLE_TOKENS:
+            preamble = False
+        if tok.type == tokenize.COMMENT:
+            own_line = not tok.line[: tok.start[1]].strip()
+            for record in scan_comment(tok.string, own_line, tok.start[1]):
+                # A bare `# type: ignore` on its own line before any code or
+                # docstring silences the entire module in mypy (verified,
+                # indented included; the bracketed form there is a mypy
+                # error, not file-wide). Only a comment the directive opens
+                # qualifies: a preamble legacy type comment is a mypy
+                # syntax error (verified), not a module-wide ignore.
+                if (
+                    preamble
+                    and record.rule == "type: ignore"
+                    and DIRECTIVE_RE.match(tok.string)
+                ):
+                    record = Suppression(record.rule + FILE_WIDE, record.described)
+                records.append(record)
+    return records
+
+
+Tally = dict[str, int]  # {"count": n} or {"count": n, "undescribed": u}
+Ledger = dict[str, dict[str, Tally]]  # file -> rule -> tally
+
+
+def _tally_rules(records: list[Suppression]) -> dict[str, Tally]:
+    by_rule: dict[str, list[Suppression]] = {}
+    for record in records:
+        by_rule.setdefault(record.rule, []).append(record)
+    return {
+        rule: (
+            {"count": len(group), "undescribed": undescribed}
+            if (undescribed := sum(1 for r in group if not r.described))
+            else {"count": len(group)}
+        )
+        for rule, group in sorted(by_rule.items())
+    }
+
+
+def build_ledger(per_file: dict[str, list[Suppression]]) -> Ledger:
+    return {
+        file: _tally_rules(records)
+        for file, records in sorted(per_file.items())
+        if records
+    }
+
+
+class Counts(NamedTuple):
+    total: int
+    undescribed: int
+
+
+NONE = Counts(0, 0)
+
+Key = tuple[str, str]  # (file, rule)
+
+
+def flatten(ledger: Ledger) -> dict[Key, Counts]:
+    """Ledger as a flat (file, rule) -> Counts map (suppressions_pr_delta.py reuses this)."""
+    return {
+        (file, rule): Counts(tally["count"], tally.get("undescribed", 0))
+        for file, rules in ledger.items()
+        for rule, tally in rules.items()
+    }
+
+
+class Delta(NamedTuple):
+    key: Key
+    before: Counts
+    after: Counts
+
+
+def diff_ledgers(ledger: Ledger, actual: Ledger) -> list[Delta]:
+    """Every (file, rule) pair whose count or undescribed count differs.
+
+    An undescribed-only change (a reason added or removed) must be recorded
+    too, or a stale undescribed allowance would let the reason be deleted
+    again unnoticed.
+    """
+    before = flatten(ledger)
+    after = flatten(actual)
+    deltas = [
+        Delta(key, before.get(key, NONE), after.get(key, NONE))
+        for key in sorted(before.keys() | after.keys())
+    ]
+    return [d for d in deltas if d.before != d.after]
+
+
+def _base_rule(rule: str) -> str:
+    # The ratchet ignores the file-wide suffix: scope is a per-entry property
+    # the ledger diff already surfaces, while the ratchet tracks the repo-wide
+    # reason-less total per rule — a line ↔ file-wide swap moves between keys
+    # without changing that total.
+    return rule[: -len(FILE_WIDE)] if rule.endswith(FILE_WIDE) else rule
+
+
+def _undescribed_by_rule(ledger: Ledger) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for rules in ledger.values():
+        for rule, tally in rules.items():
+            base = _base_rule(rule)
+            totals[base] = totals.get(base, 0) + tally.get("undescribed", 0)
+    return totals
+
+
+class RatchetViolation(NamedTuple):
+    rule: str
+    before: int
+    after: int
+
+
+def ratchet_violations(ledger: Ledger, actual: Ledger) -> list[RatchetViolation]:
+    """Every rule whose repo-wide reason-less count grew.
+
+    Summed across files so moving a file never trips the ratchet; a move
+    still shows in the ledger diff via diff_ledgers, and --update records it.
+    """
+    before = _undescribed_by_rule(ledger)
+    return [
+        RatchetViolation(rule, before.get(rule, 0), after)
+        for rule, after in sorted(_undescribed_by_rule(actual).items())
+        if after > before.get(rule, 0)
+    ]
+
+
+def totals(ledger: Ledger) -> Counts:
+    counts = flatten(ledger).values()
+    return Counts(sum(c.total for c in counts), sum(c.undescribed for c in counts))
+
+
+def _list_files() -> list[str]:
+    out = subprocess.run(
+        # *.pyi too: mypy type-checks stubs, so a `type: ignore` there is a
+        # real suppression (tokenize handles stub syntax fine).
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.py",
+            "*.pyi",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    # Include untracked, non-ignored files so an update run before `git add`
+    # sees newly authored code; omit unstaged deletions still present in the
+    # index so ordinary edit-then-update workflows do not fail opening them.
+    return [f for f in out.split("\0") if f and Path(f).is_file()]
+
+
+def _scan_repo() -> Ledger:
+    def scan_file(path: str) -> list[Suppression]:
+        with tokenize.open(path) as fh:
+            source = fh.read()
+        try:
+            return scan_source(source)
+        except (tokenize.TokenError, SyntaxError) as ex:
+            # tokenize reports positions but not the file; name it.
+            raise RuntimeError(f"cannot tokenize {path}: {ex}") from ex
+
+    return build_ledger({f: scan_file(f) for f in _list_files()})
+
+
+def _summarize(ledger: Ledger) -> str:
+    count, undescribed = totals(ledger)
+    return (
+        f"{count} suppressions ({undescribed} without a reason) in {len(ledger)} files"
+    )
+
+
+def _key_of(key: Key) -> str:
+    return " — ".join(key)
+
+
+def _diff_message(d: Delta) -> str:
+    if d.after.total > d.before.total:
+        return (
+            f"NEW: {_key_of(d.key)} — {d.after.total} in code, "
+            f"{d.before.total} in ledger. Fix the code instead if at all "
+            f"possible; a genuinely unavoidable suppression needs a trailing "
+            f"`# reason` comment — then {UPDATE_HINT} and get maintainer "
+            f"sign-off on the ledger diff."
+        )
+    if d.after.total < d.before.total:
+        return (
+            f"REMOVED: {_key_of(d.key)} — {d.after.total} in code, "
+            f"{d.before.total} in ledger. {UPDATE_HINT} to record the shrink."
+        )
+    return (
+        f"REASONS: {_key_of(d.key)} — {d.after.undescribed} without a reason "
+        f"in code, {d.before.undescribed} in ledger. {UPDATE_HINT} to "
+        f"record it."
+    )
+
+
+def main() -> int:
+    # git ls-files scopes to cwd and LEDGER_PATH is relative — anchor both to
+    # the repo root so invocation from a subdirectory can't scan or write a
+    # partial ledger.
+    os.chdir(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+
+    args = sys.argv[1:]
+    if unknown := [a for a in args if a not in ("--update", "--allow-growth")]:
+        # A silently-ignored typo (e.g. --updat) would run check mode instead.
+        print(
+            f"unknown argument(s): {' '.join(unknown)} "
+            f"(expected --update and/or --allow-growth)",
+            file=sys.stderr,
+        )
+        return 2
+    update = "--update" in args
+    allow_growth = "--allow-growth" in args
+    if allow_growth and not update:
+        print("--allow-growth is only meaningful with --update.", file=sys.stderr)
+        return 2
+
+    # No ledger yet: the first --update captures the baseline as-is.
+    bootstrap = not LEDGER_PATH.exists()
+    ledger: Ledger = json.loads(LEDGER_PATH.read_text()) if not bootstrap else {}
+    actual = _scan_repo()
+
+    violations = [] if update and bootstrap else ratchet_violations(ledger, actual)
+    for v in violations:
+        prefix = "ALLOWED GROWTH" if allow_growth else "UNDESCRIBED"
+        print(
+            f"{prefix}: {v.rule} — {v.after} suppression(s) without a "
+            f"reason repo-wide, ledger allows {v.before}. New suppressions "
+            f"need a trailing `# reason` comment.",
+            file=sys.stderr,
+        )
+
+    if update:
+        if violations and not allow_growth:
+            print(
+                "refusing to record reason-less growth; fix the code or add "
+                "a `# reason` segment. For a merge from upstream that brings "
+                "in suppressions on lines this repo must not edit, rerun "
+                "with --allow-growth (the growth stays visible in the "
+                "ledger diff).",
+                file=sys.stderr,
+            )
+            return 1
+        if bootstrap:
+            # A missing ledger silently skips the ratchet above; say so, or
+            # deleting the file becomes an invisible bypass.
+            print("no existing ledger: baseline captured, ratchet not applied.")
+        LEDGER_PATH.write_text(json.dumps(actual, indent=2) + "\n")
+        print(f"{LEDGER_PATH} updated: {_summarize(actual)}.")
+        return 0
+
+    diffs = diff_ledgers(ledger, actual)
+    for d in diffs:
+        print(_diff_message(d), file=sys.stderr)
+
+    if diffs or violations:
+        return 1
+    print(f"suppressions ledger matches: {_summarize(actual)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/suppressions_pr_delta.py
+++ b/scripts/suppressions_pr_delta.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Markdown body for the sticky PR comment on suppression ledger changes.
+
+Prints nothing when the ledger is unchanged.
+
+Usage: python3 suppressions_pr_delta.py <base.json> <head.json>
+"""
+
+import html
+import json
+import sys
+from pathlib import Path
+
+# Sibling-script import: resolves because sys.path[0] is this script's
+# directory when invoked by path (as the workflow does); the test suite
+# pre-registers the module in sys.modules instead.
+from check_suppressions import Delta, Ledger, diff_ledgers, totals
+
+MARKER = "<!-- suppressions-delta -->"
+
+
+def _load(path: str) -> Ledger:
+    try:
+        ledger: Ledger = json.loads(Path(path).read_text())
+        return ledger
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _cell(value: str) -> str:
+    """Render untrusted ledger text safely inside a Markdown table cell."""
+    value = value.replace("\r", " ").replace("\n", " ")
+    return f"<code>{html.escape(value).replace('|', '&#124;')}</code>"
+
+
+def render(base: Ledger, head: Ledger) -> str | None:
+    """The comment body for a base -> head ledger change, or None if none.
+
+    An undescribed-only change (a reason added or removed) renders too:
+    otherwise such a ledger diff would produce nothing and the workflow
+    would falsely reset the sticky comment to "no longer changes the
+    ledger".
+    """
+    rows = diff_ledgers(base, head)
+    if not rows:
+        return None
+
+    total_before, undescribed_before = totals(base)
+    total_after, undescribed_after = totals(head)
+    delta = total_after - total_before
+    undescribed_delta = undescribed_after - undescribed_before
+    needs_attention = delta > 0 or undescribed_delta > 0
+    if undescribed_delta > 0 and delta <= 0:
+        heading = (
+            f"⚠️ Reason-less suppressions grew: {undescribed_before} → "
+            f"{undescribed_after} (+{undescribed_delta}); total "
+            f"{total_before} → {total_after} ({'±0' if delta == 0 else delta})"
+        )
+    elif delta > 0:
+        heading = (
+            f"⚠️ Suppression ledger grew: {total_before} → {total_after} (+{delta})"
+        )
+    else:
+        heading = (
+            f"Suppression ledger changed: {total_before} → {total_after} "
+            f"({'±0' if delta == 0 else delta})"
+        )
+
+    def render_row(row: Delta) -> str:
+        file, rule = row.key
+        change = row.after.total - row.before.total
+        change_cell = "±0" if change == 0 else f"{change:+d}"
+        reason_note = (
+            ""
+            if row.before.undescribed == row.after.undescribed
+            else f" (reason-less {row.before.undescribed} → {row.after.undescribed})"
+        )
+        return f"| {_cell(file)} | {_cell(rule)} | {change_cell}{reason_note} |"
+
+    table = "\n".join(render_row(row) for row in rows)
+
+    undescribed_line = (
+        ""
+        if undescribed_before == undescribed_after
+        else f"\nReason-less (baselined) suppressions: "
+        f"{undescribed_before} → {undescribed_after}\n"
+    )
+
+    footer = (
+        "\nEvery new suppression needs a trailing `# reason` comment and "
+        "maintainer sign-off of this ledger diff — see the Suppression gate "
+        "section in AGENTS.md."
+        if needs_attention
+        else ""
+    )
+
+    return (
+        f"{MARKER}\n### {heading}\n\n| File | Rule | Change |\n|---|---|---|\n"
+        f"{table}\n{undescribed_line}{footer}"
+    )
+
+
+def main() -> int:
+    base_path, head_path = sys.argv[1:3]
+    body = render(_load(base_path), _load(head_path))
+    if body is not None:
+        print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/suppressions.json
+++ b/suppressions.json
@@ -1,0 +1,668 @@
+{
+  "docs/_extensions/meridianlabs-ai/inspect-docs/filters/reference/commands.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[arg-type]": {
+      "count": 5,
+      "undescribed": 5
+    }
+  },
+  "docs/_extensions/meridianlabs-ai/inspect-docs/filters/reference/filter.py": {
+    "noqa:E402": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[attr-defined]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "docs/_extensions/meridianlabs-ai/inspect-docs/filters/reference/render.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "docs/_extensions/meridianlabs-ai/inspect-docs/post-render.py": {
+    "type: ignore[no-any-return]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "docs/_extensions/meridianlabs-ai/inspect-docs/pre-render.py": {
+    "noqa:E402": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[no-any-return]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "examples/sources/openclaw_telemetry_hal/tests/test_telemetry_hal.py": {
+    "type: ignore[operator]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_cli/__init__.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_cli/scan.py": {
+    "type: ignore[assignment]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/_concurrency/_mp_common.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[misc]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_concurrency/multi_process.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_llm_scanner/structured.py": {
+    "type: ignore": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/_observe/providers/anthropic.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[import-untyped]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[misc]": {
+      "count": 6,
+      "undescribed": 6
+    }
+  },
+  "src/inspect_scout/_observe/providers/google.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[import-untyped]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_observe/providers/openai.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[import-untyped]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[misc]": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "src/inspect_scout/_query/column.py": {
+    "type: ignore[override]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/_recorder/active_scans_store.py": {
+    "type: ignore[arg-type]": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "type: ignore[call-overload]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_recorder/validation.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[prop-decorator]": {
+      "count": 6,
+      "undescribed": 6
+    }
+  },
+  "src/inspect_scout/_scanner/scanner.py": {
+    "mypy: disable-error-code[overload-overlap] (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[return-value]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_scanner_ir/parser.py": {
+    "type: ignore[arg-type]": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "type: ignore[assignment]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_scanresults.py": {
+    "noqa:E731": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_transcript/database/parquet/transcripts.py": {
+    "type: ignore[call-overload]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_transcript/json/load_filtered.py": {
+    "type: ignore": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "src/inspect_scout/_transcript/json/reducer.py": {
+    "type: ignore": {
+      "count": 8,
+      "undescribed": 8
+    }
+  },
+  "src/inspect_scout/_transcript/messages.py": {
+    "type: ignore[arg-type]": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "type: ignore[misc]": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "type: ignore[unused-ignore]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_util/decorator.py": {
+    "type: ignore[attr-defined]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_util/filesystem.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_validation/types.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[no-any-return]": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "type: ignore[return-value]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/_view/_api_v2_scans.py": {
+    "noqa:B008": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/_view/_api_v2_transcripts.py": {
+    "noqa:B008": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/_view/_api_v2_types.py": {
+    "noqa:F821": {
+      "count": 7,
+      "undescribed": 7
+    },
+    "type: ignore[assignment]": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "type: ignore[valid-type]": {
+      "count": 7,
+      "undescribed": 7
+    }
+  },
+  "src/inspect_scout/sources/_atif/client.py": {
+    "type: ignore[no-any-return]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/sources/_langsmith/extraction.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "src/inspect_scout/sources/_logfire/extraction.py": {
+    "type: ignore[arg-type]": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "src/inspect_scout/sources/_phoenix/extraction.py": {
+    "type: ignore[arg-type]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/sources/_weave/__init__.py": {
+    "type: ignore[import-not-found]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "src/inspect_scout/sources/_weave/client.py": {
+    "type: ignore[import-not-found]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/cli/test_parse_validation.py": {
+    "noqa:E501": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/concurrency/test_model_pickling.py": {
+    "type: ignore[import-untyped]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/fixtures/sample_scanners.py": {
+    "type: ignore[type-var]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/llm_scanner/test_parse_answer.py": {
+    "type: ignore[call-overload]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/llm_scanner/test_retry_refusals.py": {
+    "type: ignore[return-value]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/llm_scanner/test_template_forms.py": {
+    "type: ignore[union-attr]": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "tests/observe/test_observe.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[method-assign]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/observe/test_observe_e2e.py": {
+    "type: ignore[arg-type]": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "tests/observe/test_observe_providers.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[union-attr]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[unused-ignore]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/query/test_condition_sql.py": {
+    "noqa:E712": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "tests/query/test_query.py": {
+    "type: ignore[assignment]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/recorder/test_summary.py": {
+    "type: ignore[arg-type]": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "tests/scan/test_scan_where.py": {
+    "noqa:E712": {
+      "count": 6,
+      "undescribed": 6
+    },
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/scanjobs/test_store.py": {
+    "type: ignore[arg-type]": {
+      "count": 1
+    }
+  },
+  "tests/scanner/test_filter_inference.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[no-untyped-def]": {
+      "count": 1
+    }
+  },
+  "tests/scanner/test_filters.py": {
+    "type: ignore[arg-type]": {
+      "count": 10,
+      "undescribed": 10
+    },
+    "type: ignore[list-item]": {
+      "count": 7,
+      "undescribed": 7
+    }
+  },
+  "tests/scanner/test_loader.py": {
+    "type: ignore[arg-type]": {
+      "count": 10,
+      "undescribed": 10
+    }
+  },
+  "tests/scanner/test_loaders.py": {
+    "type: ignore[no-untyped-def]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/scanner/test_log_metadata.py": {
+    "noqa:E711": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/scanner/test_metadata.py": {
+    "noqa:E711": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "noqa:E712": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/scanner/test_scanner_decorator.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[return-value]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/scanner/test_transcript.py": {
+    "noqa:E711": {
+      "count": 8,
+      "undescribed": 8
+    },
+    "noqa:E712": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "tests/scanner/test_util.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/scanner/test_validation.py": {
+    "pyright: ignore[reportInvalidTypeForm]": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "type: ignore[arg-type]": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "type: ignore[list-item]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[no-untyped-def]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[return-value]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[type-var]": {
+      "count": 5,
+      "undescribed": 5
+    }
+  },
+  "tests/sources/atif_source/test_event_conversion.py": {
+    "noqa:E402 (file-wide)": {
+      "count": 1
+    },
+    "type: ignore[union-attr]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/atif_source/test_integration.py": {
+    "noqa:E402 (file-wide)": {
+      "count": 1
+    },
+    "noqa:E501": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/langsmith_source/bootstrap.py": {
+    "type: ignore (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/langsmith_source/test_db_integration.py": {
+    "type: ignore[attr-defined]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/logfire_source/bootstrap.py": {
+    "type: ignore (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[arg-type]": {
+      "count": 10,
+      "undescribed": 10
+    },
+    "type: ignore[call-overload]": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "tests/sources/logfire_source/test_db_integration.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/phoenix_source/bootstrap.py": {
+    "type: ignore (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/phoenix_source/test_db_integration.py": {
+    "type: ignore (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/weave_source/bootstrap.py": {
+    "type: ignore (file-wide)": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/sources/weave_source/conftest.py": {
+    "type: ignore[import-not-found]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/test_event_expansion.py": {
+    "type: ignore[type-var]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/test_label_validation.py": {
+    "noqa:E712": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "type: ignore[dict-item]": {
+      "count": 4,
+      "undescribed": 4
+    }
+  },
+  "tests/test_per_scanner_validation.py": {
+    "noqa:ARG001": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "noqa:ARG002": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/test_scan_results_batches.py": {
+    "type: ignore[abstract]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[import-untyped]": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[misc]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/test_validation_e2e.py": {
+    "noqa:E712": {
+      "count": 6,
+      "undescribed": 6
+    },
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/transcript/database/test_schema.py": {
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/transcript/nodes/test_timeline_serialization.py": {
+    "type: ignore[union-attr]": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "tests/transcript/test_columns_serialization.py": {
+    "noqa:E711": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "noqa:E712": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "tests/transcript/test_splice.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/util/test_async_zip.py": {
+    "noqa:F401": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "tests/validation/test_predicates.py": {
+    "type: ignore[arg-type]": {
+      "count": 1,
+      "undescribed": 1
+    }
+  }
+}

--- a/tests/test_check_suppressions.py
+++ b/tests/test_check_suppressions.py
@@ -1,0 +1,578 @@
+"""Tests for the suppression ledger gate (scripts/check_suppressions.py).
+
+Mostly pure-logic tests over the scanner and ledger diffing, plus a few CLI
+tests that run the script against a throwaway git repo. Directive examples
+live inside string literals, which the tokenize-based scanner never counts,
+so this file adds nothing to the ledger.
+"""
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+SCRIPTS_DIR = pathlib.Path(__file__).parents[1] / "scripts"
+
+spec = importlib.util.spec_from_file_location(
+    "check_suppressions", SCRIPTS_DIR / "check_suppressions.py"
+)
+assert spec is not None and spec.loader is not None
+cs = importlib.util.module_from_spec(spec)
+# Register before exec so suppressions_pr_delta.py's `import
+# check_suppressions` resolves to this instance when loaded below.
+sys.modules["check_suppressions"] = cs
+spec.loader.exec_module(cs)
+
+
+def scan(source: str) -> list[tuple[str, bool]]:
+    return [(s.rule, s.described) for s in cs.scan_source(source)]
+
+
+# --- scanner: ruff noqa ---
+
+
+def test_noqa_with_code_and_reason_segment() -> None:
+    assert scan("x = 1  # noqa: E501  # long URL\n") == [("noqa:E501", True)]
+
+
+def test_noqa_with_code_no_reason() -> None:
+    assert scan("x = 1  # noqa: E501\n") == [("noqa:E501", False)]
+
+
+def test_noqa_multiple_codes_count_separately() -> None:
+    assert scan("import a, b  # noqa: E402, F401\n") == [
+        ("noqa:E402", False),
+        ("noqa:F401", False),
+    ]
+
+
+def test_noqa_em_dash_reason() -> None:
+    assert scan("f()  # noqa: BLE001 — never crash the loop\n") == [
+        ("noqa:BLE001", True)
+    ]
+
+
+def test_noqa_double_dash_reason() -> None:
+    assert scan("f()  # noqa: BLE001 -- best effort\n") == [("noqa:BLE001", True)]
+
+
+def test_bare_noqa_keys_separately() -> None:
+    assert scan("x = 1  # noqa\n") == [("noqa", False)]
+
+
+def test_noqa_case_insensitive() -> None:
+    assert scan("x = 1  # NOQA: E501\n") == [("noqa:E501", False)]
+
+
+def test_noqa_prefix_of_word_ignored() -> None:
+    assert scan("x = 1  # noqable\n") == []
+
+
+def test_file_wide_ruff_noqa() -> None:
+    assert scan("# ruff: noqa\n") == [("noqa (file-wide)", False)]
+
+
+def test_file_wide_ruff_noqa_with_space_separated_codes() -> None:
+    assert scan("# ruff: noqa: F401 F403\n") == [
+        ("noqa:F401 (file-wide)", False),
+        ("noqa:F403 (file-wide)", False),
+    ]
+
+
+def test_file_wide_flake8_noqa() -> None:
+    assert scan("# flake8: noqa\n") == [("noqa (file-wide)", False)]
+
+
+def test_file_wide_noqa_loose_spellings_honored_by_ruff() -> None:
+    # ruff honors the noqa token in any case and whitespace around the
+    # colons (all verified against the pinned ruff); miss these and a
+    # whole-file suppression lands with no ledger entry.
+    for text in (
+        "# ruff: NOQA\n",
+        "# ruff: Noqa\n",
+        "# ruff : noqa\n",
+        "#ruff : noqa\n",
+        "# flake8 : noqa\n",
+    ):
+        assert scan(text) == [("noqa (file-wide)", False)], text
+    assert scan("# ruff: NOQA: F401\n") == [("noqa:F401 (file-wide)", False)]
+
+
+def test_file_wide_noqa_uppercase_prefix_is_inert() -> None:
+    # ruff ignores an uppercase prefix ("RUFF: NOQA" suppresses nothing,
+    # verified), and the scanner matches nothing either: the file-level
+    # prefix is case-sensitive on purpose, and the line-level noqa branch
+    # requires the token to open a comment segment.
+    assert scan("# RUFF: NOQA\n") == []
+
+
+def test_trailing_file_wide_noqa_is_inert() -> None:
+    # ruff warns ("File-level suppression comments must appear on their own
+    # line") and suppresses nothing (verified), for either spelling.
+    assert scan("x = 1  # ruff: noqa\n") == []
+    assert scan("x = 1  # flake8: noqa\n") == []
+
+
+def test_file_wide_noqa_mid_comment_is_inert() -> None:
+    # Own line, but the directive doesn't open the comment: ruff silently
+    # ignores it (verified).
+    assert scan("# prose  # ruff: noqa\nimport os\n") == []
+
+
+# --- scanner: mypy ---
+
+
+def test_type_ignore_bare() -> None:
+    assert scan("x = f()  # type: ignore\n") == [("type: ignore", False)]
+
+
+def test_type_ignore_with_code_and_reason_segment() -> None:
+    assert scan("x = f()  # type: ignore[assignment]  # stub is wrong\n") == [
+        ("type: ignore[assignment]", True)
+    ]
+
+
+def test_type_ignore_multiple_codes() -> None:
+    assert scan("x = f()  # type: ignore[method-assign, assignment]\n") == [
+        ("type: ignore[method-assign]", False),
+        ("type: ignore[assignment]", False),
+    ]
+
+
+def test_type_ignore_no_space_variant() -> None:
+    assert scan("x = f()  #type:ignore[arg-type]\n") == [
+        ("type: ignore[arg-type]", False)
+    ]
+
+
+def test_type_ignore_word_prefix_ignored() -> None:
+    assert scan("x = 1  # type: ignored by design\n") == []
+
+
+def test_type_ignore_mid_comment_is_inert() -> None:
+    # mypy only honors type: ignore when it opens the comment.
+    assert scan("x = f()  # prose  # type: ignore\n") == []
+
+
+def test_double_hash_type_ignore_is_inert() -> None:
+    assert scan("## type: ignore\nimport x\n") == []
+
+
+def test_type_ignore_after_legacy_type_comment_counts() -> None:
+    # mypy honors the trailing ignore of a legacy type comment (verified),
+    # so it must be counted or it would evade the ledger.
+    assert scan("x = f()  # type: List[int]  # type: ignore\n") == [
+        ("type: ignore", False)
+    ]
+    assert scan("x = f()  # type: List[int]  # type: ignore[assignment]\n") == [
+        ("type: ignore[assignment]", False)
+    ]
+
+
+def test_type_ignore_after_legacy_type_comment_with_reason_segment() -> None:
+    assert scan("x = f()  # type: List[int]  # type: ignore  # stub is wrong\n") == [
+        ("type: ignore", True)
+    ]
+
+
+def test_type_ignore_after_legacy_type_comment_with_prose_between_is_inert() -> None:
+    # mypy honors the ignore only as the type comment's first embedded
+    # segment (verified: a prose segment in between defeats it).
+    assert scan("x = f()  # type: List[int]  # prose  # type: ignore\n") == []
+
+
+def test_legacy_type_comment_in_preamble_is_not_file_wide() -> None:
+    # An own-line legacy type comment before any code is a mypy syntax
+    # error (verified), so its trailing ignore must not upgrade to the
+    # module-wide form the way a bare preamble type: ignore does.
+    assert scan("# type: List[int]  # type: ignore\nimport x\n") == [
+        ("type: ignore", False)
+    ]
+
+
+def test_duplicate_type_ignore_counts_once_and_is_not_a_reason() -> None:
+    assert scan("x = f()  # type: ignore  # type: ignore\n") == [
+        ("type: ignore", False)
+    ]
+
+
+def test_type_ignore_trailing_prose_is_not_a_reason() -> None:
+    # mypy rejects the directive outright when bare prose follows it, so
+    # prose there is a broken comment, not a reason.
+    assert scan("x = f()  # type: ignore stub is wrong\n") == [("type: ignore", False)]
+
+
+def test_type_ignore_space_before_bracket() -> None:
+    # mypy honors and scopes the code despite the space (verified).
+    assert scan("x = f()  # type: ignore [assignment]\n") == [
+        ("type: ignore[assignment]", False)
+    ]
+
+
+def test_bare_type_ignore_at_top_of_file_is_file_wide() -> None:
+    # A bare own-line type: ignore before any code or docstring silences
+    # the whole module in mypy, even indented (verified).
+    assert scan("# type: ignore\nimport x\n") == [("type: ignore (file-wide)", False)]
+    assert scan("    # type: ignore\nimport x\n") == [
+        ("type: ignore (file-wide)", False)
+    ]
+
+
+def test_type_ignore_after_docstring_is_not_file_wide() -> None:
+    assert scan('"""Doc."""\nx = f()  # type: ignore\n') == [("type: ignore", False)]
+
+
+def test_bracketed_type_ignore_at_top_of_file_stays_line_level() -> None:
+    # mypy errors on the bracketed form at module level rather than
+    # treating it as file-wide.
+    assert scan("# type: ignore[assignment]\nimport x\n") == [
+        ("type: ignore[assignment]", False)
+    ]
+
+
+def test_mypy_ignore_errors_file_wide() -> None:
+    assert scan("# mypy: ignore-errors\n") == [
+        ("mypy: ignore-errors (file-wide)", False)
+    ]
+
+
+def test_trailing_mypy_config_comment_is_inert() -> None:
+    # mypy config comments are honored only on a line of their own; a
+    # trailing one suppresses nothing (verified).
+    assert scan("x = 1  # mypy: ignore-errors\n") == []
+
+
+def test_mid_file_own_line_mypy_config_comment_counts() -> None:
+    # Own-line placement is what matters, not top-of-file (verified: a
+    # mid-file `# mypy: ignore-errors` suppresses the module).
+    assert scan("x = 1\n# mypy: ignore-errors\ny = 2\n") == [
+        ("mypy: ignore-errors (file-wide)", False)
+    ]
+
+
+def test_indented_mypy_config_comment_is_inert() -> None:
+    # mypy config comments must start at column 0: an indented own-line
+    # one suppresses nothing (verified for both forms).
+    assert scan("if x:\n    # mypy: ignore-errors\n    pass\n") == []
+    assert scan('if x:\n    # mypy: disable-error-code="assignment"\n    pass\n') == []
+
+
+def test_indented_file_level_noqa_still_counts() -> None:
+    # Unlike mypy config comments, ruff honors an indented own-line
+    # file-level noqa comment (verified: it suppresses file-wide).
+    assert scan("if x:\n    # ruff: noqa\n    pass\n") == [("noqa (file-wide)", False)]
+
+
+def test_mypy_disable_error_code_file_wide() -> None:
+    assert scan('# mypy: disable-error-code="unused-ignore"\n') == [
+        ("mypy: disable-error-code[unused-ignore] (file-wide)", False)
+    ]
+
+
+def test_mypy_prose_comment_not_a_directive() -> None:
+    assert scan("# mypy: passing None would require Optional here\n") == []
+
+
+# --- scanner: pyright ---
+
+
+def test_pyright_ignore_with_rules() -> None:
+    assert scan(
+        "x = f()  # pyright: ignore[reportUnknownMemberType,reportPrivateUsage]\n"
+    ) == [
+        ("pyright: ignore[reportUnknownMemberType]", False),
+        ("pyright: ignore[reportPrivateUsage]", False),
+    ]
+
+
+def test_pyright_mode_comment_not_a_directive() -> None:
+    assert scan("# pyright: basic\n") == []
+
+
+# --- scanner: reasons and comment structure ---
+
+
+def test_directive_following_directive_is_not_a_reason() -> None:
+    assert scan("x = f()  # type: ignore  # noqa: E501\n") == [
+        ("type: ignore", False),
+        ("noqa:E501", False),
+    ]
+
+
+def test_separator_only_tail_is_not_a_reason() -> None:
+    assert scan("x = f()  # type: ignore  # --- #\n") == [("type: ignore", False)]
+
+
+def test_directive_text_in_string_literal_ignored() -> None:
+    assert scan('s = "x  # noqa: E501"\n') == []
+
+
+def test_directive_mid_prose_without_hash_ignored() -> None:
+    assert scan("# remove the type: ignore below once fixed\n") == []
+
+
+def test_directive_after_prose_comment_counts_but_prose_is_not_a_reason() -> None:
+    # ruff honors a noqa directive opening a later segment of the comment;
+    # a reason must FOLLOW the directive (preceding prose describes the code).
+    assert scan("x = 1  # legacy import  # noqa: F401\n") == [("noqa:F401", False)]
+
+
+# --- ledger building ---
+
+
+def test_build_ledger_tallies_sorts_and_omits_empty() -> None:
+    S = cs.Suppression
+    ledger = cs.build_ledger(
+        {
+            "b.py": [S("r", False), S("r", True)],
+            "a.py": [S("r", True)],
+            "empty.py": [],
+        }
+    )
+    assert ledger == {
+        "a.py": {"r": {"count": 1}},
+        "b.py": {"r": {"count": 2, "undescribed": 1}},
+    }
+    assert list(ledger.keys()) == ["a.py", "b.py"]
+
+
+# --- diffing ---
+
+
+def test_diff_ledgers_reports_growth_and_shrink() -> None:
+    diffs = cs.diff_ledgers(
+        {"a.py": {"r": {"count": 2}}, "gone.py": {"r": {"count": 1}}},
+        {"a.py": {"r": {"count": 3}}},
+    )
+    assert [(d.before.total, d.after.total) for d in diffs] == [(2, 3), (1, 0)]
+
+
+def test_diff_ledgers_reports_undescribed_only_change() -> None:
+    diffs = cs.diff_ledgers(
+        {"a.py": {"r": {"count": 2, "undescribed": 2}}},
+        {"a.py": {"r": {"count": 2, "undescribed": 1}}},
+    )
+    assert [(d.before.undescribed, d.after.undescribed) for d in diffs] == [(2, 1)]
+
+
+def test_diff_ledgers_empty_on_match() -> None:
+    ledger = {"a.py": {"r": {"count": 1}}}
+    assert cs.diff_ledgers(ledger, ledger) == []
+
+
+# --- ratchet ---
+
+
+def test_ratchet_flags_undescribed_growth_allows_shrink_and_described_growth() -> None:
+    ledger = {"a.py": {"r": {"count": 2, "undescribed": 2}}}
+    grow = {"a.py": {"r": {"count": 3, "undescribed": 3}}}
+    described_grow = {"a.py": {"r": {"count": 3, "undescribed": 2}}}
+    shrink = {"a.py": {"r": {"count": 1, "undescribed": 1}}}
+    assert len(cs.ratchet_violations(ledger, grow)) == 1
+    assert cs.ratchet_violations(ledger, described_grow) == []
+    assert cs.ratchet_violations(ledger, shrink) == []
+
+
+def test_ratchet_flags_new_file_with_undescribed_suppression() -> None:
+    assert (
+        len(
+            cs.ratchet_violations({}, {"new.py": {"r": {"count": 1, "undescribed": 1}}})
+        )
+        == 1
+    )
+
+
+def test_ratchet_is_per_rule_across_files_so_a_move_does_not_trip_it() -> None:
+    assert (
+        cs.ratchet_violations(
+            {"old.py": {"r": {"count": 2, "undescribed": 2}}},
+            {"new.py": {"r": {"count": 2, "undescribed": 2}}},
+        )
+        == []
+    )
+
+
+def test_line_to_file_wide_swap_is_a_ledger_diff_but_not_a_ratchet_trip() -> None:
+    ledger = {"a.py": {"noqa:F401": {"count": 1, "undescribed": 1}}}
+    actual = {"a.py": {"noqa:F401 (file-wide)": {"count": 1, "undescribed": 1}}}
+    assert [d.key[1] for d in cs.diff_ledgers(ledger, actual)] == [
+        "noqa:F401",
+        "noqa:F401 (file-wide)",
+    ]
+    assert cs.ratchet_violations(ledger, actual) == []
+
+
+def test_ratchet_still_fires_when_a_move_also_adds_a_reasonless_suppression() -> None:
+    assert cs.ratchet_violations(
+        {"old.py": {"r": {"count": 2, "undescribed": 2}}},
+        {"new.py": {"r": {"count": 3, "undescribed": 3}}},
+    ) == [cs.RatchetViolation("r", 2, 3)]
+
+
+# --- totals ---
+
+
+def test_totals_sums_counts_and_undescribed() -> None:
+    assert cs.totals(
+        {
+            "a.py": {"r": {"count": 2, "undescribed": 1}, "s": {"count": 1}},
+            "b.py": {"r": {"count": 3, "undescribed": 3}},
+        }
+    ) == cs.Counts(6, 4)
+
+
+# --- PR delta comment (suppressions_pr_delta.py) ---
+
+delta_spec = importlib.util.spec_from_file_location(
+    "suppressions_pr_delta", SCRIPTS_DIR / "suppressions_pr_delta.py"
+)
+assert delta_spec is not None and delta_spec.loader is not None
+delta = importlib.util.module_from_spec(delta_spec)
+delta_spec.loader.exec_module(delta)
+
+
+Ledger = dict[str, dict[str, dict[str, int]]]
+
+
+def render(base: Ledger, head: Ledger) -> str | None:
+    body = delta.render(base, head)
+    assert body is None or isinstance(body, str)
+    return body
+
+
+def test_delta_renders_nothing_when_unchanged() -> None:
+    ledger = {"a.py": {"r": {"count": 1, "undescribed": 1}}}
+    assert render(ledger, ledger) is None
+
+
+def test_delta_growth_renders_marker_warning_row_and_footer() -> None:
+    body = render({}, {"a.py": {"r": {"count": 1}}})
+    assert body is not None
+    assert body.startswith(delta.MARKER)
+    assert "⚠️ Suppression ledger grew: 0 → 1 (+1)" in body
+    assert "| <code>a.py</code> | <code>r</code> | +1 |" in body
+    assert "maintainer sign-off" in body
+
+
+def test_delta_shrink_renders_plain_heading_without_footer() -> None:
+    body = render(
+        {"a.py": {"r": {"count": 2}}},
+        {"a.py": {"r": {"count": 1}}},
+    )
+    assert body is not None
+    assert "Suppression ledger changed: 2 → 1 (-1)" in body
+    assert "maintainer sign-off" not in body
+
+
+def test_delta_undescribed_only_change_still_renders() -> None:
+    body = render(
+        {"a.py": {"r": {"count": 1, "undescribed": 1}}},
+        {"a.py": {"r": {"count": 1}}},
+    )
+    assert body is not None
+    assert "| <code>a.py</code> | <code>r</code> | ±0 (reason-less 1 → 0) |" in body
+    assert "Reason-less (baselined) suppressions: 1 → 0" in body
+
+
+def test_delta_warns_when_reasonless_count_grows_without_total_growth() -> None:
+    body = render(
+        {"a.py": {"r": {"count": 1}}},
+        {"a.py": {"r": {"count": 1, "undescribed": 1}}},
+    )
+    assert body is not None
+    assert "⚠️ Reason-less suppressions grew: 0 → 1 (+1)" in body
+    assert "maintainer sign-off" in body
+
+
+def test_delta_escapes_untrusted_table_cell_text() -> None:
+    body = render({}, {"a`\n@team|.py": {"r`\n@team|": {"count": 1}}})
+    assert body is not None
+    assert "<code>a` @team&#124;.py</code>" in body
+    assert "<code>r` @team&#124;</code>" in body
+
+
+# --- CLI: bootstrap, ratchet refusal, and --allow-growth (throwaway git repo) ---
+
+
+def _init_repo(tmp_path: pathlib.Path, files: dict[str, str]) -> pathlib.Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    for name, content in files.items():
+        (tmp_path / name).write_text(content)
+    # ls-files only sees tracked files; staging suffices (no commit needed).
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def _run_gate(repo: pathlib.Path, *args: str) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "check_suppressions.py"), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_update_bootstrap_ratchet_refusal_and_allow_growth(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo = _init_repo(tmp_path, {"a.py": "x = 1  # noqa: E501\n"})
+
+    # Bootstrap --update captures the baseline and says the ratchet was skipped.
+    boot = _run_gate(repo, "--update")
+    assert boot.returncode == 0
+    assert "ratchet not applied" in boot.stdout
+
+    # A second reason-less suppression: --update refuses via the ratchet
+    # and points at the sanctioned override.
+    (repo / "a.py").write_text("x = 1  # noqa: E501\ny = 2  # noqa: E501\n")
+    refused = _run_gate(repo, "--update")
+    assert refused.returncode == 1
+    assert "UNDESCRIBED: noqa:E501" in refused.stderr
+    assert "--allow-growth" in refused.stderr
+
+    # --allow-growth records the growth, loudly.
+    allowed = _run_gate(repo, "--update", "--allow-growth")
+    assert allowed.returncode == 0
+    assert "ALLOWED GROWTH: noqa:E501" in allowed.stderr
+    assert _run_gate(repo).returncode == 0
+
+
+def test_allow_growth_without_update_is_an_error(tmp_path: pathlib.Path) -> None:
+    repo = _init_repo(tmp_path, {})
+    result = _run_gate(repo, "--allow-growth")
+    assert result.returncode == 2
+    assert "--update" in result.stderr
+
+
+def test_unknown_argument_is_an_error(tmp_path: pathlib.Path) -> None:
+    # A typo'd flag must not silently fall through to check mode.
+    repo = _init_repo(tmp_path, {})
+    result = _run_gate(repo, "--updat")
+    assert result.returncode == 2
+    assert "--updat" in result.stderr
+
+
+def test_pyi_stubs_are_scanned(tmp_path: pathlib.Path) -> None:
+    repo = _init_repo(tmp_path, {"a.pyi": "x: int  # type: ignore[assignment]\n"})
+    result = _run_gate(repo, "--update")
+    assert result.returncode == 0
+    assert '"a.pyi"' in (repo / "suppressions.json").read_text()
+
+
+def test_update_scans_untracked_files_and_omits_unstaged_deletions(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo = _init_repo(
+        tmp_path,
+        {"deleted.py": "x = 1  # noqa: E501\n"},
+    )
+    (repo / "deleted.py").unlink()
+    (repo / "untracked.py").write_text("x = 1  # noqa: E501\n")
+
+    result = _run_gate(repo, "--update")
+
+    assert result.returncode == 0
+    ledger = (repo / "suppressions.json").read_text()
+    assert '"untracked.py"' in ledger
+    assert '"deleted.py"' not in ledger


### PR DESCRIPTION
Adds the inline-suppression ledger and gate, ported from inspect_ai's Python version (meridianlabs-ai/inspect_ai#5136). Every inline suppression (`# noqa`, `# type: ignore`, `# pyright: ignore`, and the file-wide forms) is recorded in a committed `suppressions.json`. CI fails when code and ledger disagree, so every add, remove, or move of a suppression shows up as a reviewable ledger diff instead of slipping through.

## What's in it

- `scripts/check_suppressions.py`: stdlib-only, tokenize-based scanner plus the gate. Directives in string literals never count; a `type: ignore` counts only when it opens the comment; `# type: ignore [code]` with a space is code-scoped; a bare own-line `# type: ignore` before any code is file-wide. `--update` regenerates the ledger and refuses to grow any rule's repo-wide reason-less count (new suppressions must carry a reason in a trailing `# reason` segment, the only style mypy accepts). `--update --allow-growth` is the loud escape hatch for wholesale code imports.
- `scripts/suppressions_pr_delta.py`: renders the sticky PR comment body.
- `.github/workflows/suppressions.yml`: the gate plus its tests, on `pull_request` with a read-only token.
- `.github/workflows/suppressions-comment.yml`: the sticky delta comment, on `pull_request_target` so fork PRs get it too. It runs only base-branch code and reads the PR's ledger as data via `git show`, never checking out or installing PR code. The security model is documented at the top of the file; please read it before editing that workflow. Because `pull_request_target` runs the base branch's workflows, no comment appears on this PR itself; it starts working for PRs opened after this merges (the comment body it would have posted here was rendered locally, see below).
- `make suppressions-check` / `make suppressions-update`, with the check folded into `make check`.
- An AGENTS.md "Suppression gate" section with the rules and the reason convention.
- `tests/test_check_suppressions.py`: the ported test suite (67 tests).

## Baseline

`suppressions.json` captures the repo as it stands: 274 suppressions, 270 without a reason, across 81 files. No suppressions were removed in this PR; the reason-less ones burn down over time under the ratchet. Largest rules: `type: ignore[arg-type]` (70), `noqa:E712` (28), bare `type: ignore` (22).

## Verified locally

- Gate passes on the baseline; the 67 ported tests pass.
- A fresh reason-less `# type: ignore[assignment]` fails the check (NEW + UNDESCRIBED) and `--update` refuses to record it.
- The same suppression with a trailing `# reason` segment passes `--update` and the delta script renders the sticky-comment body for it.
- Reverting returns the gate to green.
- ruff, ruff format, and mypy are clean on the touched files.

## Coexistence with #594

#594 is the config-level sibling (a ledger for checker relaxations in pyproject.toml). The two gates coexist on purpose: separate ledgers, separate scripts, separate CI jobs, distinct Makefile targets and AGENTS.md sections. Both branch off main, so they overlap in the Makefile `check:` line and nearby AGENTS.md text; whoever merges second resolves that small conflict. The two could be unified later if that ever seems worth it.

## Port adaptations

Scripts live in `scripts/` (scout convention, matching #594) rather than `.github/scripts/`. Scout's stricter ruff rules required `strict=` on a `zip()` (with an early return for the empty-match case, covered by the ported tests) and an explicit `check=False` on a `subprocess.run` in the test helper. The test file gained a typed `Ledger` alias for scout's strict mypy. The AGENTS.md ratchet-exception wording was adjusted since scout is not a fork.

### Agent review

- Author: Claude (Fable 5). Reviewer: /code-review at high effort (fresh context, same model family), one pass: 8 finder angles, 1-vote verification, 10 findings.
- 1 fixed pre-review (a port-introduced `zip(strict=True)` crash on comments with no directive match, caught by the ported tests), 9 dismissed with reasons:
  - Inherited from the reviewed upstream reference, kept for parity and fixable there first: wrong-shape PR ledger crashes the comment job while broken JSON silently becomes `{}` (data problem; the read-only gate still enforces), the comment compares against the base tip rather than the merge-base, the sticky-comment lookup doesn't filter by author, hand-rolled argv parsing, lowercase noqa codes counted although ruff rejects them (overcount, fails safe), and untracked files included in `--update` scans (deliberate per the code comment, so pre-`git add` updates work).
  - Port-parity choices: the gate workflow re-runs the test file py-test also runs (intentional: proves the gate passes in a bare environment with no project install); bare `python3` in the Makefile matches the existing targets' assumption that the dev env is on PATH (repo requires Python >= 3.10).
  - Out of scope: enforcing "never the bare code-less form" via ruff PGH004 / mypy `ignore-without-code` is a checker-config change that belongs with #594's territory and would need the 270 baselined entries handled; possible follow-up.
