### PR TITLE
feat: carry the scorer's explanation on TranscriptInfo

### DIFF
--- a/src/inspect_scout/_transcript/columns.py
+++ b/src/inspect_scout/_transcript/columns.py
@@ -121,6 +121,11 @@ class Columns:
         return Column("score")
 
     @property
+    def score_explanation(self) -> Column:
+        """Scorer's account of how it reached the headline score."""
+        return Column("score_explanation")
+
+    @property
     def success(self) -> Column:
         """Reduction of 'score' to True/False sucess."""
         return Column("success")

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -1077,6 +1077,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 if isinstance(transcript.score, (dict, list))
                 else (str(transcript.score) if transcript.score is not None else None)
             ),
+            "score_explanation": transcript.score_explanation,
             "success": transcript.success,
             "message_count": transcript.message_count,
             "total_time": transcript.total_time,

--- a/src/inspect_scout/_transcript/database/parquet/transcripts.py
+++ b/src/inspect_scout/_transcript/database/parquet/transcripts.py
@@ -507,6 +507,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
             transcript_model = row_dict.get("model")
             transcript_model_options = row_dict.get("model_options")
             transcript_score = row_dict.get("score")
+            transcript_score_explanation = row_dict.get("score_explanation")
             transcript_success = row_dict.get("success")
             transcript_message_count = row_dict.get("message_count")
             transcript_total_time = row_dict.get("total_time")
@@ -549,6 +550,7 @@ class ParquetTranscriptsDB(TranscriptsDB):
                 model=transcript_model,
                 model_options=transcript_model_options,
                 score=transcript_score,
+                score_explanation=transcript_score_explanation,
                 success=transcript_success,
                 message_count=transcript_message_count,
                 total_time=transcript_total_time,

--- a/src/inspect_scout/_transcript/database/schema.py
+++ b/src/inspect_scout/_transcript/database/schema.py
@@ -117,6 +117,12 @@ TRANSCRIPT_SCHEMA_FIELDS: list[SchemaField] = [
         json_serialized=True,
     ),
     SchemaField(
+        name="score_explanation",
+        pyarrow_type=pa.large_string(),
+        required=False,
+        description="Scorer's account of how it reached the score.",
+    ),
+    SchemaField(
         name="success",
         pyarrow_type=pa.bool_(),
         required=False,

--- a/src/inspect_scout/_transcript/eval_log.py
+++ b/src/inspect_scout/_transcript/eval_log.py
@@ -357,6 +357,10 @@ class EvalLogTranscriptsView(TranscriptsView):
             transcript_model = row_dict.get("model", None)
             transcript_model_options = row_dict.get("generate_config", None)
             transcript_score = row_dict.get("score", None)
+            # absent from an index written before this column existed, which
+            # reads as a transcript whose scorer gave no explanation -- the
+            # same thing every caller already handles
+            transcript_score_explanation = row_dict.get("score_explanation", None)
             transcript_success = row_dict.get("success", None)
             transcript_message_count = row_dict.get("message_count", None)
             transcript_total_time = row_dict.get("total_time", None)
@@ -409,6 +413,7 @@ class EvalLogTranscriptsView(TranscriptsView):
                 model=transcript_model,
                 model_options=transcript_model_options,
                 score=transcript_score,
+                score_explanation=transcript_score_explanation,
                 success=transcript_success,
                 message_count=transcript_message_count,
                 total_time=transcript_total_time,
@@ -784,6 +789,22 @@ def sample_score(sample: EvalSample | EvalSampleSummary) -> Value | None:
         return score.value
 
 
+def sample_score_explanation(sample: EvalSample | EvalSampleSummary) -> str | None:
+    """The headline scorer's explanation, where it recorded one.
+
+    Reads the same score `sample_score` reads — the first — so the value and
+    the account of it can never come from different scorers.
+    """
+    if not sample.scores:
+        return None
+
+    score = next(iter(sample.scores.values()), None)
+    if score is None:
+        return None
+
+    return score.explanation
+
+
 def sample_success(sample: EvalSample | EvalSampleSummary) -> bool | None:
     if not sample.scores:
         return None
@@ -838,6 +859,7 @@ def transcript_info_from_eval_sample(
         task_repeat=eval_sample.epoch,
         model=model,
         score=cast(JsonValue, sample_score(eval_sample)),
+        score_explanation=sample_score_explanation(eval_sample),
         success=sample_success(eval_sample),
         message_count=len(eval_sample.messages),
         total_time=eval_sample.total_time,
@@ -948,6 +970,7 @@ TranscriptColumns: list[Column] = (
         SampleColumn("target", path="target", required=True, value=list_as_str),
         SampleColumn("sample_metadata", path="metadata", default={}),
         SampleColumn("score", path=sample_score),
+        SampleColumn("score_explanation", path=sample_score_explanation),
         SampleColumn("success", path=sample_success),
         SampleColumn("score_*", path="scores", value=score_values),
         SampleColumn("total_tokens", path=sample_total_tokens),

--- a/src/inspect_scout/_transcript/types.py
+++ b/src/inspect_scout/_transcript/types.py
@@ -185,6 +185,17 @@ class TranscriptInfo(BaseModel):
     score: JsonValue | None = Field(default=None)
     """Value indicating score on task."""
 
+    score_explanation: str | None = Field(default=None)
+    """Scorer's account of how it reached `score`, where it gave one.
+
+    The value alone says what the verdict was; this says why. For a scorer that
+    runs a test suite it is the suite's own output — which tests were required,
+    which passed, which are missing — and that is frequently the only evidence
+    that distinguishes a task the agent genuinely failed from one where the
+    grading itself misfired. A scanner asked to judge whether a score can be
+    trusted cannot answer from the number.
+    """
+
     success: bool | None = Field(default=None)
     """Boolean reduction of score to succeeded/failed."""
 

--- a/src/inspect_scout/_transcript/util.py
+++ b/src/inspect_scout/_transcript/util.py
@@ -237,6 +237,7 @@ def filter_transcript(transcript: Transcript, content: TranscriptContent) -> Tra
         model=transcript.model,
         model_options=transcript.model_options,
         score=transcript.score,
+        score_explanation=transcript.score_explanation,
         success=transcript.success,
         message_count=transcript.message_count,
         total_time=transcript.total_time,

--- a/src/inspect_scout/_view/dist/assets/index-BMfxR3--.js
+++ b/src/inspect_scout/_view/dist/assets/index-BMfxR3--.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cc77700e3651b123b24821922a0d833d6c87233dbb367bca291ce4aadaeaecf
-size 3166736

--- a/src/inspect_scout/_view/dist/assets/index-DuQhcP7x.js
+++ b/src/inspect_scout/_view/dist/assets/index-DuQhcP7x.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa6a682fe5be97f7fa915e06657964c095aa21c1f725865914749d3f4f83c70
+size 3167334

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9aabdcaf3e711aa42de7c3ac3bace79b2ac061243e46892a8bf370ca8f31329f
+oid sha256:b9ec319646e96202c1e64ab80a1686f7971be3a7a5bc669007dfbd08553245aa
 size 3844

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -6717,7 +6717,7 @@
         "type": "string"
       },
       "Reference": {
-        "description": "Reference to scanned content.",
+        "description": "Reference from a score to content in the scored transcript.\n\nReferences are stored as a list of dicts under a score's\n`metadata[\"scanner_references\"]` key. Inspect View identifies scanner\nscores by the presence of that key and renders cites in the score's\nexplanation (e.g. `[M22]`) as links to the referenced content.",
         "properties": {
           "cite": {
             "anyOf": [
@@ -11199,6 +11199,17 @@
               }
             ]
           },
+          "score_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score Explanation"
+          },
           "source_id": {
             "anyOf": [
               {
@@ -11451,6 +11462,17 @@
                 "type": "null"
               }
             ]
+          },
+          "score_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score Explanation"
           },
           "source_id": {
             "anyOf": [

--- a/tests/transcript/database/test_schema.py
+++ b/tests/transcript/database/test_schema.py
@@ -49,6 +49,7 @@ class TestTranscriptSchemaFields:
             "model",
             "model_options",
             "score",
+            "score_explanation",
             "success",
             "message_count",
             "total_time",
@@ -128,7 +129,7 @@ class TestTranscriptsDbSchema:
         """transcripts_db_schema('pyarrow') returns valid PyArrow Schema."""
         schema = transcripts_db_schema(format="pyarrow")
         assert isinstance(schema, pa.Schema)
-        assert len(schema) == 23
+        assert len(schema) == 24
         assert "transcript_id" in schema.names
 
     def test_pyarrow_field_types(self) -> None:
@@ -146,7 +147,7 @@ class TestTranscriptsDbSchema:
         assert schema["type"] == "record"
         assert schema["name"] == "Transcript"
         assert "fields" in schema
-        assert len(schema["fields"]) == 23
+        assert len(schema["fields"]) == 24
 
     def test_avro_field_structure(self) -> None:
         """Avro schema fields have correct structure."""
@@ -200,7 +201,7 @@ class TestTranscriptsDbSchema:
         df = transcripts_db_schema(format="pandas")
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
-        assert len(df.columns) == 23
+        assert len(df.columns) == 24
 
     def test_pandas_column_dtypes(self) -> None:
         """Pandas DataFrame has correct column dtypes."""
@@ -236,9 +237,9 @@ class TestReservedColumns:
         assert "filename" in reserved
 
     def test_count(self) -> None:
-        """Should have correct count (23 schema fields + filename)."""
+        """Should have correct count (24 schema fields + filename)."""
         reserved = reserved_columns()
-        assert len(reserved) == 24
+        assert len(reserved) == 25
 
 
 class TestValidateTranscriptSchema:

--- a/tests/transcript/test_transcript_builders.py
+++ b/tests/transcript/test_transcript_builders.py
@@ -109,6 +109,58 @@ def test_info_score_with_single_scorer() -> None:
     assert info.success is True  # 0.75 > 0
 
 
+def test_info_carries_the_scorers_explanation() -> None:
+    """The account of a score, not only its value.
+
+    A scorer that runs a test suite puts the suite's output here — which tests
+    were required, which passed, which are missing — and that is often the only
+    thing separating a task the agent failed from one the grading got wrong. A
+    scanner asked whether a score can be trusted cannot answer from the number.
+    """
+    sample = _make_eval_sample(
+        scores={
+            "harbor": Score(
+                value=0.0,
+                explanation="Required tests: 171 Passed tests: 169 RESULT: FAILED",
+            )
+        }
+    )
+    info = transcript_info_from_eval_sample(
+        sample, eval_id="e", log_location=None, model=None
+    )
+
+    assert info.score == 0.0
+    assert info.score_explanation is not None
+    assert "Passed tests: 169" in info.score_explanation
+
+
+def test_info_score_explanation_is_none_when_the_scorer_gave_one_none() -> None:
+    sample = _make_eval_sample(scores={"acc": Score(value=1.0)})
+    info = transcript_info_from_eval_sample(
+        sample, eval_id="e", log_location=None, model=None
+    )
+
+    assert info.score_explanation is None
+
+
+def test_info_score_explanation_comes_from_the_scored_scorer() -> None:
+    # `sample_score` takes the first scorer, so the explanation has to as well
+    # -- a value and an account of it drawn from different scorers would be
+    # worse than no account at all
+    sample = _make_eval_sample(
+        scores={
+            "first": Score(value=0.5, explanation="the one that counted"),
+            "second": Score(value=0.0, explanation="the one that did not"),
+        },
+    )
+    info = transcript_info_from_eval_sample(
+        sample, eval_id="e", log_location=None, model=None
+    )
+
+    assert info.score == 0.5
+    assert info.score_explanation == "the one that counted"
+
+
 def test_info_score_picks_first_with_multiple_scorers() -> None:
     """Scout's `sample_score` returns the *first* score with multiple scorers.
 


### PR DESCRIPTION
`sample_score` keeps `score.value` and drops everything else, so a transcript arrives at a scanner carrying `score=0.0` and no account of how that was reached. For a scorer that runs a test suite the discarded half is the suite's own output -- which tests were required, which passed, which are missing -- and that is frequently the only evidence separating a task the agent genuinely failed from one where the grading misfired.

The cost is concrete. A scoring-integrity scanner asked whether a recorded score can be trusted, shown only the number, can do no better than flag the inconsistency and recommend that a human go and read the grader logs. Observed on a SWE-bench-style eval set: five samples flagged as possibly mis-scored, every explanation ending in "a reviewer should inspect the grader logs". Four of the five were resolvable from the explanation alone and should never have been raised -- one of them decisively, since the same instance under another model scored 1.0 on the same grader with 171/171 gold tests, while the flagged run failed five named tests.

`score_explanation` is populated from the same score `sample_score` reads -- the first -- so a value and the account of it can never come from different scorers. Added to the parquet schema and both index readers; an index written before the column existed reads as a transcript whose scorer gave no explanation, which every caller already handles.