### PR TITLE
ci: run pnpm check on the ts-mono submodule in js-dist-validation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -323,6 +323,14 @@ jobs:
         working-directory: src/inspect_scout/_view/ts-mono
         run: pnpm install --frozen-lockfile
 
+      # Same gate the npm publish workflow runs (lint, typecheck, format). The
+      # build below is plain `vite build` and does not typecheck, so without
+      # this a gitlink bump to a non-compiling ts-mono commit passes CI here
+      # and only fails at release time.
+      - name: Check
+        working-directory: src/inspect_scout/_view/ts-mono
+        run: pnpm check
+
       - name: Build
         working-directory: src/inspect_scout/_view/ts-mono
         run: pnpm build


### PR DESCRIPTION
## Why

The `Publish React Viewer Lib` workflow runs `pnpm check` (lint, typecheck, format) in the submodule before publishing, but nothing in `build.yaml` does. `js-dist-validation` runs `pnpm build`, which is plain `vite build` and never invokes `tsc`. So a gitlink bump to a ts-mono commit that does not compile passes every gate here and fails only at release time. That is exactly what happened on 0.5.0 and 0.5.1 (see #625).

## Change

Add a `pnpm check` step to `js-dist-validation`, between `pnpm install` and `pnpm build`, so the parent repo applies the same gate as the publish workflow. Adds roughly 20-30s to the job locally; the job has a 20-minute timeout.

## Expected CI on this PR

`js-dist-validation` will be **red** on this PR until #625 merges, because `main` currently pins the non-compiling ts-mono commit. That red is the gate working. Merge #625 first, then update this branch.

## Agent involvement

Prepared by Claude Fable 5.1 (Claude Code).

### Agent review
- No review pass was run. The change is an 8-line workflow step insertion mirroring the existing step in `npm-publish.yml`.
