### PR TITLE
fix: temp parquet files leak when a scan sync does not complete the scan

### DIFF
--- a/src/inspect_scout/_recorder/file.py
+++ b/src/inspect_scout/_recorder/file.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Sequence, cast
@@ -125,9 +126,11 @@ class FileRecorder(ScanRecorder):
 
         # fresh start: clear any stale buffer state from a prior scan that
         # used the same scan_location (the buffer dir is deterministic per
-        # scan_location, so unrelated remnants would otherwise carry over)
-        cleanup_buffer_dir(RecorderBuffer.buffer_dir(self._scan_dir.as_posix()))
-        _clear_prior_parquet_cache(self._scan_dir.as_posix())
+        # scan_location, so unrelated remnants would otherwise carry over).
+        # wiping the buffer also invalidates any cached prior parquet
+        buffer_dir = RecorderBuffer.buffer_dir(self._scan_dir.as_posix())
+        cleanup_buffer_dir(buffer_dir)
+        _drop_cached_priors(buffer_dir)
 
         self._scan_buffer = RecorderBuffer(
             self._scan_dir.as_posix(),
@@ -156,10 +159,6 @@ class FileRecorder(ScanRecorder):
         self._scan_fs = filesystem(self._scan_dir.as_posix())
         self._scan_spec = await _read_scan_spec(self._scan_dir)
 
-        # a new run starts here: any prior parquet cached by an earlier
-        # run against this location is no longer trustworthy
-        _clear_prior_parquet_cache(scan_location)
-
         self._seed_buffer_summary_from_scan_dir()
         # clear errors of transcripts that are about to be retried
         buffer_dir = RecorderBuffer.buffer_dir(self._scan_dir.as_posix())
@@ -185,10 +184,6 @@ class FileRecorder(ScanRecorder):
         self._scan_dir = UPath(scan_location)
         self._scan_fs = filesystem(self._scan_dir.as_posix())
         self._scan_spec = await _read_scan_spec(self._scan_dir)
-
-        # a new run starts here: any prior parquet cached by an earlier
-        # run against this location is no longer trustworthy
-        _clear_prior_parquet_cache(scan_location)
 
         self._seed_buffer_summary_from_scan_dir()
         self._seed_buffer_errors_from_scan_dir()
@@ -266,6 +261,20 @@ class FileRecorder(ScanRecorder):
     async def summary(self) -> Summary:
         return self._scan_buffer.scan_summary().model_copy(deep=True)
 
+    @override
+    @contextmanager
+    def run_scope(self) -> Iterator[None]:
+        """Reuse downloaded remote priors across syncs (see `_prior_parquet_cache`)."""
+        buffer_dir = RecorderBuffer.buffer_dir(self.scan_dir.as_posix())
+        key = _prior_parquet_cache_key(buffer_dir)
+        _drop_cached_priors(buffer_dir)
+        _prior_parquet_cache[key] = {}
+        try:
+            yield
+        finally:
+            _drop_cached_priors(buffer_dir)
+            _prior_parquet_cache.pop(key, None)
+
     @property
     def scan_dir(self) -> UPath:
         if self._scan_dir is None:
@@ -306,8 +315,8 @@ class FileRecorder(ScanRecorder):
         # this may run mid-scan (see the `results_buffer` scan option) with
         # scanning still in flight, so it must stay off the event loop as
         # much as possible: compaction runs in a worker thread, remote
-        # priors are downloaded at most once per run, and remote writes go
-        # through the async filesystem.
+        # priors are downloaded at most once per run (inside `run_scope`),
+        # and remote writes go through the async filesystem.
         #
         # remote object stores expose new objects atomically (an object only
         # becomes visible once fully uploaded), so we PUT directly to the
@@ -344,15 +353,16 @@ class FileRecorder(ScanRecorder):
                     # remove leftovers: the remote-upload temp file, or a
                     # partially-written local `.tmp` after a failure (after
                     # a successful local rename the path no longer exists)
-                    UPath(compact_file).unlink(missing_ok=True)
+                    _unlink_quietly(compact_file)
 
             # sync summary and errors
             await _sync_status_files(fs, scan_dir, scan_buffer_dir, scan_spec, complete)
 
-        # cleanup scan buffer if we are complete
+        # cleanup scan buffer if we are complete (wiping the buffer also
+        # invalidates any cached prior parquet)
         if complete:
             cleanup_buffer_dir(scan_buffer_dir)
-            _clear_prior_parquet_cache(scan_location)
+            _drop_cached_priors(scan_buffer_dir)
 
         return Status(
             complete=complete,
@@ -748,28 +758,52 @@ class FileRecorder(ScanRecorder):
 
 
 # local copies of previously-compacted scanner parquets, downloaded from
-# remote scan dirs at most once per scan run. keyed by buffer dir (which is
-# deterministic per scan_location), mapping scanner -> local temp path (or
-# None when the scan dir had no prior parquet when first checked). the cache
-# stays valid for the whole run because this process is the only writer of
-# the compacted outputs and everything it adds to them comes from the buffer
-# (which `scanner_table` treats as authoritative per transcript_id), so the
-# pre-run parquet remains the correct merge input for every subsequent sync.
-# without it, each periodic sync (see the `results_buffer` scan option)
-# would re-download the ever-growing compacted output it wrote itself.
-# cleared when a run starts (`init`/`resume`/`attach`) and when a sync
-# completes the scan.
+# remote scan dirs so `scanner_table` can merge them with the buffer. keyed
+# by buffer dir, mapping scanner -> local temp path (None: no prior existed).
+#
+# entries exist only inside `FileRecorder.run_scope()`, which the scan driver
+# holds for a whole run: the buffer (authoritative per transcript_id) keeps
+# every row a run adds, so the pre-run parquet stays the correct merge input
+# for all of the run's syncs and is downloaded once instead of once per
+# periodic sync (see the `results_buffer` scan option). the scope removes the
+# downloads on exit. wiping the buffer dir (`init`, `sync(complete=True)`)
+# breaks that invariant, so it drops the downloads too. outside a scope a
+# sync removes its download before returning.
 _prior_parquet_cache: dict[str, dict[str, str | None]] = {}
 
 
-def _clear_prior_parquet_cache(scan_location: str) -> None:
-    cache = _prior_parquet_cache.pop(
-        RecorderBuffer.buffer_dir(scan_location).as_posix(), None
-    )
+def _prior_parquet_cache_key(scan_buffer_dir: UPath) -> str:
+    return scan_buffer_dir.as_posix()
+
+
+def _drop_cached_priors(scan_buffer_dir: UPath) -> None:
+    """Remove any cached prior downloads (an open scope stays open)."""
+    cache = _prior_parquet_cache.get(_prior_parquet_cache_key(scan_buffer_dir))
     if cache:
         for local_path in cache.values():
             if local_path is not None:
-                Path(local_path).unlink(missing_ok=True)
+                _unlink_quietly(local_path)
+        cache.clear()
+
+
+def _unlink_quietly(path: str) -> None:
+    """Remove a local temp file; failure is logged rather than raised."""
+    try:
+        Path(path).unlink(missing_ok=True)
+    except OSError as ex:
+        logger.warning(f"Unable to remove temporary file '{path}': {ex}")
+
+
+async def _download_prior(fs: AsyncFilesystem, prior: UPath) -> str:
+    """Download `prior` to a local temp file (removed again if that fails)."""
+    tmp_fd, local_prior = tempfile.mkstemp(suffix=".parquet")
+    os.close(tmp_fd)
+    try:
+        await fs.get_file(prior.as_posix(), local_prior)
+    except BaseException:
+        _unlink_quietly(local_prior)
+        raise
+    return local_prior
 
 
 async def _compact_with_prior(
@@ -787,30 +821,41 @@ async def _compact_with_prior(
 
     `scanner_table` requires uniform local paths and does blocking CPU +
     local file work, so remote priors are downloaded through the async
-    filesystem (at most once per run — see `_prior_parquet_cache`) and the
-    compaction itself runs in a worker thread. This keeps the event loop
-    responsive when syncs run mid-scan.
+    filesystem (reused across syncs only inside `FileRecorder.run_scope()`,
+    see `_prior_parquet_cache`) and the compaction itself runs in a worker
+    thread. This keeps the event loop responsive when syncs run mid-scan.
     """
+    owned_prior: str | None = None
     if prior.protocol in ("", "file"):
         extra = [prior] if prior.exists() else None
     else:
-        cache = _prior_parquet_cache.setdefault(scan_buffer_dir.as_posix(), {})
-        if scanner in cache:
-            local_prior = cache[scanner]
-        elif await fs.exists(prior.as_posix()):
-            tmp_fd, local_prior = tempfile.mkstemp(suffix=".parquet")
-            os.close(tmp_fd)
-            await fs.get_file(prior.as_posix(), local_prior)
-            cache[scanner] = local_prior
+        key = _prior_parquet_cache_key(scan_buffer_dir)
+        # `{}` is a live (empty) scope entry, so test for None, not truthiness
+        run_cache = _prior_parquet_cache.get(key)
+        if run_cache is not None and scanner in run_cache:
+            local_prior = run_cache[scanner]
         else:
-            local_prior = None
-            cache[scanner] = None
+            local_prior = (
+                await _download_prior(fs, prior)
+                if await fs.exists(prior.as_posix())
+                else None
+            )
+            # the scope may have closed while we awaited
+            run_cache = _prior_parquet_cache.get(key)
+            if run_cache is not None:
+                run_cache[scanner] = local_prior
+            else:
+                owned_prior = local_prior
         extra = [UPath(local_prior)] if local_prior is not None else None
-    return await anyio.to_thread.run_sync(
-        functools.partial(
-            scanner_table, scan_buffer_dir, scanner, output_file, extra_inputs=extra
+    try:
+        return await anyio.to_thread.run_sync(
+            functools.partial(
+                scanner_table, scan_buffer_dir, scanner, output_file, extra_inputs=extra
+            )
         )
-    )
+    finally:
+        if owned_prior is not None:
+            _unlink_quietly(owned_prior)
 
 
 def _scanner_parquet_file(scan_dir: UPath, scanner: str) -> str:

--- a/src/inspect_scout/_recorder/recorder.py
+++ b/src/inspect_scout/_recorder/recorder.py
@@ -1,5 +1,6 @@
 import abc
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
@@ -306,6 +307,18 @@ class ScanRecorder(abc.ABC):
 
     @abc.abstractmethod
     async def summary(self) -> Summary: ...
+
+    @abc.abstractmethod
+    def run_scope(self) -> AbstractContextManager[None]:
+        """Scope a scan run driven by this process.
+
+        Resources a recorder may hold across syncs of one run (e.g. a
+        downloaded remote prior) are released on exit, whether or not the
+        run completed. Per location, not per instance; one scope per
+        location at a time, with its syncs run one after another.
+        Requires `init`, `resume`, or `attach` first.
+        """
+        ...
 
     @staticmethod
     @abc.abstractmethod

--- a/src/inspect_scout/_scan.py
+++ b/src/inspect_scout/_scan.py
@@ -496,9 +496,12 @@ async def _scan_async(
     async def run(tg: TaskGroup) -> None:
         try:
             nonlocal result
-            result = await _scan_async_inner(
-                scan=scan, recorder=recorder, tg=tg, fail_on_error=fail_on_error
-            )
+            # the scope must outlive the interrupted-path sync inside
+            # `_scan_async_inner`, so it wraps the whole call
+            with recorder.run_scope():
+                result = await _scan_async_inner(
+                    scan=scan, recorder=recorder, tg=tg, fail_on_error=fail_on_error
+                )
         finally:
             tg.cancel_scope.cancel()
 

--- a/tests/recorder/test_prior_parquet_cleanup.py
+++ b/tests/recorder/test_prior_parquet_cleanup.py
@@ -1,0 +1,375 @@
+"""Temporary prior parquets downloaded by `FileRecorder.sync` never leak.
+
+Syncing a remote scan location downloads the previously compacted parquet
+so new buffer rows can be merged into it. Outside `FileRecorder.run_scope`
+every sync removes its download before returning; inside one (held by the
+scan driver for a whole run) the download is reused across syncs and
+removed when the scope exits, whether or not the run completed.
+
+A `memory://` location stands in for remote storage: it takes the same
+code path as S3 (download, compact locally, upload) without credentials.
+"""
+
+import io
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pyarrow.parquet as pq
+import pytest
+from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_ai.model import ChatMessageUser
+from inspect_scout import Result, Scanner, scan, scan_resume, scanner
+from inspect_scout._recorder import file as file_module
+from inspect_scout._recorder.buffer import RecorderBuffer
+from inspect_scout._recorder.file import (
+    FileRecorder,
+    _prior_parquet_cache,
+    _prior_parquet_cache_key,
+)
+from inspect_scout._scanner.result import ResultReport
+from inspect_scout._scanspec import ScannerSpec, ScanSpec
+from inspect_scout._transcript.factory import transcripts_from
+from inspect_scout._transcript.types import Transcript, TranscriptInfo
+from upath import UPath
+
+from tests.helpers import temp_active_scans_store
+
+LOGS_DIR = Path(__file__).parent.parent.parent / "examples" / "scanner" / "logs"
+SCANNER = "s"
+
+
+@pytest.fixture(autouse=True)
+def scout_buffer_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point SCOUT_SCANBUFFER_DIR at an isolated temp dir."""
+    buf_dir = tmp_path / "buffer"
+    monkeypatch.setenv("SCOUT_SCANBUFFER_DIR", str(buf_dir))
+    return buf_dir
+
+
+@pytest.fixture(autouse=True)
+def temp_parquets(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[Path]]:
+    """Every `.parquet` path handed out by `tempfile.mkstemp` during the test."""
+    created: list[Path] = []
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        fd, path = real_mkstemp(*args, **kwargs)
+        if path.endswith(".parquet"):
+            created.append(Path(path))
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+    yield created
+    _prior_parquet_cache.clear()
+    for path in created:
+        path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def memory_location() -> Iterator[str]:
+    """A unique scans location on the process-global fsspec memory filesystem."""
+    root = UPath(f"memory://{uuid.uuid4().hex}")
+    yield root.as_posix()
+    if root.exists():
+        root.rmdir(recursive=True)
+
+
+@pytest.fixture
+def get_file_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Remote paths downloaded via `AsyncFilesystem.get_file` during the test."""
+    calls: list[str] = []
+    real_get_file = AsyncFilesystem.get_file
+
+    async def counting_get_file(self: AsyncFilesystem, remote: str, local: str) -> None:
+        calls.append(remote)
+        await real_get_file(self, remote, local)
+
+    monkeypatch.setattr(AsyncFilesystem, "get_file", counting_get_file)
+    return calls
+
+
+def _spec() -> ScanSpec:
+    return ScanSpec(scan_name="leak", scanners={SCANNER: ScannerSpec(name=SCANNER)})
+
+
+def _report() -> ResultReport:
+    return ResultReport(
+        input_type="message",
+        input_ids=[],
+        input=ChatMessageUser(content=""),
+        result=Result(value=1),
+        validation=None,
+        error=None,
+        events=[],
+        model_usage={},
+    )
+
+
+async def _record(recorder: FileRecorder, transcript_id: str) -> None:
+    await recorder.record(
+        TranscriptInfo(
+            transcript_id=transcript_id,
+            source_type="test",
+            source_id="src",
+            source_uri=f"test://{transcript_id}",
+        ),
+        SCANNER,
+        [_report()],
+        None,
+    )
+
+
+async def _scan_with_prior(scans_location: str) -> str:
+    """Create a scan whose dir already holds a compacted parquet; return the dir."""
+    recorder = FileRecorder()
+    await recorder.init(_spec(), scans_location)
+    await _record(recorder, "t-prior")
+    scan_dir = recorder.scan_dir.as_posix()
+    await FileRecorder.sync(scan_dir, complete=True)
+    return scan_dir
+
+
+async def _attach_and_record(scan_dir: str, transcript_id: str) -> FileRecorder:
+    """Mirror inspect_ai's eval-time scanning: attach, then record a new row."""
+    recorder = FileRecorder()
+    await recorder.attach(scan_dir)
+    await _record(recorder, transcript_id)
+    return recorder
+
+
+def _cache_key(scan_dir: str) -> str:
+    return _prior_parquet_cache_key(RecorderBuffer.buffer_dir(scan_dir))
+
+
+def _row_count(scan_dir: str) -> int:
+    data = (UPath(scan_dir) / f"{SCANNER}.parquet").read_bytes()
+    return pq.ParquetFile(io.BytesIO(data)).metadata.num_rows
+
+
+def _live(temp_parquets: list[Path]) -> list[Path]:
+    return [p for p in temp_parquets if p.exists()]
+
+
+def _assert_no_temp_parquets(temp_parquets: list[Path]) -> None:
+    assert temp_parquets, "expected the sync to go through temp parquet files"
+    assert _live(temp_parquets) == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_non_final_syncs_leave_no_temp_files(
+    memory_location: str, temp_parquets: list[Path], get_file_calls: list[str]
+) -> None:
+    """Each sync outside a run scope downloads the prior and removes it again."""
+    scan_dir = await _scan_with_prior(memory_location)
+    await _attach_and_record(scan_dir, "t-1")
+    assert _cache_key(scan_dir) not in _prior_parquet_cache
+
+    for _ in range(3):
+        await FileRecorder.sync(scan_dir, complete=False)
+
+    assert len(get_file_calls) == 3
+    _assert_no_temp_parquets(temp_parquets)
+    assert _cache_key(scan_dir) not in _prior_parquet_cache
+
+
+@pytest.mark.asyncio
+async def test_final_sync_leaves_no_temp_files(
+    memory_location: str, temp_parquets: list[Path], get_file_calls: list[str]
+) -> None:
+    scan_dir = await _scan_with_prior(memory_location)
+    await _attach_and_record(scan_dir, "t-1")
+
+    await FileRecorder.sync(scan_dir, complete=True)
+
+    assert len(get_file_calls) == 1
+    _assert_no_temp_parquets(temp_parquets)
+    assert _cache_key(scan_dir) not in _prior_parquet_cache
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["compaction", "upload"])
+async def test_failed_sync_leaves_no_temp_files(
+    memory_location: str,
+    temp_parquets: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    scan_dir = await _scan_with_prior(memory_location)
+    await _attach_and_record(scan_dir, "t-1")
+
+    def failing_compaction(*args: Any, **kwargs: Any) -> bool:
+        raise RuntimeError("boom")
+
+    async def failing_upload(*args: Any, **kwargs: Any) -> str | None:
+        raise RuntimeError("boom")
+
+    if failure == "compaction":
+        monkeypatch.setattr(file_module, "scanner_table", failing_compaction)
+    else:
+        monkeypatch.setattr(AsyncFilesystem, "write_file_streaming", failing_upload)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await FileRecorder.sync(scan_dir, complete=False)
+
+    _assert_no_temp_parquets(temp_parquets)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_download_leaves_no_temp_files(
+    memory_location: str, temp_parquets: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scan_dir = await _scan_with_prior(memory_location)
+    await _attach_and_record(scan_dir, "t-1")
+    downloading = anyio.Event()
+
+    async def hanging_get_file(self: AsyncFilesystem, remote: str, local: str) -> None:
+        downloading.set()
+        await anyio.sleep_forever()
+
+    monkeypatch.setattr(AsyncFilesystem, "get_file", hanging_get_file)
+
+    async def run_sync() -> None:
+        await FileRecorder.sync(scan_dir, complete=False)
+
+    with anyio.fail_after(30):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_sync)
+            await downloading.wait()
+            tg.cancel_scope.cancel()
+
+    _assert_no_temp_parquets(temp_parquets)
+
+
+@pytest.mark.asyncio
+async def test_run_scope_reuses_download_and_removes_it_on_exit(
+    memory_location: str, temp_parquets: list[Path], get_file_calls: list[str]
+) -> None:
+    """Inside a run scope the prior is downloaded once and kept until exit."""
+    scan_dir = await _scan_with_prior(memory_location)
+    recorder = await _attach_and_record(scan_dir, "t-1")
+
+    with recorder.run_scope():
+        await FileRecorder.sync(scan_dir, complete=False)
+        await FileRecorder.sync(scan_dir, complete=False)
+        assert len(get_file_calls) == 1
+        live = _live(temp_parquets)
+        assert len(live) == 1
+        assert _prior_parquet_cache[_cache_key(scan_dir)] == {SCANNER: str(live[0])}
+
+    _assert_no_temp_parquets(temp_parquets)
+    assert _cache_key(scan_dir) not in _prior_parquet_cache
+
+
+@pytest.mark.asyncio
+async def test_complete_sync_inside_run_scope_drops_cached_prior(
+    memory_location: str, temp_parquets: list[Path], get_file_calls: list[str]
+) -> None:
+    """Wiping the buffer invalidates the cached prior, so it is dropped at once.
+
+    The buffer rows that prior was paired with are gone, so reusing it would
+    overwrite the completed results with pre-run rows. The scope stays open:
+    a later sync downloads the completed output afresh and caches that.
+    """
+    scan_dir = await _scan_with_prior(memory_location)
+    recorder = await _attach_and_record(scan_dir, "t-1")
+
+    with recorder.run_scope():
+        await FileRecorder.sync(scan_dir, complete=False)
+        await FileRecorder.sync(scan_dir, complete=True)
+        assert len(get_file_calls) == 1
+        _assert_no_temp_parquets(temp_parquets)
+        assert _prior_parquet_cache[_cache_key(scan_dir)] == {}
+
+        await FileRecorder.sync(scan_dir, complete=False)
+        assert len(get_file_calls) == 2
+        assert len(_live(temp_parquets)) == 1
+
+    _assert_no_temp_parquets(temp_parquets)
+    assert _cache_key(scan_dir) not in _prior_parquet_cache
+    assert _row_count(scan_dir) == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_download_inside_run_scope_is_retried(
+    memory_location: str, temp_parquets: list[Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed download leaves nothing behind and is not remembered as a prior."""
+    scan_dir = await _scan_with_prior(memory_location)
+    recorder = await _attach_and_record(scan_dir, "t-1")
+    calls: list[str] = []
+    real_get_file = AsyncFilesystem.get_file
+
+    async def flaky_get_file(self: AsyncFilesystem, remote: str, local: str) -> None:
+        calls.append(remote)
+        if len(calls) == 1:
+            raise OSError("transient")
+        await real_get_file(self, remote, local)
+
+    monkeypatch.setattr(AsyncFilesystem, "get_file", flaky_get_file)
+
+    with recorder.run_scope():
+        with pytest.raises(OSError, match="transient"):
+            await FileRecorder.sync(scan_dir, complete=False)
+        assert _live(temp_parquets) == []
+        assert _prior_parquet_cache[_cache_key(scan_dir)] == {}
+
+        await FileRecorder.sync(scan_dir, complete=False)
+        assert len(calls) == 2
+        assert len(_live(temp_parquets)) == 1
+
+    _assert_no_temp_parquets(temp_parquets)
+
+
+@pytest.mark.asyncio
+async def test_local_prior_is_never_deleted(
+    tmp_path: Path, temp_parquets: list[Path]
+) -> None:
+    """A local scan dir's compacted parquet is the prior; it must survive syncs."""
+    recorder = FileRecorder()
+    await recorder.init(_spec(), (tmp_path / "scans").as_posix())
+    await _record(recorder, "t-1")
+    scan_dir = recorder.scan_dir.as_posix()
+
+    await FileRecorder.sync(scan_dir, complete=False)
+    await FileRecorder.sync(scan_dir, complete=False)
+
+    assert (recorder.scan_dir / f"{SCANNER}.parquet").exists()
+    assert temp_parquets == []
+
+
+@scanner(name="prior_leak_always_failing", messages="all")
+def always_failing_scanner() -> Scanner[Transcript]:
+    """Fails on every transcript, so a scan and its resume both end with errors."""
+
+    async def scan_transcript(transcript: Transcript) -> Result:
+        raise RuntimeError("always fails")
+
+    return scan_transcript
+
+
+def test_scan_and_resume_on_remote_location_leave_no_temp_files(
+    memory_location: str, temp_parquets: list[Path], get_file_calls: list[str]
+) -> None:
+    """A run that ends with errors (a non-final sync) still cleans up."""
+    with temp_active_scans_store():
+        first = scan(
+            scanners=[always_failing_scanner()],
+            transcripts=transcripts_from(LOGS_DIR),
+            scans=memory_location,
+            limit=2,
+            max_processes=1,
+            display="none",
+        )
+        assert first.complete is False
+        assert get_file_calls == []
+
+        resumed = scan_resume(first.location, display="none")
+
+    assert resumed.complete is False
+    assert len(get_file_calls) == 1, "resume should download the prior parquet"
+    _assert_no_temp_parquets(temp_parquets)
+    assert _cache_key(first.location) not in _prior_parquet_cache


### PR DESCRIPTION
Syncing a remote scan location (S3 and friends) downloads the previously compacted parquet so new buffer rows can be merged into it. That download was parked in a module-level cache that was only emptied by `init`/`resume`/`attach` or a `sync(complete=True)`, so any process whose last sync was `complete=False` exited with a multi-GB orphan in the temp dir. A later `complete=True` sync from another process could not remove it. A download that failed or was cancelled midway was orphaned too.

Affected callers, all of which end a process with a non-final sync:

- inspect_ai's eval-time scanning (`eval_set(scanner=...)`): it attaches per sample and finalizes with `FileRecorder.sync(scan_dir, complete=not errors)`, so any eval with a scanner error leaked one prior per scanner. This is the reported case (one ~2.2 GB orphan per 10-minute run).
- Scout's own `scan()`/`scan_resume()` against remote storage when the run ends with errors or is interrupted.
- Any external caller of `FileRecorder.sync(location, complete=False)`.

## Fix

The cache exists so that periodic in-run syncs (`results_buffer`) do not re-download the ever-growing compacted output on every sync; without it a run with M periodic syncs and final size S re-downloads roughly M*S/2. Only Scout's scan driver performs periodic syncs, so:

- `ScanRecorder.run_scope()` is a new context manager. `FileRecorder` retains downloads only inside it, and `_scan_async` holds it for the whole run (including the interrupted-path sync). Leaving the scope removes every download, whether or not the run completed.
- Every sync outside a scope (inspect_ai's finalize, `scan_complete`, external callers) downloads, compacts, and removes the download before returning. An upload failure leaves nothing behind because the download is already gone.
- A failed or cancelled download removes its temp file before re-raising and is never remembered as a prior.
- Wiping the buffer dir (`init`, `sync(complete=True)`) drops cached downloads: the cached pre-run prior is only a valid merge input while the buffer still holds every row merged on top of it. This guards a data-loss path where an in-scope sync after a `complete=True` would otherwise merge an empty buffer into the stale pre-run prior and upload that over the completed results.
- Temp-file removal is best-effort (logged, never raised) so cleanup cannot fail an otherwise successful sync.

No change to `sync`'s signature, to `scan_complete`, or to inspect_ai; its attach-then-sync pattern becomes leak-free with this change alone. Local scan directories are untouched.

## Repro

Against a `memory://` scan location (same code path as S3, no credentials):

1. `FileRecorder.init(...)`, record one result, then three times: clear the in-process cache (a fresh process) and `FileRecorder.sync(loc, complete=False)`. Before: three `tmp*.parquet` orphans, and a final `complete=True` sync from a fresh process removes none. After: none.
2. `scan()` with an always-failing scanner on `memory://`, then `scan_resume()`. Before: the resumed run downloads the prior once, ends `complete=False`, and leaves one `tmp*.parquet` plus a stale cache entry. After: none.

Both are encoded in `tests/recorder/test_prior_parquet_cleanup.py`, which fails on `main` for exactly these reasons.

## Tests

New `tests/recorder/test_prior_parquet_cleanup.py` (10 tests) covers: repeated non-final syncs and a final sync outside a scope leave no temp files and no cache entry; `attach` starts no retention (the inspect_ai pattern); compaction and upload failures; a cancelled download; in-scope reuse (one download across two syncs) with removal on scope exit; a `complete=True` sync inside a scope drops the cached prior and a later sync re-downloads with every row preserved; a failed in-scope download is retried rather than remembered; a local scan dir's parquet is never deleted; and `scan()` then `scan_resume()` through the public API on a `memory://` location.

`make check` passes. The full suite has 50 failures and 2 errors in source-connector, observe, and two `results_buffer` tests; the identical set reproduces on the unfixed source (local environment, pyarrow 24 schema-merge error for the `results_buffer` ones), so none are from this change.

## Follow-ups considered and deferred

- Storing the download under the buffer dir instead of the temp dir would make the invariant structural, but it changes semantics (cross-process reuse of a possibly stale prior, multi-GB files kept in the data dir for abandoned scans, and an out-of-run sync creating a buffer dir that `status()` reads as in-progress).
- Skipping the download/compact/upload round trip when a scanner's buffer is empty (a no-op sync currently re-uploads the full parquet).

### Agent review
- Design critique before implementation: Claude Fable 5.1 Plan agent, fresh context, 2 passes (initial design, then the revised scope-owned design). Findings: keep the in-run cache (quantified the egress cost of dropping it); the `{}`-is-falsy footgun; best-effort unlinks; keep the `complete=True` clear (a data-loss path); test-design corrections (record `mkstemp` calls instead of redirecting the temp dir; a test scanner that is a pure function of its input because `scan_resume` reloads the scanner module). All applied.
- `/code-review high` on the diff: 8 finder agents in fresh contexts reported; the orchestrator's verification stage stalled, so the author session triaged the findings. Applied: one key-derivation helper; collapsed download branch that re-reads the scope entry after the awaits; a `complete=True` sync inside a scope empties the cache without ending the scope; trimmed duplicated lifecycle prose and a stale comment in `sync`; best-effort unlink for the compaction temp file. Dismissed: relocating the download into the buffer dir (semantics change, listed as a follow-up); hoisting test fixtures and spec helpers into a conftest (tests/recorder uses per-file copies); making `run_scope` non-abstract (the ABC is all-abstract, same as `flush()`); removing private-cache assertions from the tests (the report explicitly asks to verify no stale cache entries); skipping empty-buffer syncs and dropping the `exists` probe (pre-existing behaviour, listed as a follow-up).
- Final diff: Claude Fable 5.1 general-purpose agent, fresh context, 1 pass. No correctness bugs; 3 nits and 1 unconfirmed risk. Applied: an ABC docstring clause that syncs within a scope run one after another; a trimmed duplicated test docstring. Kept: the defensive re-read of the scope entry after the download awaits and the scope-entry drop (unreachable in-repo, cheap insurance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uhderkbkjaYWXF3pWzkJX
