### PR TITLE
ci: run the ts-mono viewer tests against this repo's fixtures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -266,6 +266,10 @@ jobs:
 
       - name: Run inspect-components tests
         working-directory: src/inspect_scout/_view/ts-mono
+        # The variable asserts that this repo's corpus is present, so the suite
+        # fails rather than skipping if it can no longer find the fixtures.
+        env:
+          TSMONO_REQUIRE_FIXTURES: "1"
         run: pnpm --filter @tsmono/inspect-components test
 
   js-dist-validation:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -236,6 +236,37 @@ jobs:
             exit 1
           fi
 
+  # Runs the viewer test suite in the inspect_scout embedding. This includes the
+  # fixture-driven timeline tests (packages/inspect-components), which consume
+  # tests/transcript/nodes/fixtures/events/ from this repo and are skipped in
+  # ts-mono's own standalone CI — so without this job, nothing exercises them
+  # against this repo's corpus. Mirrors inspect_ai's viewer-tests job.
+  viewer-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: src/inspect_scout/_view/ts-mono/package.json
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: src/inspect_scout/_view/ts-mono/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: src/inspect_scout/_view/ts-mono
+        run: pnpm install --frozen-lockfile
+
+      - name: Run inspect-components tests
+        working-directory: src/inspect_scout/_view/ts-mono
+        run: pnpm --filter @tsmono/inspect-components test
+
   js-dist-validation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,6 +243,7 @@ jobs:
   # against this repo's corpus. Mirrors inspect_ai's viewer-tests job.
   viewer-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`packages/inspect-components`' timeline suite loads its fixtures from the **embedding parent repo** (nine directories up). ts-mono's own CI is standalone, finds no fixtures, and skips the suite via `describe.runIf`. inspect_ai closed that gap with its `viewer-tests` job in `log_viewer.yml`, whose comment says it plainly: *"skipped in ts-mono's own standalone CI — without this job they run nowhere."* This repo had no equivalent, so nothing had ever run that suite against our 50 fixtures.

This adds the missing job, mirroring inspect_ai's and using this repo's existing action versions.

## What it caught

The suite had been failing since ts-mono `f524de88` (2026-08-22, "Normalize wire data at the parse boundary (#555, phase 1)"), which removed the defensive reads in `core.ts`:

```diff
-  const choices = event.output?.choices;
-  if (choices && choices.length > 0) {
+  const choices = event.output.choices;
+  if (choices.length > 0) {
```

Correct under the #555 contract, where the normalizer fills required-with-default fields and downstream code trusts the types. But `fixtureTimeline.test.ts` built its events by hand, set `choices: undefined`, and asserted `as Event` over it. 109 of our 135 fixture model events omit `output.choices`, so `hasToolCalls` dereferenced `undefined`. Bisected: green at `f524de88^` (52/52), 37 failures at `f524de88`.

Meanwhile `tests/transcript/nodes/test_timeline.py` stayed 71/71 on the same corpus. That corpus exists to stop exactly this: *"The same fixtures can be used by both Python and TypeScript test suites."* The two timeline implementations disagreed for 11 days and no gate reported it, because the gate that would have was the one this repo never ran.

Fixed in ts-mono#610, which landed as `1ec898af` — it types the fixture fields and builds events with `@tsmono/inspect-common/testing`'s builders, removing the cast that hid the violation.

## Contents

- `viewer-tests` job in `build.yaml`, running `pnpm --filter @tsmono/inspect-components test` in the submodule.
- ts-mono gitlink `24b515da` → `1ec898af`, picking up that fix. Also carries `9553a657` (ts-mono CI only, no effect here). `dist/` unchanged.
- A 20-minute cap on the job.
- `TSMONO_REQUIRE_FIXTURES: "1"`, so the suite will fail instead of skipping if it stops finding the corpus. **Inert until ts-mono#612 merges** — nothing reads that variable at `1ec898af` or on ts-mono `main` yet. It is a no-op env var today, not a working guard, and it would not have caught the bug above: the fixtures were present and readable the whole time; the test helper was wrong.

`viewer-tests` now passes in 58s.

### Agent review

- Prepared by Claude Opus 5 (1M context) via Claude Code, across two sessions.
- Verified by parsing the workflow YAML, matching inspect_ai's job step-for-step, bisecting ts-mono to identify the breaking commit, and running the job's exact command in the submodule before and after the gitlink bump.
- The automated review on the first head passed with no findings. A second session caught the stale merge-time squash message on this PR and that the `TSMONO_REQUIRE_FIXTURES` variable has no reader yet; both are corrected in this description.
