### PR TITLE
perf: bound the segments an llm_scanner holds and scans at once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "click>=8.1.3,!=8.2.0,!=8.2.2,!=8.3.0,!=8.3.1",
     "cloudpickle>=3.0.0",
     "duckdb>=1.4.0",
+    "exceptiongroup; python_version < '3.11'",
     "fastapi>=0.128.1",
     "ijson>=3.2.0",
     "importlib-metadata",

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -1,7 +1,7 @@
-from functools import partial
-from typing import Any, Awaitable, Callable, Literal, cast, overload
+import sys
+from typing import Any, AsyncIterator, Awaitable, Callable, Literal, cast, overload
 
-from inspect_ai._util._async import tg_collect
+import anyio
 from inspect_ai._util.content import ContentText
 from inspect_ai.model import (
     CachePolicy,
@@ -35,6 +35,52 @@ from .prompt import (
     DEFAULT_SCANNER_TEMPLATE_SUFFIX,
 )
 from .types import AnswerSpec
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
+
+_SEGMENT_WINDOW_CAP = 16  # bound memory: one rendered segment string per slot
+
+
+async def _scan_segments_bounded(
+    source: AsyncIterator[tuple[str | None, str]],
+    scan_segment: Callable[[str], Awaitable[Result]],
+    model: Model,
+) -> list[tuple[str | None, Result]]:
+    """Scan lazily-yielded segments with bounded concurrency, in order.
+
+    Each ``(span_id, messages_str)`` from ``source`` is scanned; results return
+    in segment order (reduction is order-sensitive). A failing segment raises
+    its original exception, unwrapped from the task-group ``ExceptionGroup``.
+    """
+    # Never bound below what the model layer will run anyway -- those tasks would
+    # just queue on inspect_ai's own semaphore. The cap is the memory policy, and
+    # it also clamps batch mode's much larger connection limit.
+    window = anyio.Semaphore(
+        min(
+            model.config.max_connections or model.api.max_connections(),
+            _SEGMENT_WINDOW_CAP,
+        )
+    )
+    indexed: list[tuple[int, str | None, Result]] = []
+
+    async def scan_bounded(index: int, span_id: str | None, messages_str: str) -> None:
+        try:
+            indexed.append((index, span_id, await scan_segment(messages_str)))
+        finally:
+            window.release()
+
+    try:
+        async with anyio.create_task_group() as tg:
+            index = 0
+            async for span_id, messages_str in source:
+                await window.acquire()
+                tg.start_soon(scan_bounded, index, span_id, messages_str)
+                index += 1
+    except ExceptionGroup as ex:
+        raise ex.exceptions[0] from None
+
+    return [(span_id, r) for _, span_id, r in sorted(indexed, key=lambda t: t[0])]
 
 
 @overload
@@ -303,8 +349,10 @@ def llm_scanner(
                 "the scanner template."
             )
 
-        segments = [
-            seg
+        async def source() -> AsyncIterator[tuple[str | None, str]]:
+            # Pair each segment with its originating span id (None on
+            # non-timeline paths) so aggregate_results can group timeline
+            # chunks by span.
             async for seg in transcript_messages(
                 transcript,
                 messages_as_str=messages_as_str_fn,
@@ -314,20 +362,11 @@ def llm_scanner(
                 compaction=compaction,
                 depth=depth,
                 prompt_reserve=template_tokens,
-            )
-        ]
-        segment_results: list[Result] = await tg_collect(
-            [partial(scan_segment, seg.messages_str) for seg in segments]
-        )
-        # Pair each result with its originating span id (None on non-timeline
-        # paths) so aggregate_results can group timeline chunks by span.
-        results: list[tuple[str | None, Result]] = [
-            (
-                seg.span.id if isinstance(seg, TimelineMessages) else None,
-                result,
-            )
-            for seg, result in zip(segments, segment_results, strict=True)
-        ]
+            ):
+                span_id = seg.span.id if isinstance(seg, TimelineMessages) else None
+                yield span_id, seg.messages_str
+
+        results = await _scan_segments_bounded(source(), scan_segment, resolved_model)
 
         return await aggregate_results(
             results=results,

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -48,11 +48,10 @@ async def _scan_segments_bounded(
     scan_segment: Callable[[str], Awaitable[Result]],
     model: Model,
 ) -> list[tuple[str | None, Result]]:
-    """Scan lazily-yielded segments with bounded concurrency, in order.
+    """Scan lazily-yielded segments with bounded concurrency, in segment order.
 
-    Each ``(span_id, messages_str)`` from ``source`` is scanned; results return
-    in segment order (reduction is order-sensitive). A failing segment raises
-    its original exception, unwrapped from the task-group ``ExceptionGroup``.
+    A failing segment raises its original exception, unwrapped from the
+    task-group ``ExceptionGroup``.
     """
     # Never bound below what the model layer will run anyway -- those tasks would
     # just queue on inspect_ai's own semaphore. The cap is the memory policy, and
@@ -86,6 +85,7 @@ async def _scan_segments_bounded(
     except ExceptionGroup as ex:
         raise ex.exceptions[0] from None
 
+    # Reduction is order-sensitive, so undo the completion-order interleaving.
     return [(span_id, r) for _, span_id, r in sorted(indexed, key=lambda t: t[0])]
 
 

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -43,7 +43,10 @@ from .types import AnswerSpec
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
-_SEGMENT_WINDOW_CAP = 16  # bound memory: one rendered segment string per slot
+# Bounds memory (one rendered segment string per slot), not connections:
+# inspect_ai's own per-model semaphore gates the real generate calls, so a
+# surplus admitted task costs a string and nothing else.
+_SEGMENT_WINDOW_CAP = 16
 
 
 async def _scan_segments_bounded(
@@ -52,15 +55,11 @@ async def _scan_segments_bounded(
 ) -> list[tuple[str | None, Result]]:
     """Scan lazily-yielded segments with bounded concurrency, in segment order.
 
-    inspect_ai's own per-model semaphore gates real connections, so the cap is
-    purely the memory policy: a surplus admitted task costs one rendered string.
-
     Each result is paired with its originating span id (None on non-timeline
     paths) so ``aggregate_results`` can group timeline chunks by span.
 
-    A failing segment aborts the whole scan; its own exception is re-raised in
-    place of the task group's ``ExceptionGroup`` so callers see the scanner
-    error rather than the wrapper.
+    A failing segment aborts the scan and raises its own exception, unwrapped
+    from the task group's ``ExceptionGroup``.
     """
     window = anyio.Semaphore(_SEGMENT_WINDOW_CAP)
     indexed: list[tuple[int, str | None, Result]] = []

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -2,7 +2,6 @@ import sys
 from typing import Any, AsyncIterator, Awaitable, Callable, Literal, cast, overload
 
 import anyio
-from inspect_ai._util.constants import DEFAULT_MAX_CONNECTIONS_BATCH
 from inspect_ai._util.content import ContentText
 from inspect_ai.model import (
     CachePolicy,
@@ -25,7 +24,11 @@ from .._scanner.scanner import (
     Scanner,
     scanner,
 )
-from .._transcript.messages import _effective_segment_budget, transcript_messages
+from .._transcript.messages import (
+    MessagesSegment,
+    _effective_segment_budget,
+    transcript_messages,
+)
 from .._transcript.timeline import TimelineMessages
 from .._transcript.types import Transcript, TranscriptContent
 from ._reducer import aggregate_results
@@ -44,29 +47,22 @@ _SEGMENT_WINDOW_CAP = 16  # bound memory: one rendered segment string per slot
 
 
 async def _scan_segments_bounded(
-    source: AsyncIterator[tuple[str | None, str]],
+    segments: AsyncIterator[MessagesSegment],
     scan_segment: Callable[[str], Awaitable[Result]],
-    model: Model,
 ) -> list[tuple[str | None, Result]]:
     """Scan lazily-yielded segments with bounded concurrency, in segment order.
 
-    A failing segment raises its original exception, unwrapped from the
-    task-group ``ExceptionGroup``.
+    inspect_ai's own per-model semaphore gates real connections, so the cap is
+    purely the memory policy: a surplus admitted task costs one rendered string.
+
+    Each result is paired with its originating span id (None on non-timeline
+    paths) so ``aggregate_results`` can group timeline chunks by span.
+
+    A failing segment aborts the whole scan; its own exception is re-raised in
+    place of the task group's ``ExceptionGroup`` so callers see the scanner
+    error rather than the wrapper.
     """
-    # Never bound below what the model layer will run anyway -- those tasks would
-    # just queue on inspect_ai's own semaphore. The cap is the memory policy, and
-    # it also clamps batch mode's much larger connection limit.
-    window = anyio.Semaphore(
-        min(
-            model.config.max_connections
-            or (
-                DEFAULT_MAX_CONNECTIONS_BATCH
-                if model.config.batch
-                else model.api.max_connections()
-            ),
-            _SEGMENT_WINDOW_CAP,
-        )
-    )
+    window = anyio.Semaphore(_SEGMENT_WINDOW_CAP)
     indexed: list[tuple[int, str | None, Result]] = []
 
     async def scan_bounded(index: int, span_id: str | None, messages_str: str) -> None:
@@ -78,11 +74,25 @@ async def _scan_segments_bounded(
     try:
         async with anyio.create_task_group() as tg:
             index = 0
-            async for span_id, messages_str in source:
+            while True:
+                # Admit before pulling: `async for` renders the next segment
+                # while the window is full, holding one string over the cap.
                 await window.acquire()
-                tg.start_soon(scan_bounded, index, span_id, messages_str)
+                seg = await anext(segments, None)
+                if seg is None:
+                    window.release()
+                    break
+                tg.start_soon(
+                    scan_bounded,
+                    index,
+                    seg.span.id if isinstance(seg, TimelineMessages) else None,
+                    seg.messages_str,
+                )
                 index += 1
     except ExceptionGroup as ex:
+        # Deliberately not inspect_ai's `inner_exception`: it also walks
+        # `__context__`, and picks from an unordered set -- so an unrelated
+        # chained exception can win over the segment's actual failure.
         raise ex.exceptions[0] from None
 
     # Reduction is order-sensitive, so undo the completion-order interleaving.
@@ -355,11 +365,8 @@ def llm_scanner(
                 "the scanner template."
             )
 
-        async def source() -> AsyncIterator[tuple[str | None, str]]:
-            # Pair each segment with its originating span id (None on
-            # non-timeline paths) so aggregate_results can group timeline
-            # chunks by span.
-            async for seg in transcript_messages(
+        results = await _scan_segments_bounded(
+            transcript_messages(
                 transcript,
                 messages_as_str=messages_as_str_fn,
                 model=resolved_model,
@@ -368,11 +375,9 @@ def llm_scanner(
                 compaction=compaction,
                 depth=depth,
                 prompt_reserve=template_tokens,
-            ):
-                span_id = seg.span.id if isinstance(seg, TimelineMessages) else None
-                yield span_id, seg.messages_str
-
-        results = await _scan_segments_bounded(source(), scan_segment, resolved_model)
+            ),
+            scan_segment,
+        )
 
         return await aggregate_results(
             results=results,

--- a/src/inspect_scout/_llm_scanner/_llm_scanner.py
+++ b/src/inspect_scout/_llm_scanner/_llm_scanner.py
@@ -2,6 +2,7 @@ import sys
 from typing import Any, AsyncIterator, Awaitable, Callable, Literal, cast, overload
 
 import anyio
+from inspect_ai._util.constants import DEFAULT_MAX_CONNECTIONS_BATCH
 from inspect_ai._util.content import ContentText
 from inspect_ai.model import (
     CachePolicy,
@@ -58,7 +59,12 @@ async def _scan_segments_bounded(
     # it also clamps batch mode's much larger connection limit.
     window = anyio.Semaphore(
         min(
-            model.config.max_connections or model.api.max_connections(),
+            model.config.max_connections
+            or (
+                DEFAULT_MAX_CONNECTIONS_BATCH
+                if model.config.batch
+                else model.api.max_connections()
+            ),
             _SEGMENT_WINDOW_CAP,
         )
     )

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -228,6 +228,128 @@ async def segment_messages(
         )
 
 
+async def stream_segment_messages(
+    source: AsyncIterator[ChatMessage],
+    *,
+    messages_as_str: MessagesAsStr,
+    model: Model | str | None = None,
+    context_window: int | None = None,
+    prompt_reserve: int | float = 0.2,
+) -> AsyncIterator[MessagesSegment]:
+    """Streaming counterpart to ``segment_messages()``.
+
+    Consume ``source`` one message at a time and yield ``MessagesSegment``
+    instances as segments fill, so callers can process the first segment before
+    the rest is read.
+
+    Sizing matches ``segment_messages()``; token counts are serialized (one
+    ``count_tokens`` per chunk) since chunks aren't known ahead of time.
+
+    Args:
+        source: An async iterator of ChatMessage.
+        messages_as_str: Rendering function from ``message_numbering()``, called
+            sequentially to preserve counter ordering.
+        model: Model used for token counting.
+        context_window: Context window override; looked up from the model if None.
+        prompt_reserve: Window allowance for prompt scaffolding — a float
+            reserves that fraction, an int that many tokens (plus a safety
+            margin). Default 0.2 leaves 80% for messages.
+
+    Yields:
+        MessagesSegment instances within the token budget (a single oversized
+        chunk is still yielded alone). Segment counter increments across yields.
+    """
+    # Resolve model
+    model = get_model(model)
+
+    # Compute effective budget
+    effective_budget = max(
+        1,
+        _effective_segment_budget(
+            model=model,
+            context_window=context_window,
+            prompt_reserve=prompt_reserve,
+        ),
+    )
+
+    chunk_char_target = max(
+        1,
+        int(
+            effective_budget * _COUNT_CHUNK_BUDGET_FRACTION * _COUNT_EST_CHARS_PER_TOKEN
+        ),
+    )
+
+    segment_counter = 0
+    current_messages: list[ChatMessage] = []
+    current_texts: list[str] = []
+    running_tokens = 0
+
+    pending_chunk: list[tuple[ChatMessage, str]] = []
+    pending_chars = 0
+
+    async def close_chunk() -> tuple[list[ChatMessage], list[str], int]:
+        """Count tokens for the pending chunk and return its contents."""
+        nonlocal pending_chunk, pending_chars
+        chunk_messages = [msg for msg, _ in pending_chunk]
+        chunk_texts = [text for _, text in pending_chunk]
+        chunk_str = "\n".join(chunk_texts)
+        tokens = await model.count_tokens(chunk_str)
+        pending_chunk = []
+        pending_chars = 0
+        return chunk_messages, chunk_texts, tokens
+
+    async for msg in source:
+        text = await messages_as_str([msg])
+        if not text:  # Skip empty renders (e.g. filtered system messages)
+            continue
+
+        if pending_chunk and pending_chars + len(text) > chunk_char_target:
+            chunk_messages, chunk_texts, tokens = await close_chunk()
+
+            if current_messages and running_tokens + tokens > effective_budget:
+                yield MessagesSegment(
+                    messages=current_messages,
+                    messages_str="\n".join(current_texts),
+                    segment=segment_counter,
+                )
+                segment_counter += 1
+                current_messages = []
+                current_texts = []
+                running_tokens = 0
+
+            current_messages.extend(chunk_messages)
+            current_texts.extend(chunk_texts)
+            running_tokens += tokens
+
+        pending_chunk.append((msg, text))
+        pending_chars += len(text)
+
+    if pending_chunk:
+        chunk_messages, chunk_texts, tokens = await close_chunk()
+
+        if current_messages and running_tokens + tokens > effective_budget:
+            yield MessagesSegment(
+                messages=current_messages,
+                messages_str="\n".join(current_texts),
+                segment=segment_counter,
+            )
+            segment_counter += 1
+            current_messages = []
+            current_texts = []
+            running_tokens = 0
+
+        current_messages.extend(chunk_messages)
+        current_texts.extend(chunk_texts)
+        running_tokens += tokens
+
+    if current_messages:
+        yield MessagesSegment(
+            messages=current_messages,
+            messages_str="\n".join(current_texts),
+            segment=segment_counter,
+        )
+
+
 async def transcript_messages(
     transcript: "Transcript",
     *,

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -277,54 +277,41 @@ async def stream_segment_messages(
         ),
     )
 
+    async def chunks() -> AsyncIterator[tuple[list[ChatMessage], list[str], int]]:
+        """Group rendered messages into chunks, counting tokens once per chunk."""
+        pending: list[tuple[ChatMessage, str]] = []
+        pending_chars = 0
+
+        async def close() -> tuple[list[ChatMessage], list[str], int]:
+            texts = [text for _, text in pending]
+            return (
+                [msg for msg, _ in pending],
+                texts,
+                await model.count_tokens("\n".join(texts)),
+            )
+
+        async for msg in source:
+            text = await messages_as_str([msg])
+            if not text:  # Skip empty renders (e.g. filtered system messages)
+                continue
+
+            if pending and pending_chars + len(text) > chunk_char_target:
+                yield await close()
+                pending = []
+                pending_chars = 0
+
+            pending.append((msg, text))
+            pending_chars += len(text)
+
+        if pending:
+            yield await close()
+
     segment_counter = 0
     current_messages: list[ChatMessage] = []
     current_texts: list[str] = []
     running_tokens = 0
 
-    pending_chunk: list[tuple[ChatMessage, str]] = []
-    pending_chars = 0
-
-    async def close_chunk() -> tuple[list[ChatMessage], list[str], int]:
-        """Count tokens for the pending chunk and return its contents."""
-        nonlocal pending_chunk, pending_chars
-        chunk_messages = [msg for msg, _ in pending_chunk]
-        chunk_texts = [text for _, text in pending_chunk]
-        chunk_str = "\n".join(chunk_texts)
-        tokens = await model.count_tokens(chunk_str)
-        pending_chunk = []
-        pending_chars = 0
-        return chunk_messages, chunk_texts, tokens
-
-    async for msg in source:
-        text = await messages_as_str([msg])
-        if not text:  # Skip empty renders (e.g. filtered system messages)
-            continue
-
-        if pending_chunk and pending_chars + len(text) > chunk_char_target:
-            chunk_messages, chunk_texts, tokens = await close_chunk()
-
-            if current_messages and running_tokens + tokens > effective_budget:
-                yield MessagesSegment(
-                    messages=current_messages,
-                    messages_str="\n".join(current_texts),
-                    segment=segment_counter,
-                )
-                segment_counter += 1
-                current_messages = []
-                current_texts = []
-                running_tokens = 0
-
-            current_messages.extend(chunk_messages)
-            current_texts.extend(chunk_texts)
-            running_tokens += tokens
-
-        pending_chunk.append((msg, text))
-        pending_chars += len(text)
-
-    if pending_chunk:
-        chunk_messages, chunk_texts, tokens = await close_chunk()
-
+    async for chunk_messages, chunk_texts, tokens in chunks():
         if current_messages and running_tokens + tokens > effective_budget:
             yield MessagesSegment(
                 messages=current_messages,

--- a/src/inspect_scout/_transcript/messages.py
+++ b/src/inspect_scout/_transcript/messages.py
@@ -246,7 +246,7 @@ async def stream_segment_messages(
     ``count_tokens`` per chunk) since chunks aren't known ahead of time.
 
     Args:
-        source: An async iterator of ChatMessage.
+        source: Messages to segment, consumed one at a time.
         messages_as_str: Rendering function from ``message_numbering()``, called
             sequentially to preserve counter ordering.
         model: Model used for token counting.
@@ -259,10 +259,8 @@ async def stream_segment_messages(
         MessagesSegment instances within the token budget (a single oversized
         chunk is still yielded alone). Segment counter increments across yields.
     """
-    # Resolve model
     model = get_model(model)
 
-    # Compute effective budget
     effective_budget = max(
         1,
         _effective_segment_budget(

--- a/tests/llm_scanner/test_segment_concurrency.py
+++ b/tests/llm_scanner/test_segment_concurrency.py
@@ -134,6 +134,47 @@ async def test_bounded_segment_concurrency(
     assert peak <= limit, f"peak in-flight {peak} exceeded window limit={limit}"
 
 
+@pytest.mark.anyio
+async def test_bounded_segment_concurrency_batch_mode() -> None:
+    """Batch mode (no explicit max_connections) uses _SEGMENT_WINDOW_CAP, not the provider's non-batch default.
+
+    inspect_ai resolves batch mode's effective max_connections to
+    DEFAULT_MAX_CONNECTIONS_BATCH (10_000), far above the cap -- so the window
+    should reach _SEGMENT_WINDOW_CAP (16). `model.api.max_connections()` (10 for
+    mockllm) is the *non-batch* provider default and must not leak into the
+    window when `config.batch` is set.
+
+    Calls `_scan_segments_bounded` directly (skipping the full scanner and any
+    real `generate` call) so this isn't muddied by inspect_ai's own model-level
+    connection semaphore/cache, the same concern that ruled out measuring the
+    other two legs inside a mock `generate`.
+    """
+    model = get_model("mockllm/model", config=GenerateConfig(batch=True), memoize=False)
+    assert model.api.max_connections() == 10  # sanity: would wrongly cap the window
+
+    in_flight = 0
+    peak = 0
+
+    async def scan_segment(messages_str: str) -> Result:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        try:
+            await anyio.sleep(0.01)
+        finally:
+            in_flight -= 1
+        return Result(value=True)
+
+    async def source() -> AsyncIterator[tuple[str | None, str]]:
+        for i in range(20):
+            yield None, f"segment {i}"
+
+    await llm_scanner_mod._scan_segments_bounded(source(), scan_segment, model)
+
+    assert peak > 10, f"window degraded to the non-batch provider default (peak={peak})"
+    assert peak <= 16
+
+
 # ---------------------------------------------------------------------------
 # segment order preserved through reduction
 # ---------------------------------------------------------------------------

--- a/tests/llm_scanner/test_segment_concurrency.py
+++ b/tests/llm_scanner/test_segment_concurrency.py
@@ -1,8 +1,8 @@
 """Tests for llm_scanner's bounded segment concurrency window.
 
-Covers `_scan_segments_bounded`'s window sizing -- `min(model's effective
-max_connections, _SEGMENT_WINDOW_CAP)` -- and that segment order survives
-concurrent scanning + reduction.
+Covers that `_scan_segments_bounded` admits no more than `_SEGMENT_WINDOW_CAP`
+segments at once, and that segment order survives concurrent scanning +
+reduction.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from inspect_ai.tool import ToolChoice, ToolInfo
 from inspect_scout import llm_scanner
 from inspect_scout._llm_scanner import _llm_scanner as llm_scanner_mod
 from inspect_scout._scanner.result import Result
+from inspect_scout._transcript.messages import MessagesSegment
 from inspect_scout._transcript.types import Transcript
 
 
@@ -43,37 +44,21 @@ def _make_transcript(n_messages: int, *, words: int = 3) -> Transcript:
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("window_cap", "max_connections", "limit"),
-    [
-        # cap binds: model allows more connections than the cap permits.
-        pytest.param(2, 10, 2, id="cap-binds"),
-        # connections bind: the model allows fewer than the (much larger) cap.
-        pytest.param(16, 2, 2, id="connections-bind"),
-    ],
-)
-async def test_bounded_segment_concurrency(
-    monkeypatch: pytest.MonkeyPatch,
-    window_cap: int,
-    max_connections: int,
-    limit: int,
-) -> None:
-    """No more than min(_SEGMENT_WINDOW_CAP, model max_connections) segments scan concurrently."""
-    monkeypatch.setattr(llm_scanner_mod, "_SEGMENT_WINDOW_CAP", window_cap)
+async def test_bounded_segment_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No more than _SEGMENT_WINDOW_CAP segments are scanned concurrently."""
+    monkeypatch.setattr(llm_scanner_mod, "_SEGMENT_WINDOW_CAP", 2)
 
     # Count concurrency at _scan_segments_bounded's own admission window, not
     # inside the mock `generate` call: inspect_ai's model-level connection
-    # semaphore independently caps concurrent `generate` calls at
-    # max_connections, which would mask an under-derived window on the
-    # connections-bind leg if measured there instead.
+    # semaphore independently caps concurrent `generate` calls, which would
+    # mask a window that admits too many segments if measured there instead.
     in_flight = 0
     peak = 0
     original_bounded = llm_scanner_mod._scan_segments_bounded
 
     async def counting_bounded(
-        source: AsyncIterator[tuple[str | None, str]],
+        segments: AsyncIterator[MessagesSegment],
         scan_segment: Callable[[str], Awaitable[Result]],
-        model: Model,
     ) -> list[tuple[str | None, Result]]:
         async def counted_segment(messages_str: str) -> Result:
             nonlocal in_flight, peak
@@ -84,7 +69,7 @@ async def test_bounded_segment_concurrency(
             finally:
                 in_flight -= 1
 
-        return await original_bounded(source, counted_segment, model)
+        return await original_bounded(segments, counted_segment)
 
     monkeypatch.setattr(llm_scanner_mod, "_scan_segments_bounded", counting_bounded)
 
@@ -104,12 +89,7 @@ async def test_bounded_segment_concurrency(
             stop_reason="stop",
         )
 
-    mock_model = get_model(
-        "mockllm/model",
-        custom_outputs=custom,
-        memoize=False,
-        config=GenerateConfig(max_connections=max_connections),
-    )
+    mock_model = get_model("mockllm/model", custom_outputs=custom, memoize=False)
 
     scan_fn = llm_scanner(
         question="Is this helpful?",
@@ -122,48 +102,40 @@ async def test_bounded_segment_concurrency(
     await scan_fn(transcript)
 
     assert peak > 1, "test should exercise concurrency (multiple segments in flight)"
-    assert peak <= limit, f"peak in-flight {peak} exceeded window limit={limit}"
+    assert peak <= 2, f"peak in-flight {peak} exceeded the window cap"
 
 
 @pytest.mark.anyio
-async def test_bounded_segment_concurrency_batch_mode() -> None:
-    """Batch mode (no explicit max_connections) uses _SEGMENT_WINDOW_CAP, not the provider's non-batch default.
+async def test_segment_window_admits_before_pulling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A window slot is taken before the next segment is pulled off the source.
 
-    inspect_ai resolves batch mode's effective max_connections to
-    DEFAULT_MAX_CONNECTIONS_BATCH (10_000), far above the cap -- so the window
-    should reach _SEGMENT_WINDOW_CAP (16). `model.api.max_connections()` (10 for
-    mockllm) is the *non-batch* provider default and must not leak into the
-    window when `config.batch` is set.
-
-    Calls `_scan_segments_bounded` directly (skipping the full scanner and any
-    real `generate` call) so this isn't muddied by inspect_ai's own model-level
-    connection semaphore/cache, the same concern that ruled out measuring the
-    other two legs inside a mock `generate`.
+    Pulling first would render (and hold) one segment string beyond the cap.
     """
-    model = get_model("mockllm/model", config=GenerateConfig(batch=True), memoize=False)
-    assert model.api.max_connections() == 10  # sanity: would wrongly cap the window
+    monkeypatch.setattr(llm_scanner_mod, "_SEGMENT_WINDOW_CAP", 2)
 
-    in_flight = 0
-    peak = 0
+    pulled = 0
+    completed = 0
+
+    async def segments() -> AsyncIterator[MessagesSegment]:
+        nonlocal pulled
+        for i in range(6):
+            pulled += 1
+            yield MessagesSegment(messages=[], messages_str=f"seg {i}", segment=i)
 
     async def scan_segment(messages_str: str) -> Result:
-        nonlocal in_flight, peak
-        in_flight += 1
-        peak = max(peak, in_flight)
-        try:
-            await anyio.sleep(0.01)
-        finally:
-            in_flight -= 1
+        nonlocal completed
+        await anyio.sleep(0.01)
+        assert pulled <= completed + 2, (
+            f"pulled {pulled} segments with {completed} scanned and a cap of 2"
+        )
+        completed += 1
         return Result(value=True)
 
-    async def source() -> AsyncIterator[tuple[str | None, str]]:
-        for i in range(20):
-            yield None, f"segment {i}"
+    await llm_scanner_mod._scan_segments_bounded(segments(), scan_segment)
 
-    await llm_scanner_mod._scan_segments_bounded(source(), scan_segment, model)
-
-    assert peak > 10, f"window degraded to the non-batch provider default (peak={peak})"
-    assert peak <= 16
+    assert pulled == 6
 
 
 # -- segment order tests --

--- a/tests/llm_scanner/test_segment_concurrency.py
+++ b/tests/llm_scanner/test_segment_concurrency.py
@@ -23,7 +23,6 @@ from inspect_ai.tool import ToolChoice, ToolInfo
 from inspect_scout import llm_scanner
 from inspect_scout._llm_scanner import _llm_scanner as llm_scanner_mod
 from inspect_scout._scanner.result import Result
-from inspect_scout._scanner.scanner import Scanner
 from inspect_scout._transcript.types import Transcript
 
 
@@ -40,15 +39,7 @@ def _make_transcript(n_messages: int, *, words: int = 3) -> Transcript:
     return Transcript(transcript_id="t", messages=msgs)
 
 
-async def _scan(scan_fn: Scanner[Transcript], transcript: Transcript) -> Result:
-    out = await scan_fn(transcript)
-    assert isinstance(out, Result)
-    return out
-
-
-# ---------------------------------------------------------------------------
-# bounded concurrency: window = min(model max_connections, _SEGMENT_WINDOW_CAP)
-# ---------------------------------------------------------------------------
+# -- bounded concurrency tests --
 
 
 @pytest.mark.anyio
@@ -128,7 +119,7 @@ async def test_bounded_segment_concurrency(
         context_window=400,
     )
 
-    await _scan(scan_fn, transcript)
+    await scan_fn(transcript)
 
     assert peak > 1, "test should exercise concurrency (multiple segments in flight)"
     assert peak <= limit, f"peak in-flight {peak} exceeded window limit={limit}"
@@ -175,23 +166,7 @@ async def test_bounded_segment_concurrency_batch_mode() -> None:
     assert peak <= 16
 
 
-# ---------------------------------------------------------------------------
-# segment order preserved through reduction
-# ---------------------------------------------------------------------------
-
-
-def _make_recording_reducer() -> tuple[
-    Callable[[list[Result]], Awaitable[Result]], list[str]
-]:
-    """Build a reducer that records the answers it receives, in order."""
-    recorded: list[str] = []
-
-    async def reducer(results: list[Result]) -> Result:
-        recorded.clear()
-        recorded.extend(str(r.answer) for r in results)
-        return results[0]
-
-    return reducer, recorded
+# -- segment order tests --
 
 
 @pytest.mark.anyio
@@ -231,7 +206,13 @@ async def test_segment_order_preserved_in_reduction() -> None:
 
     mock_model: Model = get_model("mockllm/model", custom_outputs=custom, memoize=False)
 
-    reducer, recorded_order = _make_recording_reducer()
+    recorded_order: list[str] = []
+
+    async def reducer(results: list[Result]) -> Result:
+        recorded_order.clear()
+        recorded_order.extend(str(r.answer) for r in results)
+        return results[0]
+
     scan_fn = llm_scanner(
         question="What is here?",
         answer="string",
@@ -241,9 +222,8 @@ async def test_segment_order_preserved_in_reduction() -> None:
         reducer=reducer,
     )
 
-    await _scan(scan_fn, transcript)
+    await scan_fn(transcript)
 
     assert recorded_order, "reducer should have received multiple segments"
-    # Extract the leading index from each recorded answer ("seg0", "seg3", ...)
     indices = [int(ans.removeprefix("seg")) for ans in recorded_order]
     assert indices == sorted(indices), f"segment order not preserved: {indices}"

--- a/tests/llm_scanner/test_segment_concurrency.py
+++ b/tests/llm_scanner/test_segment_concurrency.py
@@ -1,0 +1,208 @@
+"""Tests for llm_scanner's bounded segment concurrency window.
+
+Covers `_scan_segments_bounded`'s window sizing -- `min(model's effective
+max_connections, _SEGMENT_WINDOW_CAP)` -- and that segment order survives
+concurrent scanning + reduction.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Awaitable, Callable
+
+import anyio
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageUser,
+    GenerateConfig,
+    Model,
+    ModelOutput,
+    get_model,
+)
+from inspect_ai.tool import ToolChoice, ToolInfo
+from inspect_scout import llm_scanner
+from inspect_scout._llm_scanner import _llm_scanner as llm_scanner_mod
+from inspect_scout._scanner.result import Result
+from inspect_scout._scanner.scanner import Scanner
+from inspect_scout._transcript.types import Transcript
+
+
+def _make_transcript(n_messages: int, *, words: int = 3) -> Transcript:
+    # Pad each message with filler words so it consumes enough tokens to force
+    # segmentation under a small context window, while keeping a unique
+    # "message number {i}" marker for order/identity checks.
+    msgs: list[ChatMessage] = [
+        ChatMessageUser(
+            content=f"message number {i} " + ("filler " * words), id=f"m{i}"
+        )
+        for i in range(n_messages)
+    ]
+    return Transcript(transcript_id="t", messages=msgs)
+
+
+async def _scan(scan_fn: Scanner[Transcript], transcript: Transcript) -> Result:
+    out = await scan_fn(transcript)
+    assert isinstance(out, Result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# bounded concurrency: window = min(model max_connections, _SEGMENT_WINDOW_CAP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("window_cap", "max_connections", "limit"),
+    [
+        # cap binds: model allows more connections than the cap permits.
+        pytest.param(2, 10, 2, id="cap-binds"),
+        # connections bind: the model allows fewer than the (much larger) cap.
+        pytest.param(16, 2, 2, id="connections-bind"),
+    ],
+)
+async def test_bounded_segment_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+    window_cap: int,
+    max_connections: int,
+    limit: int,
+) -> None:
+    """No more than min(_SEGMENT_WINDOW_CAP, model max_connections) segments scan concurrently."""
+    monkeypatch.setattr(llm_scanner_mod, "_SEGMENT_WINDOW_CAP", window_cap)
+
+    # Count concurrency at _scan_segments_bounded's own admission window, not
+    # inside the mock `generate` call: inspect_ai's model-level connection
+    # semaphore independently caps concurrent `generate` calls at
+    # max_connections, which would mask an under-derived window on the
+    # connections-bind leg if measured there instead.
+    in_flight = 0
+    peak = 0
+    original_bounded = llm_scanner_mod._scan_segments_bounded
+
+    async def counting_bounded(
+        source: AsyncIterator[tuple[str | None, str]],
+        scan_segment: Callable[[str], Awaitable[Result]],
+        model: Model,
+    ) -> list[tuple[str | None, Result]]:
+        async def counted_segment(messages_str: str) -> Result:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            try:
+                return await scan_segment(messages_str)
+            finally:
+                in_flight -= 1
+
+        return await original_bounded(source, counted_segment, model)
+
+    monkeypatch.setattr(llm_scanner_mod, "_scan_segments_bounded", counting_bounded)
+
+    transcript = _make_transcript(12, words=80)
+
+    async def custom(
+        input_msgs: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        # Yield control so overlapping calls can accumulate.
+        await anyio.sleep(0.01)
+        return ModelOutput.from_content(
+            model="mockllm",
+            content="Reasoning.\n\nANSWER: yes",
+            stop_reason="stop",
+        )
+
+    mock_model = get_model(
+        "mockllm/model",
+        custom_outputs=custom,
+        memoize=False,
+        config=GenerateConfig(max_connections=max_connections),
+    )
+
+    scan_fn = llm_scanner(
+        question="Is this helpful?",
+        answer="boolean",
+        model=mock_model,
+        # Force multiple small segments (yields 6 with this padding).
+        context_window=400,
+    )
+
+    await _scan(scan_fn, transcript)
+
+    assert peak > 1, "test should exercise concurrency (multiple segments in flight)"
+    assert peak <= limit, f"peak in-flight {peak} exceeded window limit={limit}"
+
+
+# ---------------------------------------------------------------------------
+# segment order preserved through reduction
+# ---------------------------------------------------------------------------
+
+
+def _make_recording_reducer() -> tuple[
+    Callable[[list[Result]], Awaitable[Result]], list[str]
+]:
+    """Build a reducer that records the answers it receives, in order."""
+    recorded: list[str] = []
+
+    async def reducer(results: list[Result]) -> Result:
+        recorded.clear()
+        recorded.extend(str(r.answer) for r in results)
+        return results[0]
+
+    return reducer, recorded
+
+
+@pytest.mark.anyio
+async def test_segment_order_preserved_in_reduction() -> None:
+    """Segment order survives concurrent scanning + reduction.
+
+    Each segment's mock answer encodes the message index it contains. The
+    recording reducer captures per-segment answers in the order it receives
+    them; asserting that order is ascending verifies the sort-by-index step.
+    """
+    n = 8
+    transcript = _make_transcript(n, words=80)
+
+    async def custom(
+        input_msgs: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        # Recover the message index embedded in the rendered prompt so each
+        # segment's answer is distinguishable and order-checkable.
+        text = "\n".join(m.text for m in input_msgs)
+        idx = -1
+        for i in range(n):
+            if f"message number {i}" in text:
+                idx = i
+                break
+        # Sleep longer for earlier segments so they COMPLETE last -- forcing
+        # out-of-order task completion. Only the sort-by-index step can then
+        # restore ascending order for the reducer.
+        await anyio.sleep(0.02 * (n - idx))
+        return ModelOutput.from_content(
+            model="mockllm",
+            content=f"Segment covering index {idx}.\n\nANSWER: seg{idx}",
+            stop_reason="stop",
+        )
+
+    mock_model: Model = get_model("mockllm/model", custom_outputs=custom, memoize=False)
+
+    reducer, recorded_order = _make_recording_reducer()
+    scan_fn = llm_scanner(
+        question="What is here?",
+        answer="string",
+        model=mock_model,
+        context_window=400,
+        # Use a reducer that just records order so we don't depend on an LLM.
+        reducer=reducer,
+    )
+
+    await _scan(scan_fn, transcript)
+
+    assert recorded_order, "reducer should have received multiple segments"
+    # Extract the leading index from each recorded answer ("seg0", "seg3", ...)
+    indices = [int(ans.removeprefix("seg")) for ans in recorded_order]
+    assert indices == sorted(indices), f"segment order not preserved: {indices}"

--- a/tests/llm_scanner/test_segment_concurrency.py
+++ b/tests/llm_scanner/test_segment_concurrency.py
@@ -1,9 +1,4 @@
-"""Tests for llm_scanner's bounded segment concurrency window.
-
-Covers that `_scan_segments_bounded` admits no more than `_SEGMENT_WINDOW_CAP`
-segments at once, and that segment order survives concurrent scanning +
-reduction.
-"""
+"""Tests for llm_scanner's bounded segment concurrency window."""
 
 from __future__ import annotations
 

--- a/tests/transcript/test_messages.py
+++ b/tests/transcript/test_messages.py
@@ -1,8 +1,8 @@
 """Tests for message extraction with compaction boundary handling."""
 
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Protocol
 
 import pytest
 from inspect_ai.event import CompactionEvent, Event, ModelEvent, ToolEvent
@@ -11,6 +11,7 @@ from inspect_ai.model import (
     ChatMessageAssistant,
     ChatMessageSystem,
     ChatMessageUser,
+    Model,
     ModelOutput,
     get_model,
 )
@@ -23,6 +24,7 @@ from inspect_scout._transcript.messages import (
     segment_messages,
     span_messages,
     span_tools,
+    stream_segment_messages,
     transcript_messages,
 )
 from inspect_scout._transcript.timeline import (
@@ -519,7 +521,80 @@ def test_span_tools_empty() -> None:
     assert span_tools([_make_model_event(input=[_user1])]) == []
 
 
-# -- segment_messages tests --
+# -- segment_messages / stream_segment_messages tests --
+#
+# The two segmenters share a behavioral contract, so most tests are
+# parametrized over a `segmenter` axis: "batch" runs `segment_messages` on a
+# list, "stream" runs `stream_segment_messages` on an async iterator.
+
+
+async def _make_source(
+    msgs: list[ChatMessage],
+) -> AsyncIterator[ChatMessage]:
+    """Turn a plain list into an async iterator (no progress tracking)."""
+    for msg in msgs:
+        yield msg
+
+
+class _Segmenter(Protocol):
+    """Runs one of the two message segmenters over a message list."""
+
+    async def __call__(
+        self,
+        msgs: list[ChatMessage],
+        *,
+        model: Model | None = None,
+        context_window: int | None = None,
+    ) -> list[MessagesSegment]: ...
+
+
+async def _segment_batch(
+    msgs: list[ChatMessage],
+    *,
+    model: Model | None = None,
+    context_window: int | None = None,
+) -> list[MessagesSegment]:
+    """Collect all MessagesSegment from segment_messages (list input)."""
+    model = model or get_model("mockllm/model")
+    msgs_as_str, _ = message_numbering()
+    return [
+        seg
+        async for seg in segment_messages(
+            msgs,
+            messages_as_str=msgs_as_str,
+            model=model,
+            context_window=context_window,
+        )
+    ]
+
+
+async def _segment_stream(
+    msgs: list[ChatMessage],
+    *,
+    model: Model | None = None,
+    context_window: int | None = None,
+) -> list[MessagesSegment]:
+    """Collect all MessagesSegment from stream_segment_messages (async input)."""
+    model = model or get_model("mockllm/model")
+    msgs_as_str, _ = message_numbering()
+    return [
+        seg
+        async for seg in stream_segment_messages(
+            _make_source(msgs),
+            messages_as_str=msgs_as_str,
+            model=model,
+            context_window=context_window,
+        )
+    ]
+
+
+segmenter_axis = pytest.mark.parametrize(
+    "segmenter",
+    [
+        pytest.param(_segment_batch, id="batch"),
+        pytest.param(_segment_stream, id="stream"),
+    ],
+)
 
 
 async def _collect(
@@ -542,10 +617,11 @@ async def _collect(
 
 
 @pytest.mark.anyio
-async def test_segment_messages_single_segment() -> None:
+@segmenter_axis
+async def test_segment_messages_single_segment(segmenter: _Segmenter) -> None:
     """Small message list fits in budget → single MessagesSegment."""
     msgs: list[ChatMessage] = [_user1, _asst1, _user2]
-    results = await _collect(msgs, context_window=10_000)
+    results = await segmenter(msgs, context_window=10_000)
 
     assert len(results) == 1
     assert results[0].segment == 0
@@ -587,8 +663,9 @@ async def test_segment_messages_with_events() -> None:
 
 
 @pytest.mark.anyio
-async def test_segment_messages_chunking() -> None:
-    """Large messages exceeding budget → multiple chunks."""
+@segmenter_axis
+async def test_segment_messages_chunking(segmenter: _Segmenter) -> None:
+    """Large messages exceeding budget → multiple chunks, numbered continuously."""
     long_text = "word " * 100  # ~100 tokens
     msgs: list[ChatMessage] = [
         ChatMessageUser(content=long_text, id="long-1"),
@@ -597,7 +674,7 @@ async def test_segment_messages_chunking() -> None:
     ]
     # Set budget so each message is its own segment (budget < single message tokens)
     # 80% of 50 = 40 tokens, each message is ~100+ tokens
-    results = await _collect(msgs, context_window=50)
+    results = await segmenter(msgs, context_window=50)
 
     assert len(results) == 3
     assert results[0].segment == 0
@@ -606,21 +683,10 @@ async def test_segment_messages_chunking() -> None:
     assert len(results[0].messages) == 1
     assert len(results[1].messages) == 1
     assert len(results[2].messages) == 1
-
-
-@pytest.mark.anyio
-async def test_segment_messages_continuous_numbering() -> None:
-    """Message numbering is continuous across chunks."""
-    long_text = "word " * 100
-    msgs: list[ChatMessage] = [
-        ChatMessageUser(content=long_text, id="long-1"),
-        ChatMessageUser(content=long_text, id="long-2"),
-    ]
-    results = await _collect(msgs, context_window=50)
-
-    assert len(results) == 2
+    # Message numbering is continuous across chunks.
     assert "[M1]" in results[0].messages_str
     assert "[M2]" in results[1].messages_str
+    assert "[M3]" in results[2].messages_str
 
 
 @pytest.mark.anyio
@@ -649,8 +715,9 @@ async def test_segment_messages_events_with_chunking() -> None:
 
 
 @pytest.mark.anyio
+@segmenter_axis
 async def test_segment_messages_counts_in_chunks(
-    monkeypatch: pytest.MonkeyPatch,
+    segmenter: _Segmenter, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Token counting batches messages into chunks, not one call per message."""
     model = get_model("mockllm/model")
@@ -670,15 +737,7 @@ async def test_segment_messages_counts_in_chunks(
     msgs: list[ChatMessage] = [
         ChatMessageUser(content=f"Message number {i}", id=f"m-{i}") for i in range(50)
     ]
-    msgs_as_str, _ = message_numbering()
-    results: list[MessagesSegment] = []
-    async for seg in segment_messages(
-        msgs,
-        messages_as_str=msgs_as_str,
-        model=model,
-        context_window=100_000,
-    ):
-        results.append(seg)
+    results = await segmenter(msgs, model=model, context_window=100_000)
 
     # All 50 messages fit in a single chunk → a single count_tokens call
     assert len(count_calls) == 1
@@ -687,22 +746,87 @@ async def test_segment_messages_counts_in_chunks(
 
 
 @pytest.mark.anyio
-async def test_segment_messages_empty_input() -> None:
-    """Empty list yields nothing."""
-    results = await _collect([], context_window=10_000)
+@segmenter_axis
+async def test_segment_messages_empty_input(segmenter: _Segmenter) -> None:
+    """Empty input yields nothing."""
+    results = await segmenter([], context_window=10_000)
     assert results == []
 
 
 @pytest.mark.anyio
-async def test_segment_messages_skips_empty_renders() -> None:
+@segmenter_axis
+async def test_segment_messages_skips_empty_renders(segmenter: _Segmenter) -> None:
     """System messages excluded by default preprocessor are skipped."""
     msgs: list[ChatMessage] = [_sys, _user1]
-    results = await _collect(msgs, context_window=10_000)
+    results = await segmenter(msgs, context_window=10_000)
 
     assert len(results) == 1
     assert len(results[0].messages) == 1
     assert results[0].messages[0] is _user1
     assert "[M1]" in results[0].messages_str
+
+
+# -- stream_segment_messages-only tests --
+
+
+@pytest.mark.anyio
+async def test_stream_segment_messages_releases_early() -> None:
+    """First segment is yielded before the source iterator is exhausted."""
+    long_text = "word " * 100  # ~100 tokens, forces one message per segment
+    total_messages = 6
+    consumed = 0
+
+    async def source() -> AsyncIterator[ChatMessage]:
+        nonlocal consumed
+        for i in range(total_messages):
+            yield ChatMessageUser(content=long_text, id=f"long-{i}")
+            consumed += 1
+
+    model = get_model("mockllm/model")
+    msgs_as_str, _ = message_numbering()
+
+    segments_seen = 0
+    async for _seg in stream_segment_messages(
+        source(),
+        messages_as_str=msgs_as_str,
+        model=model,
+        context_window=50,
+    ):
+        segments_seen += 1
+        if segments_seen == 1:
+            # The first segment must have been produced without the
+            # source having been fully drained yet.
+            assert consumed < total_messages
+            break
+
+    assert segments_seen == 1
+
+
+@pytest.mark.anyio
+async def test_stream_segment_messages_equivalence() -> None:
+    """Streamed segmentation matches batch segmentation on the same input."""
+    msgs: list[ChatMessage] = [
+        ChatMessageUser(content=f"Message number {i} " * 10, id=f"m-{i}")
+        for i in range(20)
+    ]
+
+    batch_results = await _segment_batch(msgs, context_window=500)
+    stream_results = await _segment_stream(msgs, context_window=500)
+
+    # Budget should be small enough to force multiple segments.
+    assert len(batch_results) >= 3
+
+    # Streamed output equals batch output: same segment indices, same
+    # rendered text, same messages.
+    assert [seg.segment for seg in stream_results] == [
+        seg.segment for seg in batch_results
+    ]
+    assert [seg.messages_str for seg in stream_results] == [
+        seg.messages_str for seg in batch_results
+    ]
+    assert [seg.messages for seg in stream_results] == [
+        seg.messages for seg in batch_results
+    ]
 
 
 # -- timeline_messages tests --

--- a/tests/transcript/test_messages.py
+++ b/tests/transcript/test_messages.py
@@ -549,7 +549,7 @@ class _Segmenter(Protocol):
 
 
 async def _segment_batch(
-    msgs: list[ChatMessage],
+    msgs: list[ChatMessage] | list[Event],
     *,
     model: Model | None = None,
     context_window: int | None = None,
@@ -597,25 +597,6 @@ segmenter_axis = pytest.mark.parametrize(
 )
 
 
-async def _collect(
-    source: list[ChatMessage] | list[Event],
-    *,
-    context_window: int | None = None,
-) -> list[MessagesSegment]:
-    """Helper to collect all MessagesSegment from segment_messages."""
-    model = get_model("mockllm/model")
-    msgs_as_str, _ = message_numbering()
-    results: list[MessagesSegment] = []
-    async for seg in segment_messages(
-        source,
-        messages_as_str=msgs_as_str,
-        model=model,
-        context_window=context_window,
-    ):
-        results.append(seg)
-    return results
-
-
 @pytest.mark.anyio
 @segmenter_axis
 async def test_segment_messages_single_segment(segmenter: _Segmenter) -> None:
@@ -635,7 +616,7 @@ async def test_segment_messages_single_segment(segmenter: _Segmenter) -> None:
 async def test_segment_messages_renders_text() -> None:
     """Rendered text contains [M1], [M2] etc. from message_numbering()."""
     msgs: list[ChatMessage] = [_user1, _asst1]
-    results = await _collect(msgs, context_window=10_000)
+    results = await _segment_batch(msgs, context_window=10_000)
 
     assert len(results) == 1
     text = results[0].messages_str
@@ -651,7 +632,7 @@ async def test_segment_messages_with_events() -> None:
         _make_compaction_event(type="summary"),
         _make_model_event(input=[_user2], output_content="Seg 1"),
     ]
-    results = await _collect(events, context_window=10_000)
+    results = await _segment_batch(events, context_window=10_000)
 
     # Now produces a single merged segment (not two separate segments)
     assert len(results) == 1
@@ -704,7 +685,7 @@ async def test_segment_messages_events_with_chunking() -> None:
             output_content=long_text,
         ),
     ]
-    results = await _collect(events, context_window=50)
+    results = await _segment_batch(events, context_window=50)
 
     # Messages are merged then chunked — segment counter should be
     # monotonically increasing
@@ -774,13 +755,13 @@ async def test_stream_segment_messages_releases_early() -> None:
     """First segment is yielded before the source iterator is exhausted."""
     long_text = "word " * 100  # ~100 tokens, forces one message per segment
     total_messages = 6
-    consumed = 0
+    read = 0
 
     async def source() -> AsyncIterator[ChatMessage]:
-        nonlocal consumed
+        nonlocal read
         for i in range(total_messages):
+            read += 1
             yield ChatMessageUser(content=long_text, id=f"long-{i}")
-            consumed += 1
 
     model = get_model("mockllm/model")
     msgs_as_str, _ = message_numbering()
@@ -794,9 +775,9 @@ async def test_stream_segment_messages_releases_early() -> None:
     ):
         segments_seen += 1
         if segments_seen == 1:
-            # The first segment must have been produced without the
-            # source having been fully drained yet.
-            assert consumed < total_messages
+            # Segment 0 holds the first message; the third is what closed
+            # the chunk that overflowed it. Nothing beyond that is read.
+            assert read == 3
             break
 
     assert segments_seen == 1

--- a/tests/transcript/test_messages.py
+++ b/tests/transcript/test_messages.py
@@ -531,7 +531,7 @@ def test_span_tools_empty() -> None:
 async def _make_source(
     msgs: list[ChatMessage],
 ) -> AsyncIterator[ChatMessage]:
-    """Turn a plain list into an async iterator (no progress tracking)."""
+    """Turn a plain list into an async iterator."""
     for msg in msgs:
         yield msg
 


### PR DESCRIPTION
## Summary

An `llm_scanner` over a long transcript rendered every segment into a list before scanning any of them, then issued one model call per segment with no ceiling. On a transcript that segments into hundreds of chunks, that is hundreds of rendered copies of the conversation resident at once.

Segments are now produced lazily and admitted through a fixed window, so at most `_SEGMENT_WINDOW_CAP` rendered segments exist at a time.

## Why a fixed cap and not a derived one

The window deliberately does *not* try to match the model's connection limit. `inspect_ai` already gates real requests with its own per-model semaphore, so a task admitted beyond that limit simply waits — it costs one rendered string, which is exactly what this cap bounds. An earlier version derived the window from `max_connections`; it read the unmerged config and mirrored only one of `inspect_ai`'s two concurrency strategies, so it under-bounded for most model shapes while claiming the opposite.

This is a behaviour change for any existing multi-segment `llm_scanner` user: fewer segments are in flight at once.

## Notes for reviewers

One of six PRs carved out of #491, which was closed as too large to review. This one stands alone on `main` and depends on none of the others.

`stream_segment_messages` lands here with no caller — its consumer is the viewer LLM-search slice, later in the series. It is a streaming counterpart to `segment_messages` with identical sizing rules, proven by parametrizing the existing suite over both.

### Agent review

- Author: Claude Opus 5, reviewed across several fresh-context passes including a five-dimension analysis and an independent `codex` pass.
- The derived-window removal above came out of that review: two reviewers independently found the derivation read the wrong config object, and a third had given it a clean bill.
- One proposed change was declined on evidence: switching the `ExceptionGroup` unwrap to `inner_exception` looked like a simplification but walks `__context__` and selects from an unordered set, which surfaces an unrelated `RuntimeError` as the user-visible scan error.
