### PR TITLE
fix(scan): keep adaptive connections when the scan is certainly single process

### DIFF
--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -97,6 +97,21 @@ from ._util.log import init_log
 logger = getLogger(__name__)
 
 
+def certainly_single_process(*, limit: int | None, max_processes: int | None) -> bool:
+    """Will this scan certainly run in a single process?
+
+    The scan strategy is not chosen until the transcripts have been enumerated, but
+    three of its four conditions are known as soon as the options are resolved. Only
+    "there is exactly one scan to run" needs the reader.
+
+    This is deliberately one-directional: True means single-process for certain, while
+    False means "possibly multi-process" rather than "definitely multi-process". That
+    is the safe direction for the caller that uses it to decide whether adaptive
+    connections can be left enabled, since adaptive is not supported across processes.
+    """
+    return limit == 1 or max_processes == 1 or os.name == "nt"
+
+
 def scan(
     scanners: Scanners,
     transcripts: Transcripts | None = None,
@@ -321,7 +336,13 @@ async def scan_async(
         if scanjob._generate_config and model_config
         else model_config or scanjob._generate_config or GenerateConfig()
     )
-    if scanjob._generate_config.max_connections is None:
+    if (
+        scanjob._generate_config.max_connections is None
+        and not certainly_single_process(
+            limit=scanjob._limit,
+            max_processes=scanjob._max_processes,
+        )
+    ):
         scanjob._generate_config.max_connections = scanjob._max_transcripts
 
     # initialize runtime context
@@ -659,11 +680,9 @@ async def _scan_async_inner(
                     "yes",
                 )
                 # are we running single process?
-                single_process = (
-                    total_scans == 1
-                    or scan.spec.options.limit == 1
-                    or scan.spec.options.max_processes == 1
-                    or os.name == "nt"
+                single_process = total_scans == 1 or certainly_single_process(
+                    limit=scan.spec.options.limit,
+                    max_processes=scan.spec.options.max_processes,
                 )
 
                 # set strategy accordingly

--- a/tests/scan/test_max_connections_resolution.py
+++ b/tests/scan/test_max_connections_resolution.py
@@ -1,0 +1,128 @@
+"""How `max_connections` is resolved, and when adaptive connections survive it.
+
+Scout used to stamp `max_connections` unconditionally during config resolution. That
+silently disabled adaptive connections, because `adaptive_active()` in inspect_ai
+requires `max_connections` to be None. Adaptive is not supported across processes (the
+cross-process semaphore registry warns and degrades to a fixed limit), so the stamp is
+still correct whenever the scan might be multi-process, and is only skipped when the
+scan is certainly single-process.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._generate_config import active_generate_config
+from inspect_scout import Result, Scanner, scan, scanner
+from inspect_scout._scan import certainly_single_process
+from inspect_scout._scanresults import scan_results_df
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+
+
+@scanner(name="max_connections_probe", messages="all")
+def max_connections_probe() -> Scanner[Transcript]:
+    """Record what the model layer actually sees, from inside the scan."""
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        observed = active_generate_config().max_connections
+        return Result(value=observed is None, explanation=str(observed))
+
+    return scan_transcript
+
+
+def test_single_process_is_certain_when_only_one_scan_is_permitted() -> None:
+    assert certainly_single_process(limit=1, max_processes=None) is True
+
+
+def test_single_process_is_certain_when_only_one_process_is_permitted() -> None:
+    assert certainly_single_process(limit=None, max_processes=1) is True
+
+
+def test_single_process_is_certain_on_windows() -> None:
+    # The strategy has always forced single process on Windows.
+    with patch("inspect_scout._scan.os.name", "nt"):
+        assert certainly_single_process(limit=None, max_processes=4) is True
+
+
+def test_single_process_is_not_certain_for_an_ordinary_scan() -> None:
+    # False means "possibly multi-process", which is the answer that keeps the
+    # fixed limit in place. It must not be read as "definitely multi-process".
+    with patch("inspect_scout._scan.os.name", "posix"):
+        assert certainly_single_process(limit=None, max_processes=None) is False
+        assert certainly_single_process(limit=10, max_processes=4) is False
+
+
+def test_adaptive_survives_when_the_scan_is_certainly_single_process() -> None:
+    # max_processes=1 is knowable before the transcripts are read, so the stamp is
+    # skipped and max_connections reaches the model layer as None, which is what
+    # adaptive_active() requires.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[max_connections_probe()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+            max_processes=1,
+            model="mockllm/model",
+        )
+        assert status.complete
+        assert status.location is not None
+
+        results = scan_results_df(status.location, scanner="max_connections_probe")
+        observed = results.scanners["max_connections_probe"]["value"].tolist()
+        assert observed == [True]
+
+
+def test_explicit_max_connections_is_never_overridden() -> None:
+    # The resolution only ever fills in an unset value, so a caller who asks for a
+    # specific cap keeps it whichever process mode the scan turns out to use.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[max_connections_probe()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=1,
+            max_processes=1,
+            model="mockllm/model",
+            model_config=GenerateConfig(max_connections=7),
+        )
+        assert status.complete
+        assert status.location is not None
+
+        results = scan_results_df(status.location, scanner="max_connections_probe")
+        frame = results.scanners["max_connections_probe"]
+        assert frame["value"].tolist() == [False]
+        assert frame["explanation"].tolist() == ["7"]
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows always takes the single-process path, so the stamp cannot be "
+    "exercised here; this asserts the no-regression case on the platforms that can "
+    "run multi-process scans.",
+)
+def test_fixed_limit_is_still_applied_when_multi_process_is_possible() -> None:
+    # The regression this guards against: dropping the stamp altogether would leave
+    # multi-process scans on AdaptiveConcurrency().start, which is below the default
+    # max_transcripts the stamp supplies today.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = scan(
+            scanners=[max_connections_probe()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=tmpdir,
+            limit=2,
+            max_processes=2,
+            model="mockllm/model",
+        )
+        assert status.complete
+        assert status.location is not None
+
+        results = scan_results_df(status.location, scanner="max_connections_probe")
+        frame = results.scanners["max_connections_probe"]
+        assert all(value is False for value in frame["value"].tolist())


### PR DESCRIPTION
Refs #495. This is item **A** from the split proposed on that issue: stop stamping `max_connections` when the scan is certainly single-process, so adaptive connections are reachable.

Opening it speculatively rather than waiting for a ruling, because the analysis was already done and a concrete diff is easier to argue with than a proposal. Happy to reshape or close it.

> **Status (09-09):** @dragonstyle's review is correct — this branch drops the fixed limit in cases where adaptive could never activate, giving pools of 10 and 10,000 where `max_transcripts` was intended. Measurement in the thread also shows a composed guard here fixes only part of it, because this code runs before the model is built. Holding for a direction on shape rather than pushing a partial fix.

## Root cause

`_scan.py` resolved `max_connections` from `max_transcripts` whenever the caller had not set one:

```python
if scanjob._generate_config.max_connections is None:
    scanjob._generate_config.max_connections = scanjob._max_transcripts
```

`adaptive_active()` in inspect_ai is `adaptive_connections is not False and max_connections is None and not batch`, so that assignment silently disabled adaptive connections for **every** scout scan. `git grep adaptive_connections` across scout returns two hits, both in generated schema: nothing in scout reads or forwards it.

## Why the fix is conditional rather than just removing the stamp

Adaptive really is unavailable across processes. `_mp_registry.py` warns and degrades to a fixed limit when a semaphore requests it. So simply deleting the stamp would leave multi-process scans on `AdaptiveConcurrency().start`, which is 20, below the 25 they get today. That is a regression, not a fix.

> **Correction (09-09).** This section originally argued that moving the decision to where `single_process` is computed "does not work either", because `init_scan_model_context()` has already built the `Model` from this config. That was wrong, and I retracted it in the thread: `Model._resolve_config` reads `active_generate_config()` on **every** generate call, so a decision made after the strategy is chosen does take effect. Measurement since suggests the later placement is not merely possible but necessary — a guard at config-resolution time cannot see a config carried on a pre-built `Model` passed as `model=`.

Three of the four conditions in that `single_process` expression are already known during config resolution. `certainly_single_process()` answers with those, and both call sites share it so they cannot drift apart. It is deliberately one-directional:

- `True` means single-process for certain, so adaptive is safe to leave enabled.
- `False` means "possibly multi-process", which keeps the fixed limit.

The condition it cannot see is `total_scans == 1`, so a single-transcript scan keeps today's fixed limit.

**Behaviour is unchanged wherever the scan might be multi-process, including the default.**

## Tests

There was no coverage of this config-resolution block at all, so nothing pinned the old behaviour either way. Added `tests/scan/test_max_connections_resolution.py`:

- unit coverage of the predicate, including the Windows branch via a patched `os.name`;
- an end-to-end scan whose scanner reports what `active_generate_config()` actually shows it, asserting `max_connections` arrives as `None` when single-process is certain;
- an explicit `model_config=GenerateConfig(max_connections=7)` is still honoured;
- the no-regression case, that the fixed limit is still applied when multi-process is possible. That one is skipped on Windows, where `os.name == "nt"` short-circuits the predicate, so it runs on CI rather than here.

Verified the behavioural test genuinely fails without the change, by reverting only the condition and keeping the helper defined.

These tests assert the resolved config rather than the resulting connection pool, which is why they did not catch the defect @dragonstyle found. Pool-level assertions are the right shape and will replace them.

One caveat worth stating: `tests/scan/test_active_scan_cleanup.py::test_interrupted_scan_survives_a_late_metrics_write` failed on one run and passed on a repeat of the identical suite with identical code, so I believe it is flaky rather than affected by this change.

## Not in this PR

- **B**, better rate-limit backoff on the multi-process path, which is where it matters most.
- **C**, adaptive across processes, which would supersede B.
- The adjacent ordering defect at `_scan.py:313-321`, where `generate_config.batch` is read before `model_config` is merged at `:334`, so `--batch` cannot influence the transcript default. Separate defect, separate change.

### Agent review

Authored with Claude Code (Opus 5). Two adversarial passes, each in a fresh context on the same model, instructed to refute rather than confirm.

**This PR was opened without a pass, and that is why the review below was needed rather than avoided.** A fresh-context reviewer told to refute would have checked the guard against all three terms of `adaptive_active()`, which is exactly the defect @dragonstyle found. Recording the gap rather than presenting the passes as prior work.

- **Open** — the guard omits the stamp on process-mode certainty alone, ignoring `adaptive_connections is not False` and `not batch`, giving pools of 10 and 10,000 where 25 was intended. **Found by @dragonstyle**, reproduced and confirmed by pass 1.
- **Open** — a composed guard at this site still leaves `batch` / `adaptive_connections` carried on a `Model` passed as `model=` at 10,000 and 10, because the guard runs at `_scan.py:339` and the model is built at `:349`. Found by pass 2; measured against `main` as the baseline. This is the reason the PR is holding for direction.
- **Fixed** — the description asserted that moving the decision later "does not work" because the `Model` is already built. Retracted in the thread and corrected above.
- **Fixed** — stale `_scan.py:303` reference, now `:313-321`.
- **Confirmed sound** — the premise that the stamp must stay wherever the scan might be multi-process. `_concurrency/_mp_registry.py:36-54` does warn and degrade to a fixed limit.
- **Dismissed** — that the reply should push the partial fix rather than ask, on the grounds that a third request for direction reads as stalling. Reasonable, but it was written before pass 2 established that the fix is partial; landing it silently would leave two routes returning the numbers the review was about.

Test caveat: `test_fixed_limit_is_still_applied_when_multi_process_is_possible` is skipped on Windows, which is where I develop, so the multi-process half is covered by CI rather than locally.
