### PR TITLE
fix: allow scanners with postponed annotations

### DIFF
--- a/src/inspect_scout/_scanner/_loaders.py
+++ b/src/inspect_scout/_scanner/_loaders.py
@@ -1,4 +1,5 @@
 import inspect
+from functools import partial
 from typing import (
     Any,
     AsyncIterator,
@@ -112,10 +113,16 @@ def create_implicit_loader(
     Returns:
         Appropriate loader for the scanner's input type.
     """
-    # Get the first parameter's annotation
+    # Resolve only the annotation that selects the loader. Resolving the full
+    # signature can fail on an unrelated return annotation.
     input_annotation = next(
-        iter(inspect.signature(scanner_fn, eval_str=True).parameters.values())
+        iter(inspect.signature(scanner_fn).parameters.values())
     ).annotation
+    if isinstance(input_annotation, str):
+        annotation_source = inspect.unwrap(scanner_fn)
+        while isinstance(annotation_source, partial):
+            annotation_source = inspect.unwrap(annotation_source.func)
+        input_annotation = eval(input_annotation, annotation_source.__globals__)
     if input_annotation is inspect.Parameter.empty or input_annotation == Transcript:
         return _IdentityLoader(content)
 

--- a/src/inspect_scout/_scanner/_loaders.py
+++ b/src/inspect_scout/_scanner/_loaders.py
@@ -114,7 +114,7 @@ def create_implicit_loader(
     """
     # Get the first parameter's annotation
     input_annotation = next(
-        iter(inspect.signature(scanner_fn).parameters.values())
+        iter(inspect.signature(scanner_fn, eval_str=True).parameters.values())
     ).annotation
     if input_annotation is inspect.Parameter.empty or input_annotation == Transcript:
         return _IdentityLoader(content)

--- a/tests/scanner/test_scanner_type_annotations.py
+++ b/tests/scanner/test_scanner_type_annotations.py
@@ -5,9 +5,49 @@ from __future__ import annotations
 import inspect
 from typing import Optional, get_type_hints
 
+import pytest
+from inspect_ai.model import ChatMessageAssistant
 from inspect_ai.model._chat_message import ChatMessage
+from inspect_scout import Transcript
 from inspect_scout._scanner.result import Result
 from inspect_scout._scanner.scanner import Scanner, scanner
+
+
+@pytest.mark.asyncio
+async def test_scanner_instantiates_with_postponed_transcript_annotation() -> None:
+    @scanner(messages="all")
+    def transcript_scanner() -> Scanner[Transcript]:
+        async def scan(transcript: Transcript) -> Result:
+            return Result(value=len(transcript.messages))
+
+        return scan
+
+    instance = transcript_scanner()
+    transcript = Transcript(
+        transcript_id="postponed",
+        source_type="test",
+        source_id="test",
+        source_uri="test://postponed",
+        messages=[ChatMessageAssistant(content="hello")],
+    )
+    result = await instance(transcript)
+    assert isinstance(result, Result)
+    assert result.value == 1
+
+
+@pytest.mark.asyncio
+async def test_scanner_instantiates_with_postponed_message_list_annotation() -> None:
+    @scanner
+    def message_scanner() -> Scanner[list[ChatMessageAssistant]]:
+        async def scan(messages: list[ChatMessageAssistant]) -> Result:
+            return Result(value=len(messages))
+
+        return scan
+
+    instance: Scanner[list[ChatMessageAssistant]] = message_scanner()
+    result = await instance([ChatMessageAssistant(content="hello")])
+    assert isinstance(result, Result)
+    assert result.value == 1
 
 
 def test_scanner_preserves_type_annotations_with_future_annotations() -> None:

--- a/tests/scanner/test_scanner_type_annotations.py
+++ b/tests/scanner/test_scanner_type_annotations.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import inspect
+from functools import partial
 from typing import Optional, get_type_hints
 
 import pytest
 from inspect_ai.model import ChatMessageAssistant
 from inspect_ai.model._chat_message import ChatMessage
-from inspect_scout import Transcript
-from inspect_scout._scanner.result import Result
-from inspect_scout._scanner.scanner import Scanner, scanner
+from inspect_scout import Result, Scanner, Transcript, scanner
+
+from tests.scanner.wrappers import wrap_async
 
 
 @pytest.mark.asyncio
@@ -48,6 +49,80 @@ async def test_scanner_instantiates_with_postponed_message_list_annotation() -> 
     result = await instance([ChatMessageAssistant(content="hello")])
     assert isinstance(result, Result)
     assert result.value == 1
+
+
+@pytest.mark.asyncio
+async def test_scanner_registers_with_unresolvable_return_annotation() -> None:
+    """Scanner registration resolves its input annotation without its return type."""
+
+    def create_scanner() -> Scanner[Transcript]:
+        from inspect_scout._scanner.result import Result as LocalResult
+
+        @scanner(messages="all")
+        def local_result_scanner() -> Scanner[Transcript]:
+            async def scan(transcript: Transcript) -> LocalResult:
+                return LocalResult(value=len(transcript.messages))
+
+            return scan
+
+        return local_result_scanner()
+
+    instance = create_scanner()
+    transcript = Transcript(
+        transcript_id="local-result",
+        source_type="test",
+        source_id="test",
+        source_uri="test://local-result",
+    )
+    result = await instance(transcript)
+    assert isinstance(result, Result)
+    assert result.value == 0
+
+
+@pytest.mark.asyncio
+async def test_scanner_registers_partial_with_postponed_input_annotation() -> None:
+    """Partial scanners retain their postponed input annotation resolution."""
+
+    @scanner(messages="all")
+    def partial_scanner() -> Scanner[Transcript]:
+        async def scan(transcript: Transcript) -> Result:
+            return Result(value=transcript.transcript_id)
+
+        return partial(scan)
+
+    instance = partial_scanner()
+    transcript = Transcript(
+        transcript_id="partial",
+        source_type="test",
+        source_id="test",
+        source_uri="test://partial",
+    )
+    result = await instance(transcript)
+    assert isinstance(result, Result)
+    assert result.value == "partial"
+
+
+@pytest.mark.asyncio
+async def test_scanner_registers_wrapped_with_postponed_input_annotation() -> None:
+    """Wrapped scanners resolve annotations in the wrapped function's globals."""
+
+    @scanner(messages="all")
+    def wrapped_scanner() -> Scanner[Transcript]:
+        async def scan(transcript: Transcript) -> Result:
+            return Result(value=transcript.transcript_id)
+
+        return wrap_async(scan)
+
+    instance = wrapped_scanner()
+    transcript = Transcript(
+        transcript_id="wrapped",
+        source_type="test",
+        source_id="test",
+        source_uri="test://wrapped",
+    )
+    result = await instance(transcript)
+    assert isinstance(result, Result)
+    assert result.value == "wrapped"
 
 
 def test_scanner_preserves_type_annotations_with_future_annotations() -> None:

--- a/tests/scanner/wrappers.py
+++ b/tests/scanner/wrappers.py
@@ -1,0 +1,20 @@
+"""Scanner wrappers used to test annotation resolution."""
+
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def wrap_async(
+    function: Callable[P, Awaitable[T]],
+) -> Callable[P, Awaitable[T]]:
+    """Wrap an async function in a module with separate globals."""
+
+    @wraps(function)
+    async def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+        return await function(*args, **kwargs)
+
+    return wrapped


### PR DESCRIPTION
Fixes #615.

With `from __future__ import annotations`, scanner factories with `Transcript` or `list[ChatMessageAssistant]` inputs fail during implicit loader selection. Resolve only the first input annotation needed to select that loader. Leave unrelated return annotations untouched, so a factory-local return alias does not break registration. Preserve the annotation namespace for supported partial and wrapped scanners.

Public registration/execution regressions cover the postponed inputs, the reviewer-reported local return alias, partial scanners and a wrapper defined in another module. The local-return regression raises `NameError` on the previous PR head; the callable controls preserve behavior that worked there.

Validation on Python 3.12:

- 39 focused scanner annotation/loader tests passed.
- Full Python suite: 3,325 passed, 107 skipped, two failures. Both Rich progress-rendering failures also reproduce on unchanged `3fc1636` in an isolated source tree with the same environment: `test_long_text_is_not_truncated_on_wide_terminal` and `test_progress_display_is_cleared_on_exit`.
- `make check` and `make suppressions-check` passed. No new suppressions.
- All 15 applicable hosted checks pass on the updated head; two non-applicable jobs are skipped.

### Agent review

Codex assisted with implementation, testing and this description. The parent Codex task performed two integration review passes in its existing task context, not a fresh independent context; its model identity was not independently verified. The first pass found that an intermediate input-only implementation lost the original namespace for partial and cross-module wrapped scanners. That was fixed and regression-tested against the previous head; the second pass checked the resulting diff and evidence. Explicitly double-quoted postponed input references remain outside the original fix, with unchanged baseline behavior.
