### PR TITLE
chore: regenerate schema and types for GenerateConfig.stream_idle_timeout

### DIFF
--- a/.claude/skills/land-ts-mono/SKILL.md
+++ b/.claude/skills/land-ts-mono/SKILL.md
@@ -30,14 +30,16 @@ submodule gitlink (see the submodule guide in repo facts for background).
 - CI jobs (`.github/workflows/build.yaml`):
   - `check-schema-and-types` — artifacts must match the Python source (docstring-only drift tolerated) and each other (exactly)
   - `submodule-on-main` — the gitlink SHA must be reachable from ts-mono `main`
-- ts-mono has merge commits **disabled** (squash or rebase only), so merging
-  the ts-mono PR always lands its change under a *new* SHA. The branch head
-  the gitlink points at in phase 1 never becomes reachable from ts-mono
-  `main`, so `submodule-on-main` never clears by itself — a second gitlink
-  bump (step 4.2) is always required. Verify with
-  `gh api repos/meridianlabs-ai/ts-mono --jq '.allow_merge_commit'` if the
-  setting may have changed.
   - `js-dist-validation` — the checked-in viewer bundle `src/inspect_scout/_view/dist` must match `pnpm build` run at the pinned submodule commit (the scout app's vite build copies its output into this repo's `dist/`)
+- ts-mono has merge commits **disabled** (squash or rebase only). Both of
+  those rewrite the commit, so the merged change lands under a *new* SHA and
+  the branch head the gitlink points at in phase 1 does not become reachable
+  from ts-mono `main` — plan on the second gitlink bump in step 4.2. This
+  holds even for a single-commit PR sitting directly on `main`: GitHub's
+  "Rebase and merge" re-commits rather than fast-forwarding (measured on
+  ts-mono#609, 1 commit / 0 behind — `d9fcc775` → `24b515da`, identical
+  tree). A true fast-forward push straight to `main` would keep the SHA, but
+  that is not a path the PR UI offers.
 - Submodule checks before pushing: `pnpm typecheck` and `pnpm test` from the ts-mono root (turbo), not per-package tsc
 - Pipeline internals: "Type Sharing" section of `CLAUDE.md`; submodule workflows: `src/inspect_scout/_view/ts-mono/docs/submodule-guide.md`
 - Sibling consumer: `inspect_ai` (also embeds ts-mono, at `src/inspect_ai/_view/ts-mono`; its regen `python src/inspect_ai/_view/schema.py` produces `packages/inspect-common/src/types/generated.ts`). Types flow inspect_ai → scout: scout's `generated.ts` imports inspect-originated types from `@tsmono/inspect-common`, and nothing on the inspect_ai side duplicates scout's types — so scout Python changes rarely require a sibling sync (see step 2a).
@@ -168,9 +170,8 @@ moment the gate clears.
    opens at merge, so don't wait for the user to come back and tell you.
 2. Fetch in the submodule, then compare the gitlink SHA against ts-mono
    `origin/main`:
-   - **SHA changed** (squash/rebase merge) — the only case that occurs with
-     ts-mono's current settings: bump the gitlink to the merged
-     `main` SHA. The bump picks up **every** ts-mono `main` change since the
+   - **SHA changed** (squash or rebase merge — anything the ts-mono PR UI can
+     do): bump the gitlink to the merged `main` SHA. The bump picks up **every** ts-mono `main` change since the
      last bump, not just yours — so rebuild the viewer bundle at the new
      commit (`pnpm install --frozen-lockfile && pnpm build` in the
      submodule; the build copies output into this repo's
@@ -179,8 +180,9 @@ moment the gate clears.
      identically — but `js-dist-validation` fails if you skip the check and
      something did change). Push.
    - **SHA unchanged** (merge commit; branch head now reachable from main):
-     just re-run the red `submodule-on-main` check. Unreachable while
-     ts-mono disallows merge commits — kept only in case that changes.
+     just re-run the red `submodule-on-main` check. Requires the branch head
+     itself to land on `main` — merge commits are disabled on ts-mono and
+     rebase merge rewrites the commit, so expect this case not to arise.
 3. Enable auto-merge on this repo's PR (`gh pr merge --auto`) and tell the
    user — the PR lands automatically the moment the gate clears. Watch until
    it actually merges; if auto-merge is unavailable (repo settings), watch CI

--- a/.claude/skills/land-ts-mono/SKILL.md
+++ b/.claude/skills/land-ts-mono/SKILL.md
@@ -30,6 +30,13 @@ submodule gitlink (see the submodule guide in repo facts for background).
 - CI jobs (`.github/workflows/build.yaml`):
   - `check-schema-and-types` — artifacts must match the Python source (docstring-only drift tolerated) and each other (exactly)
   - `submodule-on-main` — the gitlink SHA must be reachable from ts-mono `main`
+- ts-mono has merge commits **disabled** (squash or rebase only), so merging
+  the ts-mono PR always lands its change under a *new* SHA. The branch head
+  the gitlink points at in phase 1 never becomes reachable from ts-mono
+  `main`, so `submodule-on-main` never clears by itself — a second gitlink
+  bump (step 4.2) is always required. Verify with
+  `gh api repos/meridianlabs-ai/ts-mono --jq '.allow_merge_commit'` if the
+  setting may have changed.
   - `js-dist-validation` — the checked-in viewer bundle `src/inspect_scout/_view/dist` must match `pnpm build` run at the pinned submodule commit (the scout app's vite build copies its output into this repo's `dist/`)
 - Submodule checks before pushing: `pnpm typecheck` and `pnpm test` from the ts-mono root (turbo), not per-package tsc
 - Pipeline internals: "Type Sharing" section of `CLAUDE.md`; submodule workflows: `src/inspect_scout/_view/ts-mono/docs/submodule-guide.md`
@@ -124,9 +131,11 @@ breaking shared-package changes in the ts-mono PR description.
 
 Result: this repo's PR is green **except** `submodule-on-main`. That one red
 gate is the expected signal meaning "waiting on ts-mono merge" — do not try
-to fix it yet. Note: `submodule-on-main` is a job inside the "Build"
-workflow, so that whole workflow shows as failing in rollup views — read
-job-level status before concluding anything else broke.
+to fix it yet. It stays red *through* the merge and clears only once you bump
+the gitlink to the merged SHA in step 4.2; don't tell anyone it will clear on
+its own. Note: `submodule-on-main` is a job inside the "Build" workflow, so
+that whole workflow shows as failing in rollup views — read job-level status
+before concluding anything else broke.
 
 **Why two-phase:** once ts-mono merges, its `main` depends on Python changes
 that aren't merged yet, blocking anyone else who pulls ts-mono `main`. The
@@ -159,7 +168,8 @@ moment the gate clears.
    opens at merge, so don't wait for the user to come back and tell you.
 2. Fetch in the submodule, then compare the gitlink SHA against ts-mono
    `origin/main`:
-   - **SHA changed** (squash/rebase merge): bump the gitlink to the merged
+   - **SHA changed** (squash/rebase merge) — the only case that occurs with
+     ts-mono's current settings: bump the gitlink to the merged
      `main` SHA. The bump picks up **every** ts-mono `main` change since the
      last bump, not just yours — so rebuild the viewer bundle at the new
      commit (`pnpm install --frozen-lockfile && pnpm build` in the
@@ -169,7 +179,8 @@ moment the gate clears.
      identically — but `js-dist-validation` fails if you skip the check and
      something did change). Push.
    - **SHA unchanged** (merge commit; branch head now reachable from main):
-     just re-run the red `submodule-on-main` check.
+     just re-run the red `submodule-on-main` check. Unreachable while
+     ts-mono disallows merge commits — kept only in case that changes.
 3. Enable auto-merge on this repo's PR (`gh pr merge --auto`) and tell the
    user — the PR lands automatically the moment the gate clears. Watch until
    it actually merges; if auto-merge is unavailable (repo settings), watch CI

--- a/src/inspect_scout/_view/dist/assets/index-2ckSjoWG.css
+++ b/src/inspect_scout/_view/dist/assets/index-2ckSjoWG.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64acad5fccfa0af6d898be5136063cb037250a58246387c0c37030ab6eaa994c
-size 536575

--- a/src/inspect_scout/_view/dist/assets/index-BMfxR3--.js
+++ b/src/inspect_scout/_view/dist/assets/index-BMfxR3--.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cc77700e3651b123b24821922a0d833d6c87233dbb367bca291ce4aadaeaecf
+size 3166736

--- a/src/inspect_scout/_view/dist/assets/index-CPngCFh4.css
+++ b/src/inspect_scout/_view/dist/assets/index-CPngCFh4.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ffd1246ade078e015913d648d1dc53cebf30e1a96271c3ab69c9d682904ee7
+size 536774

--- a/src/inspect_scout/_view/dist/assets/index-Cy-7lZbO.js
+++ b/src/inspect_scout/_view/dist/assets/index-Cy-7lZbO.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:178fa519fae7e37c46f97c143bc5b38f80c7b16cef67630481bee00c3e855d12
-size 3162740

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f91ec5ac73dc345bbc7fc3b6c8d5525ba0a47d01956e721db7ac7a49ba7b4b35
-size 3812
+oid sha256:9aabdcaf3e711aa42de7c3ac3bace79b2ac061243e46892a8bf370ca8f31329f
+size 3844

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -3130,6 +3130,17 @@
             ],
             "title": "Stop Seqs"
           },
+          "stream_idle_timeout": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream Idle Timeout"
+          },
           "system_message": {
             "anyOf": [
               {
@@ -3633,6 +3644,17 @@
               }
             ],
             "title": "Stop Seqs"
+          },
+          "stream_idle_timeout": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream Idle Timeout"
           },
           "system_message": {
             "anyOf": [


### PR DESCRIPTION
`ci / check-schema-and-types` is red on `main` with no scout change behind it. Upstream inspect_ai [#5096](https://github.com/UKGovernmentBEIS/inspect_ai/pull/5096) added `GenerateConfig.stream_idle_timeout`; the committed `openapi.json` embeds inspect_ai's `GenerateConfig` schema and is generated against inspect_ai **main** by design, so the new upstream field reads as structural drift. First failure: [nightly run 33607936645](https://github.com/meridianlabs-ai/inspect_scout/actions/runs/33607936645). It is not nightly-only — the job installs inspect_ai from git main on every PR and push to `main`.

Pure regeneration, no hand edits:

- `src/inspect_scout/_view/openapi.json` — `stream_idle_timeout` added to `GenerateConfig-Input` and `GenerateConfig-Output` (22 lines).
- ts-mono gitlink `86bdc2af` → `24b515da`, the merge of the paired PR meridianlabs-ai/ts-mono#609 (merged), which regenerates `apps/scout/src/types/generated.ts` (4 lines).
- `dist/` rebuilt at that submodule commit. The gitlink was branched from ts-mono `main`, so it also carries the 20 ts-mono `main` commits landed since the last bump; the rebuild is what `js-dist-validation` demands and is limited to the main `index` js/css chunks and the `index.html` references to them.

Also carries two hand-written commits to `.claude/skills/land-ts-mono/SKILL.md`. The skill described the phase-1 `submodule-on-main` red as "waiting on ts-mono merge", which reads as if merging clears it; it does not, because both merge styles ts-mono allows rewrite the commit. Measured here: #609 was one commit and zero behind `main`, and "Rebase and merge" still produced a new SHA (`d9fcc775` → `24b515da`, identical tree), so the gitlink needed the second bump in the skill's step 4.2. Say separately if you'd rather that rode its own PR.

Generated with inspect_ai installed from main (`0.3.262.dev66+g76f1aa761`) via `.venv/bin/python scripts/export_openapi_schema.py`.

`submodule-on-main` is the expected phase-1 red: the gitlink points at a ts-mono branch head, not at ts-mono `main`.

**Merge order.** Merge ts-mono#609 first. ts-mono has merge commits disabled (squash or rebase only), so `d9fcc775` will not become an ancestor of ts-mono `main` and the gate will not clear on its own — this PR then needs one more commit bumping the gitlink to the squash SHA, with a `pnpm build` / `dist` re-check at that commit (`land-ts-mono` step 4.2). #609 is types-only, so the rebuild should be a no-op, but `js-dist-validation` fails if it is skipped.

### Verification

Reproduced before fixing, at `9627fb55` with the artifacts as committed:

```
$ .venv/bin/python scripts/export_openapi_schema.py
$ .venv/bin/python .github/scripts/check_openapi_drift.py
+          "stream_idle_timeout": {
+            "anyOf": [ { "type": "integer" }, { "type": "null" } ],
+            "title": "Stream Idle Timeout"
...
src/inspect_scout/_view/openapi.json has structural (non-docstring) changes.
DRIFT EXIT=1
```

After this commit, the same two commands are a no-op:

```
DRIFT EXIT=0
$ git diff --exit-code -- src/inspect_scout/_view/openapi.json     # clean
$ git -C .../ts-mono diff --exit-code -- apps/scout/src/types/generated.ts   # clean
$ pnpm --filter scout types:generate && git diff --exit-code -- apps/scout/src/types/generated.ts   # clean
$ pnpm build && git diff --exit-code -- src/inspect_scout/_view/dist   # clean
```

ts-mono root: `pnpm check` 33/33, `pnpm typecheck` 15/15. `pnpm test` fails `@tsmono/inspect-components` identically before and after — its `fixtureTimeline.test.ts` reads fixtures from the embedding parent repo, so this repo's 50 fixtures activate a suite standalone ts-mono CI skips. Pre-existing and unrelated; flagged on ts-mono#609.

### Agent review

- Prepared by Claude Opus 5 (1M context) via Claude Code.
- No separate reviewer pass. The whole diff is generator output, so verification went to the generator rather than the text: the drift was reproduced against inspect_ai main first, and every generator and build step above is a no-op against the committed result.
