### PR TITLE
perf: write recorded transcript columns as UTF-8 bytes instead of str

### DIFF
--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -532,17 +532,23 @@ def _sanitize_component(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_\-=+.,@]", "_", name)
 
 
-def _normalize_scalar(v: Any) -> Any:
+_SERIALIZED_INPUT_COLUMNS = frozenset({"input", "input_data"})
+"""Columns `ResultReport.to_df_columns` fills with pre-serialized UTF-8 JSON."""
+
+
+def _normalize_scalar(key: str, v: Any) -> Any:
     if v is None:
         return None
     if isinstance(v, bool):
         return v
     if isinstance(v, (str, int, float)):
         return v
-    # Pre-serialized UTF-8 JSON (the `input`/`input_data` columns). Passed
-    # through rather than JSON-encoded below, which would wrap it in quotes.
-    # `bytearray` because the spool hands its buffer over without copying it.
-    if isinstance(v, (bytes, bytearray)):
+    # `input`/`input_data` arrive pre-serialized as UTF-8 JSON: pass the buffer
+    # through, since `to_json` below would wrap it in quotes, and pyarrow
+    # decodes UTF-8 into a string column directly. Scoped to those two columns
+    # because any other one can hold arbitrary user metadata, where non-UTF-8
+    # bytes would reach pyarrow as an `ArrowInvalid` instead of `str(v)`.
+    if key in _SERIALIZED_INPUT_COLUMNS and isinstance(v, (bytes, bytearray)):
         return v
     # datetime/date
     try:
@@ -567,7 +573,7 @@ def _records_to_arrow(records: list[dict[str, Any]]) -> "pa.Table":
     import pyarrow as pa
 
     # First normalize scalars
-    norm = [{k: _normalize_scalar(v) for k, v in r.items()} for r in records]
+    norm = [{k: _normalize_scalar(k, v) for k, v in r.items()} for r in records]
 
     # Check for mixed-type columns and convert them to strings
     if norm:
@@ -593,8 +599,15 @@ def _records_to_arrow(records: list[dict[str, Any]]) -> "pa.Table":
         if mixed_cols:
             for record in norm:
                 for col in mixed_cols:
-                    if col in record and record[col] is not None:
-                        record[col] = str(record[col])
+                    value = record.get(col)
+                    if value is not None:
+                        # decode rather than `str()`, which would write the
+                        # b'...' repr into the cell
+                        record[col] = (
+                            value.decode()
+                            if isinstance(value, (bytes, bytearray))
+                            else str(value)
+                        )
 
     # Build arrays column-wise so string columns can use large_string offsets.
     # This avoids the ~2GB limit of Arrow's default string offset type.

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -539,6 +539,11 @@ def _normalize_scalar(v: Any) -> Any:
         return v
     if isinstance(v, (str, int, float)):
         return v
+    # Pre-serialized UTF-8 JSON (the `input`/`input_data` columns). Passed
+    # through rather than JSON-encoded below, which would wrap it in quotes.
+    # `bytearray` because the spool hands its buffer over without copying it.
+    if isinstance(v, (bytes, bytearray)):
+        return v
     # datetime/date
     try:
         from datetime import date, datetime
@@ -571,7 +576,14 @@ def _records_to_arrow(records: list[dict[str, Any]]) -> "pa.Table":
         for record in norm:
             for key, value in record.items():
                 if value is not None:
-                    val_type = type(value).__name__
+                    # str and buffers are all text for a string column, so a
+                    # column mixing them is not "mixed": stringifying here
+                    # would write b'...' into the cell.
+                    val_type = (
+                        "str"
+                        if isinstance(value, (bytes, bytearray))
+                        else type(value).__name__
+                    )
                     if key not in columns_types:
                         columns_types[key] = set()
                     columns_types[key].add(val_type)
@@ -598,7 +610,10 @@ def _records_to_arrow(records: list[dict[str, Any]]) -> "pa.Table":
     for column in columns:
         values = [record.get(column) for record in norm]
         non_null_values = [value for value in values if value is not None]
-        if non_null_values and all(isinstance(value, str) for value in non_null_values):
+        if non_null_values and all(
+            isinstance(value, (str, bytes, bytearray)) for value in non_null_values
+        ):
+            # pyarrow decodes UTF-8 bytes into a string column directly
             arrays[column] = pa.array(values, type=pa.large_string())
         else:
             arrays[column] = pa.array(values)

--- a/src/inspect_scout/_recorder/buffer.py
+++ b/src/inspect_scout/_recorder/buffer.py
@@ -543,11 +543,10 @@ def _normalize_scalar(key: str, v: Any) -> Any:
         return v
     if isinstance(v, (str, int, float)):
         return v
-    # `input`/`input_data` arrive pre-serialized as UTF-8 JSON: pass the buffer
-    # through, since `to_json` below would wrap it in quotes, and pyarrow
-    # decodes UTF-8 into a string column directly. Scoped to those two columns
-    # because any other one can hold arbitrary user metadata, where non-UTF-8
-    # bytes would reach pyarrow as an `ArrowInvalid` instead of `str(v)`.
+    # `input`/`input_data` arrive pre-serialized as UTF-8 JSON; pyarrow decodes
+    # UTF-8 into a string column directly, while `to_json` below would wrap the
+    # buffer in quotes. Scoped by key because any other column can hold
+    # arbitrary user bytes, which pyarrow rejects with `ArrowInvalid`.
     if key in _SERIALIZED_INPUT_COLUMNS and isinstance(v, (bytes, bytearray)):
         return v
     # datetime/date

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -14,7 +14,7 @@ from typing_extensions import TypeVar
 
 from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
 from inspect_scout._transcript.types import Transcript
-from inspect_scout._util._json import to_json_str_compact
+from inspect_scout._util._json import to_json_bytes_compact, to_json_str_compact
 
 # Reference comes from inspect_ai; __all__ marks it re-exported for strict mypy.
 __all__ = [
@@ -130,8 +130,9 @@ class ResultReport(BaseModel):
 
     def to_df_columns(
         self, *, pool_dedup: bool = True
-    ) -> dict[str, str | bool | int | float | None]:
-        columns: dict[str, str | bool | int | float | None] = {}
+    ) -> dict[str, str | bytes | bytearray | bool | int | float | None]:
+        # `input`/`input_data` are UTF-8 bytes: see `_serialize_input`.
+        columns: dict[str, str | bytes | bytearray | bool | int | float | None] = {}
 
         # input (transcript, event, or message)
         columns["input_type"] = self.input_type
@@ -232,23 +233,29 @@ def _serialize_input(
     input_type: ScannerInputNames,
     *,
     pool_dedup: bool,
-) -> tuple[str, str | None]:
+) -> tuple[bytes | bytearray, bytes | bytearray | None]:
     """Serialize scanner input, optionally condensing events.
+
+    Only "transcript" input pools events separately (second tuple element);
+    all other input types return None there.
+
+    Every branch returns UTF-8 bytes so the `input` column holds one type
+    regardless of which path produced it.
 
     Returns:
         (input_json, input_data_json | None)
     """
     if not pool_dedup or input_type not in ("transcript", "events"):
-        return to_json_str_compact(input), None
+        return to_json_bytes_compact(input), None
 
     if input_type == "transcript":
         assert isinstance(input, Transcript)
         condensed_events, events_data = condense_events(input.events)
         condensed = input.model_copy(update={"events": condensed_events})
-        return to_json_str_compact(condensed), to_json_str_compact(events_data)
+        return to_json_bytes_compact(condensed), to_json_bytes_compact(events_data)
 
     # input_type == "events"
     assert isinstance(input, Sequence)
     events = cast(Sequence[Event], input)
     condensed_events, events_data = condense_events(events)
-    return to_json_str_compact(condensed_events), to_json_str_compact(events_data)
+    return to_json_bytes_compact(condensed_events), to_json_bytes_compact(events_data)

--- a/src/inspect_scout/_scanner/result.py
+++ b/src/inspect_scout/_scanner/result.py
@@ -234,13 +234,7 @@ def _serialize_input(
     *,
     pool_dedup: bool,
 ) -> tuple[bytes | bytearray, bytes | bytearray | None]:
-    """Serialize scanner input, optionally condensing events.
-
-    Only "transcript" input pools events separately (second tuple element);
-    all other input types return None there.
-
-    Every branch returns UTF-8 bytes so the `input` column holds one type
-    regardless of which path produced it.
+    """Serialize scanner input as UTF-8 JSON bytes, optionally condensing events.
 
     Returns:
         (input_json, input_data_json | None)

--- a/src/inspect_scout/_util/_json.py
+++ b/src/inspect_scout/_util/_json.py
@@ -3,26 +3,26 @@ from typing import Any
 from inspect_ai._util.json import to_json_safe
 
 
-def to_json_str_compact(x: Any) -> str:
-    """Serialize to JSON without pretty-print whitespace.
+def to_json_bytes_compact(x: Any) -> bytes:
+    """Serialize to UTF-8 JSON bytes without pretty-print whitespace.
 
-    Wraps ``to_json_safe`` (surrogate-safe) with ``indent=None`` and decodes to
-    ``str``. Use for machine-read payloads such as stored parquet  columns and
-    bytes streamed to the viewer, where the default ``indent=2`` only bloats the
-    representation without benefit since the data is never human-consumed.
+    Wraps ``to_json_safe`` (surrogate-safe) with ``indent=None``. Use for
+    machine-read payloads such as stored parquet columns and bytes streamed to
+    the viewer, where the default ``indent=2`` only bloats the representation
+    without benefit since the data is never human-consumed.
 
     In extreme cases, this reduces serialized JSON from 700 MiB -> 200 MiB.
     """
-    return to_json_safe(x, indent=None).decode("utf-8")
-
-
-def to_json_bytes_compact(x: Any) -> bytes:
-    """``to_json_str_compact`` without decoding to ``str``.
-
-    Prefer this for values headed straight into a parquet column: pyarrow
-    accepts UTF-8 bytes for string columns and would re-encode a ``str``
-    anyway. Skipping the decode also avoids a second full copy of the payload,
-    at PEP 393's 1, 2, or 4 bytes per character (set by the widest code point
-    in the string).
-    """
     return to_json_safe(x, indent=None)
+
+
+def to_json_str_compact(x: Any) -> str:
+    """``to_json_bytes_compact`` decoded to ``str``.
+
+    Prefer the bytes form for values headed straight into a parquet column:
+    pyarrow accepts UTF-8 bytes for string columns and would re-encode a ``str``
+    anyway. The decode also costs a second full copy of the payload, at PEP
+    393's 1, 2, or 4 bytes per character (set by the widest code point in the
+    string).
+    """
+    return to_json_bytes_compact(x).decode("utf-8")

--- a/src/inspect_scout/_util/_json.py
+++ b/src/inspect_scout/_util/_json.py
@@ -14,3 +14,16 @@ def to_json_str_compact(x: Any) -> str:
     In extreme cases, this reduces serialized JSON from 700 MiB -> 200 MiB.
     """
     return to_json_safe(x, indent=None).decode("utf-8")
+
+
+def to_json_bytes_compact(x: Any) -> bytes:
+    """``to_json_str_compact`` without decoding to ``str``.
+
+    Prefer this for values headed straight into a parquet column: pyarrow
+    accepts UTF-8 bytes for string columns and would re-encode a ``str``
+    anyway. Skipping the round trip also avoids allocating that ``str`` at
+    all -- a second full copy of a multi-hundred-megabyte transcript, sized
+    by Python's PEP 393 representation (1, 2, or 4 bytes per character,
+    picked from the widest code point in the whole string).
+    """
+    return to_json_safe(x, indent=None)

--- a/src/inspect_scout/_util/_json.py
+++ b/src/inspect_scout/_util/_json.py
@@ -21,9 +21,8 @@ def to_json_bytes_compact(x: Any) -> bytes:
 
     Prefer this for values headed straight into a parquet column: pyarrow
     accepts UTF-8 bytes for string columns and would re-encode a ``str``
-    anyway. Skipping the round trip also avoids allocating that ``str`` at
-    all -- a second full copy of a multi-hundred-megabyte transcript, sized
-    by Python's PEP 393 representation (1, 2, or 4 bytes per character,
-    picked from the widest code point in the whole string).
+    anyway. Skipping the decode also avoids a second full copy of the payload,
+    at PEP 393's 1, 2, or 4 bytes per character (set by the widest code point
+    in the string).
     """
     return to_json_safe(x, indent=None)

--- a/tests/recorder/test_records_to_arrow.py
+++ b/tests/recorder/test_records_to_arrow.py
@@ -1,7 +1,9 @@
-"""Arrow conversion of the pre-serialized (bytes/bytearray) `input` columns.
+"""Arrow conversion of the pre-serialized `input`/`input_data` columns.
 
-`_serialize_input` emits UTF-8 buffers rather than `str`; these pin that the
-buffers survive into a real string column, for both buffer types.
+`_serialize_input` emits UTF-8 JSON buffers rather than `str`. These pin that
+the buffers reach a real string column, that either buffer type the passthrough
+accepts behaves the same, and that no other column takes the passthrough —
+arbitrary metadata can be bytes pyarrow refuses to decode.
 """
 
 from typing import Any
@@ -44,3 +46,35 @@ def test_bytes_column_preserves_non_ascii(buffer_type: BufferType) -> None:
     table = _records_to_arrow([{"input": encoded}])
 
     assert table.column("input").to_pylist() == ['{"text":"héllo 你好"}']
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(b'{"a":1}', '"{\\"a\\":1}"', id="utf8-json-encoded"),
+        pytest.param(b"\xff", "b'\\xff'", id="non-utf8-stringified"),
+    ],
+)
+def test_other_columns_keep_the_json_encode_fallback(
+    value: bytes, expected: str
+) -> None:
+    """Hoisted metadata columns carry whatever the eval log held.
+
+    Bytes there are not pre-serialized JSON, so they keep the encode-then-
+    `str()` fallback. Passing them through instead makes a non-UTF-8 value an
+    `ArrowInvalid` that aborts the whole recording.
+    """
+    table = _records_to_arrow([{"transcript_date": value}])
+
+    assert table.column("transcript_date").to_pylist() == [expected]
+
+
+def test_mixed_column_decodes_buffers_instead_of_repring_them() -> None:
+    """The mixed-column fallback is the one path left that still sees a buffer.
+
+    Latent today — `input` is uniformly bytes-or-None per recorded batch — but
+    `str()` there would put a b'...' repr in a public results column.
+    """
+    table = _records_to_arrow([{"input": b'{"a":1}'}, {"input": 3}])
+
+    assert table.column("input").to_pylist() == ['{"a":1}', "3"]

--- a/tests/recorder/test_records_to_arrow.py
+++ b/tests/recorder/test_records_to_arrow.py
@@ -1,0 +1,53 @@
+"""Arrow conversion of pre-serialized (bytes/bytearray) column values.
+
+`_serialize_input` emits the `input`/`input_data` columns as UTF-8
+bytes/bytearray to avoid materializing a second, wider copy of a large
+transcript as `str`. These assert the buffers survive into a real string
+column, for both buffer types.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from inspect_scout._recorder.buffer import _records_to_arrow
+
+BufferType = type[bytes] | type[bytearray]
+
+
+@pytest.mark.parametrize("buffer_type", [bytes, bytearray], ids=["bytes", "bytearray"])
+@pytest.mark.parametrize(
+    "template",
+    [
+        pytest.param([b'{"a":1}', b'{"a":2}'], id="all-buffers"),
+        pytest.param([b'{"a":1}', '{"a":2}'], id="buffer-and-str"),
+        pytest.param([b'{"a":1}', None], id="buffer-and-null"),
+    ],
+)
+def test_bytes_columns_become_string_columns(
+    buffer_type: BufferType, template: list[Any]
+) -> None:
+    values = [buffer_type(v) if isinstance(v, bytes) else v for v in template]
+
+    table = _records_to_arrow([{"input": value} for value in values])
+
+    assert table.schema.field("input").type == pa.large_string()
+    assert table.column("input").to_pylist() == [
+        value.decode() if isinstance(value, (bytes, bytearray)) else value
+        for value in values
+    ]
+
+
+@pytest.mark.parametrize("buffer_type", [bytes, bytearray], ids=["bytes", "bytearray"])
+def test_bytes_column_preserves_non_ascii(buffer_type: BufferType) -> None:
+    """The bytes are UTF-8; decoding must happen, not a repr()."""
+    payload = {"text": "héllo 你好"}
+    encoded = buffer_type('{"text":"héllo 你好"}'.encode())
+
+    table = _records_to_arrow([{"input": encoded}])
+
+    assert table.column("input").to_pylist() == [encoded.decode()]
+    assert table.column("input")[0].as_py() == '{"text":"héllo 你好"}'
+    assert payload["text"] in table.column("input")[0].as_py()

--- a/tests/recorder/test_records_to_arrow.py
+++ b/tests/recorder/test_records_to_arrow.py
@@ -1,12 +1,8 @@
-"""Arrow conversion of pre-serialized (bytes/bytearray) column values.
+"""Arrow conversion of the pre-serialized (bytes/bytearray) `input` columns.
 
-`_serialize_input` emits the `input`/`input_data` columns as UTF-8
-bytes/bytearray to avoid materializing a second, wider copy of a large
-transcript as `str`. These assert the buffers survive into a real string
-column, for both buffer types.
+`_serialize_input` emits UTF-8 buffers rather than `str`; these pin that the
+buffers survive into a real string column, for both buffer types.
 """
-
-from __future__ import annotations
 
 from typing import Any
 
@@ -43,11 +39,8 @@ def test_bytes_columns_become_string_columns(
 @pytest.mark.parametrize("buffer_type", [bytes, bytearray], ids=["bytes", "bytearray"])
 def test_bytes_column_preserves_non_ascii(buffer_type: BufferType) -> None:
     """The bytes are UTF-8; decoding must happen, not a repr()."""
-    payload = {"text": "héllo 你好"}
     encoded = buffer_type('{"text":"héllo 你好"}'.encode())
 
     table = _records_to_arrow([{"input": encoded}])
 
-    assert table.column("input").to_pylist() == [encoded.decode()]
-    assert table.column("input")[0].as_py() == '{"text":"héllo 你好"}'
-    assert payload["text"] in table.column("input")[0].as_py()
+    assert table.column("input").to_pylist() == ['{"text":"héllo 你好"}']

--- a/tests/recorder/test_records_to_arrow.py
+++ b/tests/recorder/test_records_to_arrow.py
@@ -1,9 +1,8 @@
 """Arrow conversion of the pre-serialized `input`/`input_data` columns.
 
-`_serialize_input` emits UTF-8 JSON buffers rather than `str`. These pin that
-the buffers reach a real string column, that either buffer type the passthrough
-accepts behaves the same, and that no other column takes the passthrough —
-arbitrary metadata can be bytes pyarrow refuses to decode.
+`_serialize_input` emits UTF-8 JSON buffers rather than `str`; these pin that
+the buffers reach a real string column, and that no other column takes the
+passthrough — arbitrary metadata can be bytes pyarrow refuses to decode.
 """
 
 from typing import Any
@@ -58,11 +57,10 @@ def test_bytes_column_preserves_non_ascii(buffer_type: BufferType) -> None:
 def test_other_columns_keep_the_json_encode_fallback(
     value: bytes, expected: str
 ) -> None:
-    """Hoisted metadata columns carry whatever the eval log held.
+    """Metadata columns hold arbitrary eval-log bytes, not pre-serialized JSON.
 
-    Bytes there are not pre-serialized JSON, so they keep the encode-then-
-    `str()` fallback. Passing them through instead makes a non-UTF-8 value an
-    `ArrowInvalid` that aborts the whole recording.
+    Passing those through would turn a non-UTF-8 value into an `ArrowInvalid`
+    that aborts the whole recording.
     """
     table = _records_to_arrow([{"transcript_date": value}])
 
@@ -70,10 +68,10 @@ def test_other_columns_keep_the_json_encode_fallback(
 
 
 def test_mixed_column_decodes_buffers_instead_of_repring_them() -> None:
-    """The mixed-column fallback is the one path left that still sees a buffer.
+    """Latent today: `input` is uniformly bytes-or-None per recorded batch.
 
-    Latent today — `input` is uniformly bytes-or-None per recorded batch — but
-    `str()` there would put a b'...' repr in a public results column.
+    `str()` in the mixed-column fallback would put a b'...' repr in a public
+    results column.
     """
     table = _records_to_arrow([{"input": b'{"a":1}'}, {"input": 3}])
 

--- a/tests/scanner/test_result_df_columns.py
+++ b/tests/scanner/test_result_df_columns.py
@@ -1,13 +1,11 @@
 """`ResultReport.to_df_columns` emits the input columns as UTF-8 JSON buffers.
 
 The recorder hands these straight to pyarrow, so the producer must not decode
-them to `str` — every branch of `_serialize_input` is covered here, since the
-`input_data` split makes it easy to fix one and miss another.
+them to `str`.
 """
 
 import json
 from datetime import datetime
-from typing import Any
 
 import pytest
 from inspect_ai.event import InfoEvent
@@ -68,12 +66,12 @@ def test_input_columns_are_utf8_json_buffers(
         model_usage={},
     )
 
-    columns: dict[str, Any] = report.to_df_columns(pool_dedup=pool_dedup)
+    columns = report.to_df_columns(pool_dedup=pool_dedup)
 
     assert isinstance(columns["input"], (bytes, bytearray))
-    assert json.loads(bytes(columns["input"]))
+    assert json.loads(columns["input"])
     if expect_input_data:
         assert isinstance(columns["input_data"], (bytes, bytearray))
-        assert json.loads(bytes(columns["input_data"])) is not None
+        assert json.loads(columns["input_data"]) is not None
     else:
         assert columns["input_data"] is None

--- a/tests/scanner/test_result_df_columns.py
+++ b/tests/scanner/test_result_df_columns.py
@@ -1,0 +1,79 @@
+"""`ResultReport.to_df_columns` emits the input columns as UTF-8 JSON buffers.
+
+The recorder hands these straight to pyarrow, so the producer must not decode
+them to `str` — every branch of `_serialize_input` is covered here, since the
+`input_data` split makes it easy to fix one and miss another.
+"""
+
+import json
+from datetime import datetime
+from typing import Any
+
+import pytest
+from inspect_ai.event import InfoEvent
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_scout._scanner.result import Result, ResultReport
+from inspect_scout._scanner.types import ScannerInput, ScannerInputNames
+from inspect_scout._transcript.types import Transcript
+
+
+def _transcript() -> Transcript:
+    return Transcript(
+        transcript_id="t1",
+        source_type="test",
+        source_id="s1",
+        source_uri="test://uri",
+        messages=[ChatMessageUser(content="héllo")],
+        events=[InfoEvent(event="info", timestamp=datetime.now(), data={"a": 1})],
+    )
+
+
+@pytest.mark.parametrize(
+    ("input", "input_type", "pool_dedup", "expect_input_data"),
+    [
+        pytest.param(_transcript(), "transcript", True, True, id="transcript-pooled"),
+        pytest.param(
+            _transcript(), "transcript", False, False, id="transcript-unpooled"
+        ),
+        pytest.param(
+            [InfoEvent(event="info", timestamp=datetime.now(), data={"a": 1})],
+            "events",
+            True,
+            True,
+            id="events-pooled",
+        ),
+        pytest.param(
+            [ChatMessageUser(content="héllo")],
+            "messages",
+            True,
+            False,
+            id="messages-never-pooled",
+        ),
+    ],
+)
+def test_input_columns_are_utf8_json_buffers(
+    input: ScannerInput,
+    input_type: ScannerInputNames,
+    pool_dedup: bool,
+    expect_input_data: bool,
+) -> None:
+    report = ResultReport(
+        input_type=input_type,
+        input_ids=["i1"],
+        input=input,
+        result=Result(value="yes"),
+        validation=None,
+        error=None,
+        events=[],
+        model_usage={},
+    )
+
+    columns: dict[str, Any] = report.to_df_columns(pool_dedup=pool_dedup)
+
+    assert isinstance(columns["input"], (bytes, bytearray))
+    assert json.loads(bytes(columns["input"]))
+    if expect_input_data:
+        assert isinstance(columns["input_data"], (bytes, bytearray))
+        assert json.loads(bytes(columns["input_data"])) is not None
+    else:
+        assert columns["input_data"] is None

--- a/tests/transcript/test_lazy_json_persistence.py
+++ b/tests/transcript/test_lazy_json_persistence.py
@@ -247,7 +247,7 @@ async def test_recorder_buffer_doesnt_materialize_metadata() -> None:
     )
 
     # Normalize it (this is what buffer.py does)
-    result = _normalize_scalar(metadata)
+    result = _normalize_scalar("transcript_metadata", metadata)
 
     # Should be a JSON string
     assert isinstance(result, str)


### PR DESCRIPTION
## Summary

`_serialize_input` built a `str` for the `input` and `input_data` columns, which pyarrow then re-encodes to UTF-8 on the way into the table. For a large transcript that is a second full copy of the payload — at 1, 2 or 4 bytes per character depending on the widest code point in the string, per PEP 393.

The recorder now hands pyarrow UTF-8 bytes directly.

## Notes for reviewers

One of six PRs carved out of #491, which was closed as too large to review. It stands alone on `main` and depends on none of the others.

The three source files change together by necessity: `result.py` emitting buffers while `buffer.py` still treated them as an unknown scalar would stringify them and write a literal `b'...'` into a public results column.

`bytes | bytearray` is deliberate throughout, and the `bytearray` arm looks dead in this PR because it is — the producer is the spool, which lands later in the series. Narrowing it to `bytes` silently re-encodes a multi-MB transcript as a JSON *string* into the `input` column.

### Agent review

- Author: Claude Opus 5, reviewed across several fresh-context passes including a five-dimension analysis and an independent `codex` pass.
- The buffer passthrough originally applied to every column, which crashed with `ArrowInvalid` on a metadata column holding non-UTF-8 bytes. Found by review, reproduced, and now scoped to the two columns that carry pre-serialized JSON.
- Three separate reviewers recommended narrowing the `bytes | bytearray` union. That recommendation is correct for this PR read in isolation and wrong for the series, for the reason above; it was declined with a probe rather than an argument.
