### PR TITLE
fix: restore nightly compatibility with Inspect main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,6 +119,62 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv cache prune --ci
 
+  wrapt-compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+        dependencies: [released, main]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "0.9.4"
+      - name: Install the supported dependency graph
+        env:
+          DEPENDENCIES: ${{ matrix.dependencies }}
+        run: |
+          uv venv --python "$(which python)"
+          if [ "$DEPENDENCIES" = released ]; then
+            # Keep the release pin aligned with Scout's inspect-ai dependency floor.
+            uv pip install '.[dev]' 'inspect-ai==0.3.263' 'wrapt==1.17.3'
+          else
+            uv pip install '.[dev]' 'inspect-ai @ git+https://github.com/UKGovernmentBEIS/inspect_ai.git' 'wrapt>=2,<3'
+          fi
+          uv pip check
+          .venv/bin/python - <<'PY'
+          import os
+          from importlib.metadata import version
+
+          inspect_version = version("inspect-ai")
+          wrapt_version = version("wrapt")
+          print(f"inspect-ai={inspect_version}, wrapt={wrapt_version}")
+          if os.environ["DEPENDENCIES"] == "released":
+              assert inspect_version == "0.3.263"
+              assert wrapt_version == "1.17.3"
+          else:
+              assert wrapt_version.split(".")[0] == "2"
+          PY
+      - name: Check provider and SDK type contracts
+        run: .venv/bin/mypy src/inspect_scout/_observe/providers tests/observe/test_wrapt_compatibility.py tests/observe/test_observe_stream_errors.py
+      - name: Test with the C extension
+        env:
+          WRAPT_DISABLE_EXTENSIONS: ""
+        run: |
+          .venv/bin/python -c 'from wrapt import ObjectProxy; from wrapt._wrappers import ObjectProxy as CProxy; assert issubclass(ObjectProxy, CProxy)'
+          .venv/bin/pytest -n 0 tests/observe/test_wrapt_compatibility.py tests/observe/test_observe_stream_errors.py
+      - name: Test the pure-Python implementation
+        env:
+          WRAPT_DISABLE_EXTENSIONS: "true"
+        run: |
+          .venv/bin/python -c 'from wrapt import ObjectProxy; from wrapt.wrappers import ObjectProxy as PythonProxy; assert issubclass(ObjectProxy, PythonProxy)'
+          .venv/bin/pytest -n 0 tests/observe/test_wrapt_compatibility.py tests/observe/test_observe_stream_errors.py
+
   py-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/src/inspect_scout/_observe/providers/_wrapt.py
+++ b/src/inspect_scout/_observe/providers/_wrapt.py
@@ -1,0 +1,30 @@
+"""Typed compatibility boundary for wrapt 1.x and 2.x."""
+
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+
+_ProxiedT = TypeVar("_ProxiedT")
+_Wrapper = Callable[
+    [Callable[..., Any], Any, tuple[Any, ...], dict[str, Any]],
+    Any,
+]
+
+if TYPE_CHECKING:
+
+    class TypedObjectProxy(Generic[_ProxiedT]):
+        __wrapped__: _ProxiedT
+
+        def __init__(self, wrapped: _ProxiedT) -> None: ...
+
+    def wrap_function_wrapper(
+        target: str,
+        name: str,
+        wrapper: _Wrapper,
+    ) -> object: ...
+
+else:
+    from wrapt import ObjectProxy
+    from wrapt import wrap_function_wrapper as wrap_function_wrapper
+
+    # Generic supplies runtime subscription because wrapt 1.x's proxy does not.
+    class TypedObjectProxy(ObjectProxy, Generic[_ProxiedT]):
+        pass

--- a/src/inspect_scout/_observe/providers/anthropic.py
+++ b/src/inspect_scout/_observe/providers/anthropic.py
@@ -1,8 +1,9 @@
 """Anthropic SDK provider for capturing LLM calls."""
 
 import json
+from collections.abc import AsyncIterable, Iterable
 from types import TracebackType
-from typing import Any, AsyncIterator, Generic, Iterator, Protocol, TypeVar
+from typing import Any, AsyncIterator, Iterator, Protocol, TypeVar
 
 from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model._generate_config import GenerateConfig
@@ -16,15 +17,7 @@ _StreamEventT = TypeVar("_StreamEventT")
 _StreamEventT_co = TypeVar("_StreamEventT_co", covariant=True)
 
 
-class _SyncStream(Protocol[_StreamEventT_co]):
-    def __iter__(self) -> Iterator[_StreamEventT_co]: ...
-
-
-class _AsyncStream(Protocol[_StreamEventT_co]):
-    def __aiter__(self) -> AsyncIterator[_StreamEventT_co]: ...
-
-
-class _SyncMessageStream(_SyncStream[_StreamEventT_co], Protocol):
+class _SyncMessageStream(Iterable[_StreamEventT_co], Protocol):
     @property
     def current_message_snapshot(self) -> object: ...
 
@@ -36,7 +29,7 @@ class _SyncMessageStream(_SyncStream[_StreamEventT_co], Protocol):
     def get_final_text(self) -> str: ...
 
 
-class _AsyncMessageStream(_AsyncStream[_StreamEventT_co], Protocol):
+class _AsyncMessageStream(AsyncIterable[_StreamEventT_co], Protocol):
     @property
     def current_message_snapshot(self) -> object: ...
 
@@ -356,14 +349,12 @@ class AnthropicStreamAccumulator:
                 self.accumulated["usage"]["output_tokens"] = event.usage.output_tokens
 
 
-class AnthropicStreamCapture(
-    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class AnthropicStreamCapture(TypedObjectProxy[Iterable[_StreamEventT]]):
     """Capture wrapper for Anthropic sync streams (with stream=True)."""
 
     def __init__(
         self,
-        stream: _SyncStream[_StreamEventT],
+        stream: Iterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -391,14 +382,12 @@ class AnthropicStreamCapture(
             self._self_emit(data)
 
 
-class AnthropicAsyncStreamCapture(
-    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class AnthropicAsyncStreamCapture(TypedObjectProxy[AsyncIterable[_StreamEventT]]):
     """Capture wrapper for Anthropic async streams (with stream=True)."""
 
     def __init__(
         self,
-        stream: _AsyncStream[_StreamEventT],
+        stream: AsyncIterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -427,7 +416,7 @@ class AnthropicAsyncStreamCapture(
 
 
 class AnthropicStreamManagerCapture(
-    TypedObjectProxy[_SyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncStreamManager[_StreamEventT]]
 ):
     """Capture wrapper for Anthropic MessageStreamManager (sync .stream())."""
 
@@ -457,7 +446,7 @@ class AnthropicStreamManagerCapture(
 
 
 class AnthropicStreamManagerCaptureContext(
-    TypedObjectProxy[_SyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncMessageStream[_StreamEventT]]
 ):
     """Context returned by AnthropicStreamManagerCapture.__enter__."""
 
@@ -487,9 +476,10 @@ class AnthropicStreamManagerCaptureContext(
 
     def _snapshot(self) -> object | None:
         """Return the SDK's partial message snapshot, if exposed."""
-        if not hasattr(self.__wrapped__, "current_message_snapshot"):
+        try:
+            return self.__wrapped__.current_message_snapshot
+        except AttributeError:
             return None
-        return self.__wrapped__.current_message_snapshot
 
     def __iter__(self) -> Iterator[_StreamEventT]:
         error: Exception | None = None
@@ -543,7 +533,7 @@ class AnthropicStreamManagerCaptureContext(
 
 
 class AnthropicAsyncStreamManagerCapture(
-    TypedObjectProxy[_AsyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncStreamManager[_StreamEventT]]
 ):
     """Capture wrapper for Anthropic AsyncMessageStreamManager."""
 
@@ -575,7 +565,7 @@ class AnthropicAsyncStreamManagerCapture(
 
 
 class AnthropicAsyncStreamManagerCaptureContext(
-    TypedObjectProxy[_AsyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncMessageStream[_StreamEventT]]
 ):
     """Context returned by AnthropicAsyncStreamManagerCapture.__aenter__."""
 
@@ -605,9 +595,10 @@ class AnthropicAsyncStreamManagerCaptureContext(
 
     def _snapshot(self) -> object | None:
         """Return the SDK's partial message snapshot, if exposed."""
-        if not hasattr(self.__wrapped__, "current_message_snapshot"):
+        try:
+            return self.__wrapped__.current_message_snapshot
+        except AttributeError:
             return None
-        return self.__wrapped__.current_message_snapshot
 
     async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
         error: Exception | None = None

--- a/src/inspect_scout/_observe/providers/anthropic.py
+++ b/src/inspect_scout/_observe/providers/anthropic.py
@@ -1,7 +1,8 @@
 """Anthropic SDK provider for capturing LLM calls."""
 
 import json
-from typing import Any, AsyncIterator, Iterator, cast
+from types import TracebackType
+from typing import Any, AsyncIterator, Generic, Iterator, Protocol, TypeVar
 
 from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model._generate_config import GenerateConfig
@@ -10,6 +11,63 @@ from inspect_ai.tool._tool_info import ToolInfo
 from wrapt import ObjectProxy
 
 from .provider import ObserveEmit
+
+_StreamEventT = TypeVar("_StreamEventT")
+_StreamEventT_co = TypeVar("_StreamEventT_co", covariant=True)
+
+
+class _SyncStream(Protocol[_StreamEventT_co]):
+    def __iter__(self) -> Iterator[_StreamEventT_co]: ...
+
+
+class _AsyncStream(Protocol[_StreamEventT_co]):
+    def __aiter__(self) -> AsyncIterator[_StreamEventT_co]: ...
+
+
+class _SyncMessageStream(_SyncStream[_StreamEventT_co], Protocol):
+    @property
+    def current_message_snapshot(self) -> object: ...
+
+    @property
+    def text_stream(self) -> Iterator[str]: ...
+
+    def get_final_message(self) -> object: ...
+
+    def get_final_text(self) -> str: ...
+
+
+class _AsyncMessageStream(_AsyncStream[_StreamEventT_co], Protocol):
+    @property
+    def current_message_snapshot(self) -> object: ...
+
+    @property
+    def text_stream(self) -> AsyncIterator[str]: ...
+
+    async def get_final_message(self) -> object: ...
+
+    async def get_final_text(self) -> str: ...
+
+
+class _SyncStreamManager(Protocol[_StreamEventT_co]):
+    def __enter__(self) -> _SyncMessageStream[_StreamEventT_co]: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None: ...
+
+
+class _AsyncStreamManager(Protocol[_StreamEventT_co]):
+    async def __aenter__(self) -> _AsyncMessageStream[_StreamEventT_co]: ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None: ...
 
 
 class AnthropicProvider:
@@ -300,12 +358,14 @@ class AnthropicStreamAccumulator:
                 self.accumulated["usage"]["output_tokens"] = event.usage.output_tokens
 
 
-class AnthropicStreamCapture(ObjectProxy[Any]):
+class AnthropicStreamCapture(
+    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for Anthropic sync streams (with stream=True)."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _SyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -314,7 +374,7 @@ class AnthropicStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_accumulator = AnthropicStreamAccumulator()
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[_StreamEventT]:
         error: Exception | None = None
         try:
             for event in self.__wrapped__:
@@ -333,12 +393,14 @@ class AnthropicStreamCapture(ObjectProxy[Any]):
             self._self_emit(data)
 
 
-class AnthropicAsyncStreamCapture(ObjectProxy[Any]):
+class AnthropicAsyncStreamCapture(
+    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for Anthropic async streams (with stream=True)."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _AsyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -347,7 +409,7 @@ class AnthropicAsyncStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_accumulator = AnthropicStreamAccumulator()
 
-    async def __aiter__(self) -> AsyncIterator[Any]:
+    async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
         error: Exception | None = None
         try:
             async for event in self.__wrapped__:
@@ -366,12 +428,14 @@ class AnthropicAsyncStreamCapture(ObjectProxy[Any]):
             self._self_emit(data)
 
 
-class AnthropicStreamManagerCapture(ObjectProxy[Any]):
+class AnthropicStreamManagerCapture(
+    ObjectProxy[_SyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for Anthropic MessageStreamManager (sync .stream())."""
 
     def __init__(
         self,
-        stream_manager: Any,
+        stream_manager: _SyncStreamManager[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -379,22 +443,29 @@ class AnthropicStreamManagerCapture(ObjectProxy[Any]):
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
 
-    def __enter__(self) -> "AnthropicStreamManagerCaptureContext":
+    def __enter__(self) -> "AnthropicStreamManagerCaptureContext[_StreamEventT]":
         stream = self.__wrapped__.__enter__()
         return AnthropicStreamManagerCaptureContext(
             stream, self._self_request_kwargs, self._self_emit
         )
 
-    def __exit__(self, *args: Any) -> Any:
-        return self.__wrapped__.__exit__(*args)
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        return self.__wrapped__.__exit__(exc_type, exc_value, traceback)
 
 
-class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
+class AnthropicStreamManagerCaptureContext(
+    ObjectProxy[_SyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Context returned by AnthropicStreamManagerCapture.__enter__."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _SyncMessageStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -403,7 +474,7 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_emitted: bool = False
 
-    def _emit_if_needed(self, message: Any, error: Exception | None = None) -> None:
+    def _emit_if_needed(self, message: object, error: Exception | None = None) -> None:
         """Emit once with the given message and optional error."""
         if self._self_emitted:
             return
@@ -416,11 +487,11 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
             data["error"] = error
         self._self_emit(data)
 
-    def _snapshot(self) -> Any:
+    def _snapshot(self) -> object:
         """Return the SDK's partial message snapshot, if exposed."""
-        return getattr(self.__wrapped__, "current_message_snapshot", None)
+        return self.__wrapped__.current_message_snapshot
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[_StreamEventT]:
         error: Exception | None = None
         try:
             for event in self.__wrapped__:
@@ -431,7 +502,7 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            elif hasattr(self.__wrapped__, "get_final_message"):
+            else:
                 self._emit_if_needed(self.__wrapped__.get_final_message())
 
     @property
@@ -447,10 +518,10 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            elif hasattr(self.__wrapped__, "get_final_message"):
+            else:
                 self._emit_if_needed(self.__wrapped__.get_final_message())
 
-    def get_final_message(self) -> Any:
+    def get_final_message(self) -> object:
         """Get final message and ensure emission."""
         try:
             message = self.__wrapped__.get_final_message()
@@ -463,7 +534,7 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
     def get_final_text(self) -> str:
         """Get final text and ensure emission."""
         self.get_final_message()  # Ensure emission happens
-        return cast(str, self.__wrapped__.get_final_text())
+        return self.__wrapped__.get_final_text()
 
     def until_done(self) -> None:
         """Consume stream to completion."""
@@ -471,12 +542,14 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
             pass
 
 
-class AnthropicAsyncStreamManagerCapture(ObjectProxy[Any]):
+class AnthropicAsyncStreamManagerCapture(
+    ObjectProxy[_AsyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for Anthropic AsyncMessageStreamManager."""
 
     def __init__(
         self,
-        stream_manager: Any,
+        stream_manager: _AsyncStreamManager[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -484,22 +557,31 @@ class AnthropicAsyncStreamManagerCapture(ObjectProxy[Any]):
         self._self_request_kwargs = request_kwargs
         self._self_emit = emit
 
-    async def __aenter__(self) -> "AnthropicAsyncStreamManagerCaptureContext":
+    async def __aenter__(
+        self,
+    ) -> "AnthropicAsyncStreamManagerCaptureContext[_StreamEventT]":
         stream = await self.__wrapped__.__aenter__()
         return AnthropicAsyncStreamManagerCaptureContext(
             stream, self._self_request_kwargs, self._self_emit
         )
 
-    async def __aexit__(self, *args: Any) -> Any:
-        return await self.__wrapped__.__aexit__(*args)
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
 
-class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
+class AnthropicAsyncStreamManagerCaptureContext(
+    ObjectProxy[_AsyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Context returned by AnthropicAsyncStreamManagerCapture.__aenter__."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _AsyncMessageStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -508,7 +590,7 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_emitted: bool = False
 
-    def _emit_if_needed(self, message: Any, error: Exception | None = None) -> None:
+    def _emit_if_needed(self, message: object, error: Exception | None = None) -> None:
         """Emit once with the given message and optional error."""
         if self._self_emitted:
             return
@@ -521,11 +603,11 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
             data["error"] = error
         self._self_emit(data)
 
-    def _snapshot(self) -> Any:
+    def _snapshot(self) -> object:
         """Return the SDK's partial message snapshot, if exposed."""
-        return getattr(self.__wrapped__, "current_message_snapshot", None)
+        return self.__wrapped__.current_message_snapshot
 
-    async def __aiter__(self) -> AsyncIterator[Any]:
+    async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
         error: Exception | None = None
         try:
             async for event in self.__wrapped__:
@@ -536,7 +618,7 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            elif hasattr(self.__wrapped__, "get_final_message"):
+            else:
                 self._emit_if_needed(await self.__wrapped__.get_final_message())
 
     @property
@@ -555,12 +637,12 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
             finally:
                 if error is not None:
                     parent._emit_if_needed(parent._snapshot(), error)
-                elif hasattr(parent.__wrapped__, "get_final_message"):
+                else:
                     parent._emit_if_needed(await parent.__wrapped__.get_final_message())
 
         return _text_stream()
 
-    async def get_final_message(self) -> Any:
+    async def get_final_message(self) -> object:
         """Get final message and ensure emission."""
         try:
             message = await self.__wrapped__.get_final_message()
@@ -573,7 +655,7 @@ class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
     async def get_final_text(self) -> str:
         """Get final text and ensure emission."""
         await self.get_final_message()  # Ensure emission happens
-        return cast(str, await self.__wrapped__.get_final_text())
+        return await self.__wrapped__.get_final_text()
 
     async def until_done(self) -> None:
         """Consume stream to completion."""

--- a/src/inspect_scout/_observe/providers/anthropic.py
+++ b/src/inspect_scout/_observe/providers/anthropic.py
@@ -7,7 +7,7 @@ from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
-from wrapt import ObjectProxy  # type: ignore[import-untyped]
+from wrapt import ObjectProxy
 
 from .provider import ObserveEmit
 
@@ -300,7 +300,7 @@ class AnthropicStreamAccumulator:
                 self.accumulated["usage"]["output_tokens"] = event.usage.output_tokens
 
 
-class AnthropicStreamCapture(ObjectProxy):  # type: ignore[misc]
+class AnthropicStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for Anthropic sync streams (with stream=True)."""
 
     def __init__(
@@ -333,7 +333,7 @@ class AnthropicStreamCapture(ObjectProxy):  # type: ignore[misc]
             self._self_emit(data)
 
 
-class AnthropicAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
+class AnthropicAsyncStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for Anthropic async streams (with stream=True)."""
 
     def __init__(
@@ -366,7 +366,7 @@ class AnthropicAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
             self._self_emit(data)
 
 
-class AnthropicStreamManagerCapture(ObjectProxy):  # type: ignore[misc]
+class AnthropicStreamManagerCapture(ObjectProxy[Any]):
     """Capture wrapper for Anthropic MessageStreamManager (sync .stream())."""
 
     def __init__(
@@ -389,7 +389,7 @@ class AnthropicStreamManagerCapture(ObjectProxy):  # type: ignore[misc]
         return self.__wrapped__.__exit__(*args)
 
 
-class AnthropicStreamManagerCaptureContext(ObjectProxy):  # type: ignore[misc]
+class AnthropicStreamManagerCaptureContext(ObjectProxy[Any]):
     """Context returned by AnthropicStreamManagerCapture.__enter__."""
 
     def __init__(
@@ -471,7 +471,7 @@ class AnthropicStreamManagerCaptureContext(ObjectProxy):  # type: ignore[misc]
             pass
 
 
-class AnthropicAsyncStreamManagerCapture(ObjectProxy):  # type: ignore[misc]
+class AnthropicAsyncStreamManagerCapture(ObjectProxy[Any]):
     """Capture wrapper for Anthropic AsyncMessageStreamManager."""
 
     def __init__(
@@ -494,7 +494,7 @@ class AnthropicAsyncStreamManagerCapture(ObjectProxy):  # type: ignore[misc]
         return await self.__wrapped__.__aexit__(*args)
 
 
-class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy):  # type: ignore[misc]
+class AnthropicAsyncStreamManagerCaptureContext(ObjectProxy[Any]):
     """Context returned by AnthropicAsyncStreamManagerCapture.__aenter__."""
 
     def __init__(

--- a/src/inspect_scout/_observe/providers/anthropic.py
+++ b/src/inspect_scout/_observe/providers/anthropic.py
@@ -8,8 +8,8 @@ from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
-from wrapt import ObjectProxy
 
+from ._wrapt import TypedObjectProxy, wrap_function_wrapper
 from .provider import ObserveEmit
 
 _StreamEventT = TypeVar("_StreamEventT")
@@ -86,8 +86,6 @@ class AnthropicProvider:
                 "The 'anthropic' package is required to use provider='anthropic'. "
                 "Install it with: pip install anthropic"
             ) from None
-
-        from wrapt import wrap_function_wrapper
 
         def _is_sync_stream(response: Any) -> bool:
             """Check if response is an Anthropic sync Stream."""
@@ -359,7 +357,7 @@ class AnthropicStreamAccumulator:
 
 
 class AnthropicStreamCapture(
-    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for Anthropic sync streams (with stream=True)."""
 
@@ -394,7 +392,7 @@ class AnthropicStreamCapture(
 
 
 class AnthropicAsyncStreamCapture(
-    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for Anthropic async streams (with stream=True)."""
 
@@ -429,7 +427,7 @@ class AnthropicAsyncStreamCapture(
 
 
 class AnthropicStreamManagerCapture(
-    ObjectProxy[_SyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for Anthropic MessageStreamManager (sync .stream())."""
 
@@ -459,7 +457,7 @@ class AnthropicStreamManagerCapture(
 
 
 class AnthropicStreamManagerCaptureContext(
-    ObjectProxy[_SyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Context returned by AnthropicStreamManagerCapture.__enter__."""
 
@@ -487,8 +485,10 @@ class AnthropicStreamManagerCaptureContext(
             data["error"] = error
         self._self_emit(data)
 
-    def _snapshot(self) -> object:
+    def _snapshot(self) -> object | None:
         """Return the SDK's partial message snapshot, if exposed."""
+        if not hasattr(self.__wrapped__, "current_message_snapshot"):
+            return None
         return self.__wrapped__.current_message_snapshot
 
     def __iter__(self) -> Iterator[_StreamEventT]:
@@ -502,7 +502,7 @@ class AnthropicStreamManagerCaptureContext(
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            else:
+            elif hasattr(self.__wrapped__, "get_final_message"):
                 self._emit_if_needed(self.__wrapped__.get_final_message())
 
     @property
@@ -518,7 +518,7 @@ class AnthropicStreamManagerCaptureContext(
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            else:
+            elif hasattr(self.__wrapped__, "get_final_message"):
                 self._emit_if_needed(self.__wrapped__.get_final_message())
 
     def get_final_message(self) -> object:
@@ -543,7 +543,7 @@ class AnthropicStreamManagerCaptureContext(
 
 
 class AnthropicAsyncStreamManagerCapture(
-    ObjectProxy[_AsyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncStreamManager[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for Anthropic AsyncMessageStreamManager."""
 
@@ -575,7 +575,7 @@ class AnthropicAsyncStreamManagerCapture(
 
 
 class AnthropicAsyncStreamManagerCaptureContext(
-    ObjectProxy[_AsyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncMessageStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Context returned by AnthropicAsyncStreamManagerCapture.__aenter__."""
 
@@ -603,8 +603,10 @@ class AnthropicAsyncStreamManagerCaptureContext(
             data["error"] = error
         self._self_emit(data)
 
-    def _snapshot(self) -> object:
+    def _snapshot(self) -> object | None:
         """Return the SDK's partial message snapshot, if exposed."""
+        if not hasattr(self.__wrapped__, "current_message_snapshot"):
+            return None
         return self.__wrapped__.current_message_snapshot
 
     async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
@@ -618,7 +620,7 @@ class AnthropicAsyncStreamManagerCaptureContext(
         finally:
             if error is not None:
                 self._emit_if_needed(self._snapshot(), error)
-            else:
+            elif hasattr(self.__wrapped__, "get_final_message"):
                 self._emit_if_needed(await self.__wrapped__.get_final_message())
 
     @property
@@ -637,7 +639,7 @@ class AnthropicAsyncStreamManagerCaptureContext(
             finally:
                 if error is not None:
                     parent._emit_if_needed(parent._snapshot(), error)
-                else:
+                elif hasattr(parent.__wrapped__, "get_final_message"):
                     parent._emit_if_needed(await parent.__wrapped__.get_final_message())
 
         return _text_stream()

--- a/src/inspect_scout/_observe/providers/google.py
+++ b/src/inspect_scout/_observe/providers/google.py
@@ -38,7 +38,7 @@ class GoogleProvider:
                 "Install it with: pip install google-genai"
             ) from None
 
-        from wrapt import wrap_function_wrapper  # type: ignore[import-untyped]
+        from wrapt import wrap_function_wrapper
 
         # Check if response is a stream (generator)
         def is_sync_stream(response: Any) -> bool:

--- a/src/inspect_scout/_observe/providers/google.py
+++ b/src/inspect_scout/_observe/providers/google.py
@@ -18,6 +18,7 @@ from inspect_ai.tool._tools._web_search._web_search import (
     web_search,
 )
 
+from ._wrapt import wrap_function_wrapper
 from .provider import ObserveEmit
 
 
@@ -37,8 +38,6 @@ class GoogleProvider:
                 "The 'google-genai' package is required to use provider='google'. "
                 "Install it with: pip install google-genai"
             ) from None
-
-        from wrapt import wrap_function_wrapper
 
         # Check if response is a stream (generator)
         def is_sync_stream(response: Any) -> bool:

--- a/src/inspect_scout/_observe/providers/openai.py
+++ b/src/inspect_scout/_observe/providers/openai.py
@@ -1,6 +1,7 @@
 """OpenAI SDK provider for capturing LLM calls."""
 
-from typing import Any, AsyncIterator, Generic, Iterator, Protocol, TypeVar
+from collections.abc import AsyncIterable, Iterable
+from typing import Any, AsyncIterator, Iterator, TypeVar
 
 from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model import StopReason
@@ -12,15 +13,6 @@ from ._wrapt import TypedObjectProxy, wrap_function_wrapper
 from .provider import ObserveEmit
 
 _StreamEventT = TypeVar("_StreamEventT")
-_StreamEventT_co = TypeVar("_StreamEventT_co", covariant=True)
-
-
-class _SyncStream(Protocol[_StreamEventT_co]):
-    def __iter__(self) -> Iterator[_StreamEventT_co]: ...
-
-
-class _AsyncStream(Protocol[_StreamEventT_co]):
-    def __aiter__(self) -> AsyncIterator[_StreamEventT_co]: ...
 
 
 def _stop_reason_from_openai_error(error: Exception) -> StopReason | None:
@@ -527,14 +519,12 @@ class OpenAIChatStreamAccumulator:
         return self.accumulated
 
 
-class OpenAIChatStreamCapture(
-    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class OpenAIChatStreamCapture(TypedObjectProxy[Iterable[_StreamEventT]]):
     """Capture wrapper for OpenAI Chat Completions sync streams."""
 
     def __init__(
         self,
-        stream: _SyncStream[_StreamEventT],
+        stream: Iterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -563,14 +553,12 @@ class OpenAIChatStreamCapture(
             self._self_emit(data)
 
 
-class OpenAIChatAsyncStreamCapture(
-    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class OpenAIChatAsyncStreamCapture(TypedObjectProxy[AsyncIterable[_StreamEventT]]):
     """Capture wrapper for OpenAI Chat Completions async streams."""
 
     def __init__(
         self,
-        stream: _AsyncStream[_StreamEventT],
+        stream: AsyncIterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -599,14 +587,12 @@ class OpenAIChatAsyncStreamCapture(
             self._self_emit(data)
 
 
-class OpenAIResponsesStreamCapture(
-    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class OpenAIResponsesStreamCapture(TypedObjectProxy[Iterable[_StreamEventT]]):
     """Capture wrapper for OpenAI Responses API sync streams."""
 
     def __init__(
         self,
-        stream: _SyncStream[_StreamEventT],
+        stream: Iterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -644,14 +630,12 @@ class OpenAIResponsesStreamCapture(
                 self._self_emit(data)
 
 
-class OpenAIResponsesAsyncStreamCapture(
-    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
-):
+class OpenAIResponsesAsyncStreamCapture(TypedObjectProxy[AsyncIterable[_StreamEventT]]):
     """Capture wrapper for OpenAI Responses API async streams."""
 
     def __init__(
         self,
-        stream: _AsyncStream[_StreamEventT],
+        stream: AsyncIterable[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:

--- a/src/inspect_scout/_observe/providers/openai.py
+++ b/src/inspect_scout/_observe/providers/openai.py
@@ -7,8 +7,8 @@ from inspect_ai.model import StopReason
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
-from wrapt import ObjectProxy
 
+from ._wrapt import TypedObjectProxy, wrap_function_wrapper
 from .provider import ObserveEmit
 
 _StreamEventT = TypeVar("_StreamEventT")
@@ -84,8 +84,6 @@ class OpenAIProvider:
                 "The 'openai' package is required to use provider='openai'. "
                 "Install it with: pip install openai"
             ) from None
-
-        from wrapt import wrap_function_wrapper
 
         def _is_stream_type(response: Any, module: str, class_name: str) -> bool:
             """Check if response is an instance of a stream class.
@@ -530,7 +528,7 @@ class OpenAIChatStreamAccumulator:
 
 
 class OpenAIChatStreamCapture(
-    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for OpenAI Chat Completions sync streams."""
 
@@ -566,7 +564,7 @@ class OpenAIChatStreamCapture(
 
 
 class OpenAIChatAsyncStreamCapture(
-    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for OpenAI Chat Completions async streams."""
 
@@ -602,7 +600,7 @@ class OpenAIChatAsyncStreamCapture(
 
 
 class OpenAIResponsesStreamCapture(
-    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for OpenAI Responses API sync streams."""
 
@@ -647,7 +645,7 @@ class OpenAIResponsesStreamCapture(
 
 
 class OpenAIResponsesAsyncStreamCapture(
-    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+    TypedObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
 ):
     """Capture wrapper for OpenAI Responses API async streams."""
 

--- a/src/inspect_scout/_observe/providers/openai.py
+++ b/src/inspect_scout/_observe/providers/openai.py
@@ -7,7 +7,7 @@ from inspect_ai.model import StopReason
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
-from wrapt import ObjectProxy  # type: ignore[import-untyped]
+from wrapt import ObjectProxy
 
 from .provider import ObserveEmit
 
@@ -518,7 +518,7 @@ class OpenAIChatStreamAccumulator:
         return self.accumulated
 
 
-class OpenAIChatStreamCapture(ObjectProxy):  # type: ignore[misc]
+class OpenAIChatStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for OpenAI Chat Completions sync streams."""
 
     def __init__(
@@ -552,7 +552,7 @@ class OpenAIChatStreamCapture(ObjectProxy):  # type: ignore[misc]
             self._self_emit(data)
 
 
-class OpenAIChatAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
+class OpenAIChatAsyncStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for OpenAI Chat Completions async streams."""
 
     def __init__(
@@ -586,7 +586,7 @@ class OpenAIChatAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
             self._self_emit(data)
 
 
-class OpenAIResponsesStreamCapture(ObjectProxy):  # type: ignore[misc]
+class OpenAIResponsesStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for OpenAI Responses API sync streams."""
 
     def __init__(
@@ -629,7 +629,7 @@ class OpenAIResponsesStreamCapture(ObjectProxy):  # type: ignore[misc]
                 self._self_emit(data)
 
 
-class OpenAIResponsesAsyncStreamCapture(ObjectProxy):  # type: ignore[misc]
+class OpenAIResponsesAsyncStreamCapture(ObjectProxy[Any]):
     """Capture wrapper for OpenAI Responses API async streams."""
 
     def __init__(

--- a/src/inspect_scout/_observe/providers/openai.py
+++ b/src/inspect_scout/_observe/providers/openai.py
@@ -1,6 +1,6 @@
 """OpenAI SDK provider for capturing LLM calls."""
 
-from typing import Any, AsyncIterator, Iterator
+from typing import Any, AsyncIterator, Generic, Iterator, Protocol, TypeVar
 
 from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model import StopReason
@@ -10,6 +10,17 @@ from inspect_ai.tool._tool_info import ToolInfo
 from wrapt import ObjectProxy
 
 from .provider import ObserveEmit
+
+_StreamEventT = TypeVar("_StreamEventT")
+_StreamEventT_co = TypeVar("_StreamEventT_co", covariant=True)
+
+
+class _SyncStream(Protocol[_StreamEventT_co]):
+    def __iter__(self) -> Iterator[_StreamEventT_co]: ...
+
+
+class _AsyncStream(Protocol[_StreamEventT_co]):
+    def __aiter__(self) -> AsyncIterator[_StreamEventT_co]: ...
 
 
 def _stop_reason_from_openai_error(error: Exception) -> StopReason | None:
@@ -518,12 +529,14 @@ class OpenAIChatStreamAccumulator:
         return self.accumulated
 
 
-class OpenAIChatStreamCapture(ObjectProxy[Any]):
+class OpenAIChatStreamCapture(
+    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for OpenAI Chat Completions sync streams."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _SyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -532,7 +545,7 @@ class OpenAIChatStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_accumulator = OpenAIChatStreamAccumulator()
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[_StreamEventT]:
         error: Exception | None = None
         try:
             for chunk in self.__wrapped__:
@@ -552,12 +565,14 @@ class OpenAIChatStreamCapture(ObjectProxy[Any]):
             self._self_emit(data)
 
 
-class OpenAIChatAsyncStreamCapture(ObjectProxy[Any]):
+class OpenAIChatAsyncStreamCapture(
+    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for OpenAI Chat Completions async streams."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _AsyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -566,7 +581,7 @@ class OpenAIChatAsyncStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_accumulator = OpenAIChatStreamAccumulator()
 
-    async def __aiter__(self) -> AsyncIterator[Any]:
+    async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
         error: Exception | None = None
         try:
             async for chunk in self.__wrapped__:
@@ -586,12 +601,14 @@ class OpenAIChatAsyncStreamCapture(ObjectProxy[Any]):
             self._self_emit(data)
 
 
-class OpenAIResponsesStreamCapture(ObjectProxy[Any]):
+class OpenAIResponsesStreamCapture(
+    ObjectProxy[_SyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for OpenAI Responses API sync streams."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _SyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -600,7 +617,7 @@ class OpenAIResponsesStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_response_snapshot: Any = None
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[_StreamEventT]:
         error: Exception | None = None
         try:
             for event in self.__wrapped__:
@@ -629,12 +646,14 @@ class OpenAIResponsesStreamCapture(ObjectProxy[Any]):
                 self._self_emit(data)
 
 
-class OpenAIResponsesAsyncStreamCapture(ObjectProxy[Any]):
+class OpenAIResponsesAsyncStreamCapture(
+    ObjectProxy[_AsyncStream[_StreamEventT]], Generic[_StreamEventT]
+):
     """Capture wrapper for OpenAI Responses API async streams."""
 
     def __init__(
         self,
-        stream: Any,
+        stream: _AsyncStream[_StreamEventT],
         request_kwargs: dict[str, Any],
         emit: ObserveEmit,
     ) -> None:
@@ -643,7 +662,7 @@ class OpenAIResponsesAsyncStreamCapture(ObjectProxy[Any]):
         self._self_emit = emit
         self._self_response_snapshot: Any = None
 
-    async def __aiter__(self) -> AsyncIterator[Any]:
+    async def __aiter__(self) -> AsyncIterator[_StreamEventT]:
         error: Exception | None = None
         try:
             async for event in self.__wrapped__:

--- a/src/inspect_scout/_view/dist/assets/index-9nH6Y5Hm.js
+++ b/src/inspect_scout/_view/dist/assets/index-9nH6Y5Hm.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e780b49bcf1057e5aad8720911eaaf147fd46263768079f50adb4518772da08
+size 3185171

--- a/src/inspect_scout/_view/dist/assets/index-BeRs5k0-.js
+++ b/src/inspect_scout/_view/dist/assets/index-BeRs5k0-.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:593381001db0e9816dd687f6aa54fa3f6287fcfda084b904097c67cde4524457
-size 3168018

--- a/src/inspect_scout/_view/dist/assets/index-CPngCFh4.css
+++ b/src/inspect_scout/_view/dist/assets/index-CPngCFh4.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21ffd1246ade078e015913d648d1dc53cebf30e1a96271c3ab69c9d682904ee7
-size 536774

--- a/src/inspect_scout/_view/dist/assets/index-Chx4n3HD.css
+++ b/src/inspect_scout/_view/dist/assets/index-Chx4n3HD.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:016a0b465fd542ca4856ecfa90bd79d10e54bdd6dd236f49111681901acf7f4f
+size 538469

--- a/src/inspect_scout/_view/dist/index.html
+++ b/src/inspect_scout/_view/dist/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2cd733abd0184a6b1efd6148ca3456d669fbcbc50b6cec7785718cad5bdf70b
+oid sha256:b7804942a7aa9d0f57861e8e738b8f68389885efd76211ed57a062687eb11628
 size 3844

--- a/src/inspect_scout/_view/openapi.json
+++ b/src/inspect_scout/_view/openapi.json
@@ -5265,6 +5265,9 @@
                   "$ref": "#/components/schemas/ApprovalEvent"
                 },
                 {
+                  "$ref": "#/components/schemas/ReviewEvent"
+                },
+                {
                   "$ref": "#/components/schemas/BranchEvent"
                 },
                 {
@@ -6999,6 +7002,112 @@
         "title": "Result",
         "type": "object"
       },
+      "ReviewEvent": {
+        "description": "Tool result review.",
+        "properties": {
+          "call": {
+            "$ref": "#/components/schemas/ToolCall"
+          },
+          "decision": {
+            "enum": [
+              "continue",
+              "terminate",
+              "escalate"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "event": {
+            "const": "review",
+            "default": "review",
+            "title": "Event",
+            "type": "string"
+          },
+          "explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "pending": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending"
+          },
+          "reviewer": {
+            "title": "Reviewer",
+            "type": "string"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "working_start": {
+            "title": "Working Start",
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "working_start",
+          "event",
+          "message",
+          "call",
+          "reviewer",
+          "decision"
+        ],
+        "title": "ReviewEvent",
+        "type": "object"
+      },
       "Sample": {
         "description": "Sample for an evaluation task.",
         "properties": {
@@ -8550,6 +8659,9 @@
                 "$ref": "#/components/schemas/ApprovalEvent"
               },
               {
+                "$ref": "#/components/schemas/ReviewEvent"
+              },
+              {
                 "$ref": "#/components/schemas/BranchEvent"
               },
               {
@@ -8620,6 +8732,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/ApprovalEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ReviewEvent"
                     },
                     {
                       "$ref": "#/components/schemas/BranchEvent"
@@ -11071,6 +11186,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ApprovalEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/ReviewEvent"
                 },
                 {
                   "$ref": "#/components/schemas/BranchEvent"

--- a/suppressions.json
+++ b/suppressions.json
@@ -89,22 +89,10 @@
     "noqa:F401": {
       "count": 1,
       "undescribed": 1
-    },
-    "type: ignore[import-untyped]": {
-      "count": 1,
-      "undescribed": 1
-    },
-    "type: ignore[misc]": {
-      "count": 6,
-      "undescribed": 6
     }
   },
   "src/inspect_scout/_observe/providers/google.py": {
     "noqa:F401": {
-      "count": 1,
-      "undescribed": 1
-    },
-    "type: ignore[import-untyped]": {
       "count": 1,
       "undescribed": 1
     }
@@ -113,14 +101,6 @@
     "noqa:F401": {
       "count": 1,
       "undescribed": 1
-    },
-    "type: ignore[import-untyped]": {
-      "count": 1,
-      "undescribed": 1
-    },
-    "type: ignore[misc]": {
-      "count": 4,
-      "undescribed": 4
     }
   },
   "src/inspect_scout/_query/column.py": {

--- a/tests/observe/test_observe_stream_errors.py
+++ b/tests/observe/test_observe_stream_errors.py
@@ -502,6 +502,13 @@ class _FakeAnthropicMessageStream:
             pass
         return self._snapshot
 
+    def get_final_text(self) -> str:
+        return "".join(
+            block.text
+            for block in self.get_final_message().content
+            if block.type == "text"
+        )
+
     def _apply(self, ev: Any) -> None:
         from anthropic.types import TextBlock
 
@@ -546,6 +553,9 @@ class _FakeAnthropicAsyncMessageStream:
             pass
         return self._sync.current_message_snapshot
 
+    async def get_final_text(self) -> str:
+        return self._sync.get_final_text()
+
 
 def _anthropic_manager_partial_text(data: dict[str, Any]) -> str:
     msg = data["response"]
@@ -562,7 +572,9 @@ def test_anthropic_sync_stream_manager_emits_partial_on_error(via: str) -> None:
     captures, emit = _record_emit()
     error = _anthropic_error()
     inner = _FakeAnthropicMessageStream(_anthropic_text_chunks(), error)
-    ctx = AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+    ctx: AnthropicStreamManagerCaptureContext[object] = (
+        AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+    )
 
     with pytest.raises(type(error)):
         if via == "iter":
@@ -590,8 +602,8 @@ async def test_anthropic_async_stream_manager_emits_partial_on_error(via: str) -
     captures, emit = _record_emit()
     error = _anthropic_error()
     inner = _FakeAnthropicAsyncMessageStream(_anthropic_text_chunks(), error)
-    ctx = AnthropicAsyncStreamManagerCaptureContext(
-        inner, {"model": "claude-test"}, emit
+    ctx: AnthropicAsyncStreamManagerCaptureContext[object] = (
+        AnthropicAsyncStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
     )
 
     with pytest.raises(type(error)):
@@ -617,7 +629,9 @@ def test_anthropic_sync_stream_manager_no_double_emit() -> None:
 
     captures, emit = _record_emit()
     inner = _FakeAnthropicMessageStream(_anthropic_text_chunks(), error=None)
-    ctx = AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+    ctx: AnthropicStreamManagerCaptureContext[object] = (
+        AnthropicStreamManagerCaptureContext(inner, {"model": "claude-test"}, emit)
+    )
 
     for _ in ctx:
         pass

--- a/tests/observe/test_observe_stream_errors.py
+++ b/tests/observe/test_observe_stream_errors.py
@@ -641,6 +641,66 @@ def test_anthropic_sync_stream_manager_no_double_emit() -> None:
     assert "error" not in captures[0]
 
 
+class _SnapshotProbe(_FakeAnthropicMessageStream):
+    def __init__(self, error: Exception, has_snapshot: bool) -> None:
+        super().__init__([], error)
+        self.has_snapshot = has_snapshot
+        self.snapshot_reads = 0
+
+    @property
+    def current_message_snapshot(self) -> object:
+        self.snapshot_reads += 1
+        if not self.has_snapshot:
+            raise AttributeError("current_message_snapshot")
+        return self._snapshot
+
+
+@pytest.mark.parametrize("has_snapshot", [False, True])
+def test_anthropic_snapshot_fallback_reads_once(has_snapshot: bool) -> None:
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicStreamManagerCaptureContext,
+    )
+
+    captures, emit = _record_emit()
+    error = _anthropic_error()
+    inner = _SnapshotProbe(error, has_snapshot)
+    ctx: AnthropicStreamManagerCaptureContext[object] = (
+        AnthropicStreamManagerCaptureContext(inner, {}, emit)
+    )
+    with pytest.raises(type(error)) as raised:
+        list(ctx)
+    assert raised.value is error
+    assert inner.snapshot_reads == 1
+    assert len(captures) == 1
+    assert captures[0]["error"] is error
+    assert (captures[0]["response"] is not None) == has_snapshot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("has_snapshot", [False, True])
+async def test_anthropic_async_snapshot_fallback_reads_once(has_snapshot: bool) -> None:
+    from inspect_scout._observe.providers.anthropic import (
+        AnthropicAsyncStreamManagerCaptureContext,
+    )
+
+    captures, emit = _record_emit()
+    error = _anthropic_error()
+    probe = _SnapshotProbe(error, has_snapshot)
+    inner = _FakeAnthropicAsyncMessageStream([], error)
+    inner._sync = probe
+    ctx: AnthropicAsyncStreamManagerCaptureContext[object] = (
+        AnthropicAsyncStreamManagerCaptureContext(inner, {}, emit)
+    )
+    with pytest.raises(type(error)) as raised:
+        async for _ in ctx:
+            pass
+    assert raised.value is error
+    assert probe.snapshot_reads == 1
+    assert len(captures) == 1
+    assert captures[0]["error"] is error
+    assert (captures[0]["response"] is not None) == has_snapshot
+
+
 # --------------------------------------------------------------------------- #
 # build_event propagates the error key onto ModelEvent.error
 # --------------------------------------------------------------------------- #

--- a/tests/observe/test_wrapt_compatibility.py
+++ b/tests/observe/test_wrapt_compatibility.py
@@ -1,0 +1,407 @@
+"""SDK-backed runtime and static contracts, run against both wrapt majors in CI."""
+
+import inspect
+import json
+from types import FunctionType
+from typing import TYPE_CHECKING, Any, Literal
+
+import anthropic
+import httpx2
+import openai
+import pytest
+from anthropic.lib.streaming import ParsedMessageStreamEvent
+from anthropic.resources.messages import AsyncMessages, Messages
+from anthropic.types import Message, RawMessageStreamEvent
+from inspect_scout._observe.providers._wrapt import (
+    TypedObjectProxy,
+    wrap_function_wrapper,
+)
+from inspect_scout._observe.providers.anthropic import (
+    AnthropicAsyncStreamCapture,
+    AnthropicAsyncStreamManagerCapture,
+    AnthropicStreamCapture,
+    AnthropicStreamManagerCapture,
+)
+from inspect_scout._observe.providers.openai import (
+    OpenAIChatAsyncStreamCapture,
+    OpenAIChatStreamCapture,
+    OpenAIResponsesAsyncStreamCapture,
+    OpenAIResponsesStreamCapture,
+)
+from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.responses import AsyncResponses, Responses
+from openai.types.chat import ChatCompletionChunk
+from openai.types.responses import ResponseStreamEvent
+from typing_extensions import assert_type
+
+
+@pytest.fixture(autouse=True)
+def _unpatched_sdk_methods(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Other observe tests leave process-wide capture hooks installed. Keep the
+    # SDK's own function decorators, and restore the existing hooks afterward.
+    for resource, name in (
+        (Completions, "create"),
+        (AsyncCompletions, "create"),
+        (Responses, "create"),
+        (AsyncResponses, "create"),
+        (Messages, "create"),
+        (AsyncMessages, "create"),
+        (Messages, "stream"),
+        (AsyncMessages, "stream"),
+    ):
+        method = getattr(resource, name)
+        monkeypatch.setattr(
+            resource,
+            name,
+            inspect.unwrap(method, stop=lambda fn: type(fn) is FunctionType),
+        )
+
+
+def _sse(*events: dict[str, Any]) -> bytes:
+    return "".join(
+        f"event: {event.get('type', 'message')}\ndata: {json.dumps(event)}\n\n"
+        for event in events
+    ).encode()
+
+
+def _response(body: bytes) -> httpx2.Response:
+    return httpx2.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        stream=httpx2.ByteStream(body),
+    )
+
+
+def _transport(response: httpx2.Response) -> httpx2.MockTransport:
+    return httpx2.MockTransport(lambda _request: response)
+
+
+def _openai_response(api: Literal["chat", "responses"]) -> httpx2.Response:
+    if api == "chat":
+        return _response(
+            _sse(
+                {
+                    "id": "chat-test",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "hello"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            )
+        )
+    return _response(
+        _sse(
+            {
+                "type": "response.completed",
+                "sequence_number": 0,
+                "response": {
+                    "id": "response-test",
+                    "object": "response",
+                    "created_at": 0,
+                    "model": "test",
+                    "output": [],
+                    "parallel_tool_calls": False,
+                    "tool_choice": "auto",
+                    "tools": [],
+                    "status": "completed",
+                },
+            }
+        )
+    )
+
+
+@pytest.mark.parametrize("api", ["chat", "responses"])
+def test_openai_sync_sdk_stream(api: Literal["chat", "responses"]) -> None:
+    response = _openai_response(api)
+    captures: list[dict[str, Any]] = []
+    with openai.OpenAI(
+        api_key="test", http_client=httpx2.Client(transport=_transport(response))
+    ) as client:
+        if api == "chat":
+            stream = client.chat.completions.create(
+                model="test", messages=[], stream=True
+            )
+            proxy = OpenAIChatStreamCapture[ChatCompletionChunk](
+                stream, {}, captures.append
+            )
+            assert proxy.__wrapped__ is stream
+            assert isinstance(proxy, openai.Stream)
+            assert not hasattr(stream, "_self_accumulator")
+            chunks = list(proxy)
+            assert_type(chunks, list[ChatCompletionChunk])
+            assert chunks[0].choices[0].delta.content == "hello"
+        else:
+            events = list(
+                OpenAIResponsesStreamCapture(
+                    client.responses.create(model="test", input="hi", stream=True),
+                    {},
+                    captures.append,
+                )
+            )
+            assert_type(events, list[ResponseStreamEvent])
+            assert events[0].type == "response.completed"
+    assert len(captures) == 1
+    assert captures[0]["api"] == ("completions" if api == "chat" else "responses")
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("api", ["chat", "responses"])
+async def test_openai_async_sdk_stream(api: Literal["chat", "responses"]) -> None:
+    response = _openai_response(api)
+    captures: list[dict[str, Any]] = []
+    async with openai.AsyncOpenAI(
+        api_key="test", http_client=httpx2.AsyncClient(transport=_transport(response))
+    ) as client:
+        if api == "chat":
+            stream = await client.chat.completions.create(
+                model="test", messages=[], stream=True
+            )
+            proxy = OpenAIChatAsyncStreamCapture[ChatCompletionChunk](
+                stream, {}, captures.append
+            )
+            assert proxy.__wrapped__ is stream
+            assert isinstance(proxy, openai.AsyncStream)
+            chunks = [chunk async for chunk in proxy]
+            assert_type(chunks, list[ChatCompletionChunk])
+            assert chunks[0].choices[0].delta.content == "hello"
+        else:
+            events = [
+                event
+                async for event in OpenAIResponsesAsyncStreamCapture(
+                    await client.responses.create(
+                        model="test", input="hi", stream=True
+                    ),
+                    {},
+                    captures.append,
+                )
+            ]
+            assert_type(events, list[ResponseStreamEvent])
+            assert events[0].type == "response.completed"
+    assert len(captures) == 1
+    assert response.is_closed
+
+
+def _anthropic_response(*, fail: bool = False) -> httpx2.Response:
+    body = _sse(
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg-test",
+                "type": "message",
+                "role": "assistant",
+                "model": "test",
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "hello"},
+        },
+    )
+    body += (
+        _sse(
+            {
+                "type": "error",
+                "error": {"type": "overloaded_error", "message": "overloaded"},
+            }
+        )
+        if fail
+        else _sse(
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 1},
+            },
+            {"type": "message_stop"},
+        )
+    )
+    return _response(body)
+
+
+def test_anthropic_sync_sdk_stream() -> None:
+    response = _anthropic_response()
+    captures: list[dict[str, Any]] = []
+    with anthropic.Anthropic(
+        api_key="test", http_client=httpx2.Client(transport=_transport(response))
+    ) as client:
+        stream = client.messages.create(
+            model="test", max_tokens=5, messages=[], stream=True
+        )
+        proxy = AnthropicStreamCapture(stream, {}, captures.append)
+        assert proxy.__wrapped__ is stream
+        events = list(proxy)
+        assert_type(events, list[RawMessageStreamEvent])
+        assert events[-1].type == "message_stop"
+    assert len(captures) == 1
+    assert captures[0]["response"]["content"][0]["text"] == "hello"
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_async_sdk_stream() -> None:
+    response = _anthropic_response()
+    captures: list[dict[str, Any]] = []
+    async with anthropic.AsyncAnthropic(
+        api_key="test", http_client=httpx2.AsyncClient(transport=_transport(response))
+    ) as client:
+        stream = await client.messages.create(
+            model="test", max_tokens=5, messages=[], stream=True
+        )
+        proxy = AnthropicAsyncStreamCapture(stream, {}, captures.append)
+        assert proxy.__wrapped__ is stream
+        events = [event async for event in proxy]
+        assert_type(events, list[RawMessageStreamEvent])
+        assert events[-1].type == "message_stop"
+    assert len(captures) == 1
+    assert response.is_closed
+
+
+@pytest.mark.parametrize("via", ["iter", "text", "final"])
+@pytest.mark.parametrize("fail", [False, True])
+def test_anthropic_sync_sdk_manager(via: str, fail: bool) -> None:
+    response = _anthropic_response(fail=fail)
+    captures: list[dict[str, Any]] = []
+    with anthropic.Anthropic(
+        api_key="test", http_client=httpx2.Client(transport=_transport(response))
+    ) as client:
+        manager = AnthropicStreamManagerCapture(
+            client.messages.stream(model="test", max_tokens=5, messages=[]),
+            {},
+            captures.append,
+        )
+        error: anthropic.APIError | None = None
+        try:
+            with manager as stream:
+                if via == "iter":
+                    events = list(stream)
+                    if TYPE_CHECKING:
+                        assert_type(events, list[ParsedMessageStreamEvent[None]])
+                elif via == "text":
+                    assert "".join(stream.text_stream) == "hello"
+                else:
+                    assert isinstance(stream.get_final_message(), Message)
+                assert stream.get_final_text() == "hello"
+        except anthropic.APIError as exc:
+            error = exc
+        assert response.is_closed
+    assert len(captures) == 1
+    if fail:
+        assert error is not None
+        assert captures[0]["error"] is error
+    else:
+        assert error is None
+        assert "error" not in captures[0]
+    message = captures[0]["response"]
+    assert isinstance(message, Message)
+    assert message.content[0].type == "text"
+    assert message.content[0].text == "hello"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("via", ["iter", "text", "final"])
+@pytest.mark.parametrize("fail", [False, True])
+async def test_anthropic_async_sdk_manager(via: str, fail: bool) -> None:
+    response = _anthropic_response(fail=fail)
+    captures: list[dict[str, Any]] = []
+    async with anthropic.AsyncAnthropic(
+        api_key="test", http_client=httpx2.AsyncClient(transport=_transport(response))
+    ) as client:
+        manager = AnthropicAsyncStreamManagerCapture(
+            client.messages.stream(model="test", max_tokens=5, messages=[]),
+            {},
+            captures.append,
+        )
+        error: anthropic.APIError | None = None
+        try:
+            async with manager as stream:
+                if via == "iter":
+                    events = [event async for event in stream]
+                    if TYPE_CHECKING:
+                        assert_type(events, list[ParsedMessageStreamEvent[None]])
+                elif via == "text":
+                    assert (
+                        "".join([text async for text in stream.text_stream]) == "hello"
+                    )
+                else:
+                    assert isinstance(await stream.get_final_message(), Message)
+                assert await stream.get_final_text() == "hello"
+        except anthropic.APIError as exc:
+            error = exc
+        assert response.is_closed
+    assert len(captures) == 1
+    if fail:
+        assert error is not None
+        assert captures[0]["error"] is error
+    else:
+        assert error is None
+        assert "error" not in captures[0]
+    message = captures[0]["response"]
+    assert isinstance(message, Message)
+    assert message.content[0].type == "text"
+    assert message.content[0].text == "hello"
+
+
+class _Counter:
+    value = 0
+
+    def increment(self, amount: int = 1) -> int:
+        self.value += amount
+        return self.value
+
+
+class _CounterProxy(TypedObjectProxy[_Counter]):
+    value: int
+    _self_marker: str
+
+
+def test_proxy_attribute_isolation_and_unwrapping() -> None:
+    counter = _Counter()
+    proxy = _CounterProxy(counter)
+    assert_type(proxy.__wrapped__, _Counter)
+    proxy.value = 5
+    proxy._self_marker = "private"
+    assert counter.value == 5
+    assert proxy.value == 5
+    assert proxy._self_marker == "private"
+    assert not hasattr(counter, "_self_marker")
+    assert proxy.__wrapped__ is counter
+    assert isinstance(proxy, _Counter)
+
+
+def test_function_wrapper_preserves_binding_and_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = _Counter.increment
+    monkeypatch.setattr(_Counter, "increment", original)
+    instances: list[object] = []
+
+    def wrapper(
+        wrapped: Any, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> Any:
+        instances.append(instance)
+        return wrapped(*args, **kwargs)
+
+    wrap_function_wrapper(__name__, "_Counter.increment", wrapper)
+    counter = _Counter()
+    assert counter.increment(amount=3) == 3
+    assert _Counter.increment(counter, 2) == 5
+    assert instances == [counter, counter]
+    assert inspect.unwrap(_Counter.increment) is original
+    assert inspect.signature(_Counter.increment) == inspect.signature(original)


### PR DESCRIPTION
## Summary

Restore the nightly build against Inspect main while preserving installation with the released Inspect dependency graph.

- Regenerate Scout's OpenAPI schema for Inspect ReviewEvent support.
- Advance the viewer submodule from `4822e2e4` to `57efa420` and rebuild the bundled frontend. This includes the separately merged ReviewEvent implementation (meridianlabs-ai/ts-mono#637), event selection/export (#459), security fixes (#621 and #622), and intervening dependency/tooling updates. ReviewEvent itself reuses approval-event styling; the broader viewer refresh also changes selection and dropdown styles.
- Keep `wrapt>=1.16.0` and introduce a small typed compatibility boundary that inherits the installed, unsubscripted `ObjectProxy` at runtime.
- Preserve event types through standard `Iterable`/`AsyncIterable` contracts and Anthropic message-stream protocols. The contract intentionally covers operations used by Scout; it does not claim arbitrary forwarded attributes or the structured-message result are fully typed.
- Remove obsolete wrapt suppressions and redundant generic bases; read Anthropic snapshot properties once while preserving the missing-attribute fallback.

## Compatibility and regression coverage

Released Inspect 0.3.263 resolves wrapt 1.17.3 through aioboto3/aiobotocore (`wrapt<2`). Inspect main resolves wrapt 2.x. Requiring wrapt 2 would conflict with the released dependency graph.

The new CI matrix tests Python 3.10 and 3.14 with both released Inspect/wrapt 1.17.3 and Inspect main/wrapt 2.x. Each job validates the resolved dependencies, runs the provider/SDK type contracts, and executes the stream tests in separate processes with the C and pure-Python implementations, asserting the selected backend.

The focused suite now has 68 cases (44 existing plus 24 added), including real OpenAI/Anthropic SDK streams over mocked HTTP, sync/async event-type inference, Anthropic manager completion and partial-error handling, connection closure, snapshot absence and single-read behavior, proxy attribute isolation, and function binding/introspection. Tests temporarily remove existing process-wide observe hooks and restore them afterward so suite order cannot introduce nested capture proxies.

Two independently reproduced pre-existing defects remain separate from this compatibility change: raw OpenAI and Anthropic (`stream=True`) context-manager use can bypass capture (and asynchronous entry fails under wrapt 1.x), and Anthropic errors before `message_start` can be masked by the SDK snapshot assertion. The new tests do not claim those paths are fixed.

## Validation

- `make check`: all 469 mypy targets and the lint/format/suppression gates passed; no new suppressions.
- Focused 68-case suite passed locally with wrapt 1.17.3 and 2.4.1, using both C and pure-Python backends. Local environments: Python 3.12/released Inspect and Python 3.14/Inspect main.
- 101 observe tests passed together in one process, including earlier tests that install SDK hooks.
- Full Python suite: 3,363 passed, 107 skipped, with the two previously reproduced macOS Rich console-capture failures deselected. Those two tests fail when included; no change to their code is part of this PR.
- `pnpm check` and `pnpm test` passed on the committed viewer revision.
- CI passed on `1a5e76cd`, including all four new compatibility jobs, the full Python suites on 3.10/3.14, schema/types, viewer tests, and distribution validation: https://github.com/meridianlabs-ai/inspect_scout/actions/runs/34714886609

Fixes the failures observed in nightly run 34682755167.

### Agent review

- Codex (GPT-6) performed one independent review before this follow-up implementation; the authoring conversation was not supplied. It inspected all three original commits, relevant SDK/wrapt source, dependency requirements, and viewer integration, and ran runtime/type probes against both wrapt majors.
- Six findings: three addressed (snapshot double-read, missing permanent compatibility coverage, and disclosure of the broader viewer scope); one accepted limitation (private proxy typing deliberately exposes a narrower contract); two reproduced pre-existing stream defects retained for separate fixes as described above. No merge-blocking runtime regression was found in the original compatibility layer.
- Both of Claude's inline cleanup suggestions were addressed: duplicate iteration protocols were replaced with the standard iterable interfaces, and redundant capture-class `Generic` bases were removed. Runtime generic subscription and SDK type inference are covered by the new tests.
- Follow-up verification included the full checks, SDK-backed regressions, and suite-order isolation checks above; no additional independent-agent review pass is claimed.
