### PR TITLE
fix: viewer lib npm publish fails typecheck on missing score_explanation column

### DIFF
--- a/src/inspect_scout/_view/dist/assets/index-BeRs5k0-.js
+++ b/src/inspect_scout/_view/dist/assets/index-BeRs5k0-.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:593381001db0e9816dd687f6aa54fa3f6287fcfda084b904097c67cde4524457
+size 3168018

--- a/src/inspect_scout/_view/dist/assets/index-DuQhcP7x.js
+++ b/src/inspect_scout/_view/dist/assets/index-DuQhcP7x.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fa6a682fe5be97f7fa915e06657964c095aa21c1f725865914749d3f4f83c70
-size 3167334

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9ec319646e96202c1e64ab80a1686f7971be3a7a5bc669007dfbd08553245aa
+oid sha256:d2cd733abd0184a6b1efd6148ca3456d669fbcbc50b6cec7785718cad5bdf70b
 size 3844


### PR DESCRIPTION
## Problem

The `Publish React Viewer Lib` workflow failed on both the 0.5.0 and 0.5.1 releases ([0.5.1 run](https://github.com/meridianlabs-ai/inspect_scout/actions/runs/34161272649), [0.5.0 run](https://github.com/meridianlabs-ai/inspect_scout/actions/runs/33828502463)), so `@meridianlabs/inspect-scout-viewer` has not shipped since 0.4.46. Both tags pin ts-mono `3ccf7bfe` ("regenerate types"), which added `score_explanation` to `TranscriptInfo` in `generated.ts` but did not register it in the three exhaustive `Record<keyof TranscriptInfo, ...>` maps in `apps/scout/src/app/transcripts/columns.tsx`:

```
src/app/transcripts/columns.tsx(25,14): error TS2741: Property 'score_explanation' is missing in type '{ success: string; ... }' but required in type 'Record<"agent" | ... | "score_explanation" | ..., string>'.
```

ts-mono's own `typecheck` job was red on that commit (it was pushed straight to `main` with no PR). #614 then bumped this repo's gitlink to it. Nothing in `build.yaml` typechecks the submodule (`js-dist-validation` runs `vite build`, which does not run `tsc`), so the bump passed CI here and the error only surfaced in the publish workflow's `pnpm check`.

meridianlabs-ai/ts-mono#619 fixed `columns.tsx` on September 4, but the gitlink was never bumped past the broken commit.

## Change

- Bump `src/inspect_scout/_view/ts-mono` from `3ccf7bfe` to `4822e2e4` (current ts-mono `main`). Commits picked up: ts-mono#465, #616, #619, #431.
- Rebuild the checked-in viewer bundle at that commit (`pnpm install --frozen-lockfile && pnpm build`). The bundle hash changed because #619 adds a column and #431/#465 change viewer code.

No ts-mono PR is needed; the fix is already on ts-mono `main`, so `submodule-on-main` should be green immediately.

## Verification

At ts-mono `4822e2e4`:
- `pnpm check` from the ts-mono root: 33/33 tasks successful (lint, typecheck, format:check across all packages).
- `pnpm --filter scout types:generate` left `generated.ts` unchanged, so the committed schema and types are in sync.

## Follow-up

A separate PR adds `pnpm check` to `js-dist-validation` so a gitlink bump that fails typecheck is rejected here instead of at release time.

Note: the release workflow checks out the tag, so merging this does not fix the 0.5.1 run. Publishing 0.5.1 requires a manual `workflow_dispatch` from `main` (with dry-run off) after this lands, or waiting for 0.5.2.

## Agent involvement

Prepared by Claude Fable 5.1 (Claude Code).

### Agent review
- No review pass was run. The change is a submodule pointer bump plus the generated `dist/` output of `pnpm build` at that pointer; there is no hand-written code to review.
