### PR TITLE
ci: disable automatic Claude review on PR open

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,35 +1,26 @@
 # Copy to .github/workflows/claude-review.yml in any Meridian repo to add the
-# read-only reviewer. Auto-reviews PRs when they open (drafts are skipped
-# until marked ready for review) and on demand via an @review comment.
+# read-only reviewer. Reviews PRs on demand via an @review comment.
 # Independent of the dev agent (claude.yml) — different trigger, different
 # (lower) permissions.
 #
-# Caveat: auto-review-on-open (the pull_request trigger) only fires where this
-# file exists on the PR's BASE branch — GitHub resolves pull_request-family
-# workflows from the PR's branches, not the default branch. On a pristine-base
-# mirror like the inspect_ai fork, PRs target a base that lacks this workflow,
-# so pull_request never fires; only the @review comment path works there, and
-# auto-review is instead driven by the dev agent posting @review on PR open.
+# Auto-review-on-open is intentionally disabled in this repo: the upstream
+# template also subscribes to `pull_request` (opened, reopened,
+# ready_for_review), which we have dropped so PRs are only reviewed when
+# someone asks with @review.
 
 name: Review
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
 jobs:
   review:
-    # Run on PR events (skipping drafts — they get reviewed via
-    # ready_for_review when marked ready), or on a PR comment containing
-    # @review. An explicit @review still works on a draft. `@review` does not
-    # collide with the dev agent's `@claude` trigger.
+    # Run on a PR comment containing @review. `@review` does not collide with
+    # the dev agent's `@claude` trigger.
     if: >
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft != true) ||
-      (github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '@review'))
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@review')
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger (opened / reopened / ready_for_review) from `.github/workflows/claude-review.yml` so newly opened PRs are no longer automatically reviewed by Claude. The on-demand path is unchanged: commenting `@review` on a PR still runs the read-only reviewer.

The header comment now records that auto-review is intentionally disabled here, since the file is otherwise a copy of the shared Meridian template.

Note: `pull_request` workflows resolve from the PR's base branch, so this takes effect for new PRs once merged to `main`.

### Agent review
- Prepared with Claude Code (Claude Fable 5.1).
- No separate review pass was run: the change only deletes a trigger and the matching branch of the job condition. YAML was validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)