### PR TITLE
chore: share repository skills with Codex

### DIFF
--- a/.agents/skills/land-ts-mono/SKILL.md
+++ b/.agents/skills/land-ts-mono/SKILL.md
@@ -41,7 +41,7 @@ submodule gitlink (see the submodule guide in repo facts for background).
   tree). A true fast-forward push straight to `main` would keep the SHA, but
   that is not a path the PR UI offers.
 - Submodule checks before pushing: `pnpm typecheck` and `pnpm test` from the ts-mono root (turbo), not per-package tsc
-- Pipeline internals: "Type Sharing" section of `CLAUDE.md`; submodule workflows: `src/inspect_scout/_view/ts-mono/docs/submodule-guide.md`
+- Pipeline internals: "Type Sharing" section of `AGENTS.md`; submodule workflows: `src/inspect_scout/_view/ts-mono/docs/submodule-guide.md`
 - Sibling consumer: `inspect_ai` (also embeds ts-mono, at `src/inspect_ai/_view/ts-mono`; its regen `python src/inspect_ai/_view/schema.py` produces `packages/inspect-common/src/types/generated.ts`). Types flow inspect_ai → scout: scout's `generated.ts` imports inspect-originated types from `@tsmono/inspect-common`, and nothing on the inspect_ai side duplicates scout's types — so scout Python changes rarely require a sibling sync (see step 2a).
 
 ## Recognize the situation

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Never change the ts-mono submodule gitlink (`src/inspect_scout/_view/ts-mono`) u
 - **No gitlink change** (the diff is empty; only the local submodule worktree is stale): run `git submodule update`.
 - **Gitlink changed** (the recorded pointer was bumped incidentally): reset it and commit: `git checkout origin/main -- src/inspect_scout/_view/ts-mono`. `git submodule update` will NOT fix this—it syncs the working tree to the already-recorded pointer, not the reverse. Never `git add` the submodule path in this state—that stages the wrong pointer.
 
-When a change legitimately requires a coordinated ts-mono update (e.g. regenerated types), follow [.claude/skills/land-ts-mono/SKILL.md](.claude/skills/land-ts-mono/SKILL.md).
+When a change legitimately requires a coordinated ts-mono update (e.g. regenerated types), follow [.agents/skills/land-ts-mono/SKILL.md](.agents/skills/land-ts-mono/SKILL.md).
 
 ## Documentation
 
@@ -180,6 +180,10 @@ Pipeline: Pydantic models → openapi.json → generated.ts
 After Python API changes:
 1. `.venv/bin/python scripts/export_openapi_schema.py`—regenerates `src/inspect_scout/_view/openapi.json`
 2. In the submodule's `apps/scout`: `pnpm types:generate`—regenerates `apps/scout/src/types/generated.ts` (`pnpm build` does NOT regenerate types)
-3. Commit both: `openapi.json` in this repo, `generated.ts` in the submodule. Landing a submodule change requires the coordinated flow in [.claude/skills/land-ts-mono/SKILL.md](.claude/skills/land-ts-mono/SKILL.md)
+3. Commit both: `openapi.json` in this repo, `generated.ts` in the submodule. Landing a submodule change requires the coordinated flow in [.agents/skills/land-ts-mono/SKILL.md](.agents/skills/land-ts-mono/SKILL.md)
 
 CI validates sync.
+
+## Repository skills
+
+Shared skills live in `.agents/skills`. `.claude/skills` links to that directory. Use `$skill-name` in Codex or `/skill-name` in Claude Code.


### PR DESCRIPTION
Codex cannot discover `land-ts-mono` under `.claude/skills`. Move it to `.agents/skills` and keep the Claude path as a symlink. Both readers use the same skill.

Verified fresh Codex and Claude discovery, tracked symlink resolution, and the updated instruction reference. No product code or submodule pointer changes.

`make check`: Ruff passes. Mypy reports 24 errors, identical on clean main with the existing environment. `make test`: 486 errors and 59 skips, including an installed `inspect_ai` missing `Reference`. A clean-main collection run reproduces that import failure. Dependencies were not changed.

GitHub CI passes on this commit.

### Agent review

Authored with Codex. Fresh Claude Opus 5 review, followed by a fix review: no required findings remain.
