### PR TITLE
ci: compare suppression ledger after merge

### DIFF
--- a/.github/workflows/suppressions-comment.yml
+++ b/.github/workflows/suppressions-comment.yml
@@ -16,16 +16,17 @@
 #      out the base branch: the delta script and the base ledger are the
 #      base repo's own trusted copies. A PR's changes to the script take
 #      effect only after a maintainer merges them.
-#   2. PR content is data, never code. The PR's suppressions.json is read
-#      with `git show` on the fetched head ref — that reads a blob and
-#      executes nothing. The PR head is never checked out.
+#   2. PR content is data, never code. The PR head is fetched but never
+#      checked out. `git merge-tree` computes the post-merge tree without
+#      touching the worktree or index, then `git show` reads only its
+#      suppressions.json blob.
 #   3. No dependency installs. The delta script is stdlib-only by design;
 #      installing the project (pip/uv) would execute PR-controllable
 #      setup and dependency code.
 #
-# Do NOT "fix" this workflow by checking out the PR head, running any
-# script from it, or adding an install step — any of those breaks the
-# security model.
+# Do NOT "fix" this workflow by checking out the PR head or computed merge
+# tree, running any script from it, or adding an install step — any of those
+# breaks the security model.
 name: Suppressions comment
 
 on:
@@ -48,8 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # No `ref`: on pull_request_target this checks out the BASE branch
-      # (trusted script + base ledger). Never add ref: pull_request.head.
+      # (trusted script + base ledger). Full history lets merge-tree find the
+      # PR's merge base without ever checking out PR-controlled content.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Comment ledger delta on PR
         env:
@@ -57,20 +61,37 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          # The PR's ledger is fetched and read as DATA: `git show` reads
-          # a blob and executes nothing. The PR head is never checked out.
-          git fetch --depth=1 origin "pull/$PR/head"
-          git show FETCH_HEAD:suppressions.json > /tmp/head-suppressions.json 2>/dev/null \
-            || echo '{}' > /tmp/head-suppressions.json
           # The workspace is the base branch, so its ledger is the base side.
           if [ -f suppressions.json ]; then
             cp suppressions.json /tmp/base-suppressions.json
           else
             echo '{}' > /tmp/base-suppressions.json
           fi
-          # Base script, system python, stdlib only — no installs (see the
-          # security model above).
-          body=$(python3 scripts/suppressions_pr_delta.py /tmp/base-suppressions.json /tmp/head-suppressions.json)
+          # Compute the post-merge ledger as DATA without checking out or
+          # executing anything from the PR. GitHub's synthetic merge ref can be
+          # stale, while comparing the raw head misreports base-only burn-downs.
+          git fetch origin "refs/pull/$PR/head"
+          if merge_output=$(git merge-tree --write-tree --name-only --no-messages HEAD FETCH_HEAD); then
+            merge_status=0
+          else
+            merge_status=$?
+          fi
+          if [ "$merge_status" -ne 0 ] && [ "$merge_status" -ne 1 ]; then
+            exit "$merge_status"
+          fi
+          merge_tree="${merge_output%%$'\n'*}"
+          conflicted_paths="${merge_output#"$merge_tree"}"
+          if grep -Fqx 'suppressions.json' <<< "$conflicted_paths"; then
+            body=$(printf '%s\n%s' \
+              '<!-- suppressions-delta -->' \
+              'Suppression delta unavailable because suppressions.json does not merge cleanly with the current base. Resolve the conflict and update the PR to rerun this check.')
+          else
+            git show "$merge_tree:suppressions.json" > /tmp/merged-suppressions.json 2>/dev/null \
+              || echo '{}' > /tmp/merged-suppressions.json
+            # Base script, system python, stdlib only — no installs (see the
+            # security model above).
+            body=$(python3 scripts/suppressions_pr_delta.py /tmp/base-suppressions.json /tmp/merged-suppressions.json)
+          fi
           # Sticky comment: match on the marker, not --edit-last, so other
           # bot comments on the PR are never clobbered.
           cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \


### PR DESCRIPTION
The suppression-delta comment compared the base branch's ledger against the
PR head's ledger. When a branch is out of date with `main`, that diff also
contains ledger burn-downs that came from `main`, so a PR touching unrelated
files gets a false "suppression ledger changed" comment (seen on
meridianlabs-ai/ts-mono#606).

This computes the post-merge ledger instead, with
`git merge-tree --write-tree --name-only --no-messages HEAD FETCH_HEAD`:
the merged tree is produced without touching the worktree or index, so the
workflow still never checks out PR-controlled content. Exit 1 (conflicts) is
expected and handled; any other exit fails the step. If `suppressions.json`
itself is among the conflicted paths, the comment says the delta is
unavailable rather than falling back to the raw head. `fetch-depth: 0` and
dropping `--depth=1` from the PR fetch are required for `merge-tree` to find
the merge base.

Port of meridianlabs-ai/ts-mono#607 at commit
`1d88363fa549d502710a3ec88e9ea52be1851233`, with this repo's script path and
checkout action version kept.

Verified locally against real PR heads in this repo:

- PR #600 (clean merge): exit 0, tree OID parsed, empty conflicted-path list.
- PR #594 (conflicts on `Makefile`, not the ledger): exit 1, path list parsed,
  delta still computed from the merged tree.
- Synthetic commit with an add/add conflict on `suppressions.json`: exit 1,
  path matched, "delta unavailable" comment body rendered.
- `git show "$merge_tree:suppressions.json"` returns valid JSON; feeding it to
  `scripts/suppressions_pr_delta.py` renders an empty body when unchanged and
  the ledger table when a count is bumped.
- YAML parses; the `run` block passes `bash -n`. `actionlint`/`yamllint` are
  not installed here.

### Agent review
- Reviewer: none. No separate review pass was run on this port; the logic is
  taken verbatim from ts-mono#607, which is under review there, and the shell
  logic was instead exercised end to end locally (above).
- Prepared by Claude Opus 5 via Claude Code.
